### PR TITLE
Remove keras package for dependabot validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ cfenv==0.5.3
 dj-database-url==0.5.0
 Django==3.2.5
 furl==2.1.2
-keras 2.4.3
 orderedmultidict==1.0.1
 psycopg2==2.9.1
 pytz==2021.1


### PR DESCRIPTION
Removes a package added to the `requirements.txt` as a test for dependabot.