### PR TITLE
Modify docker-compose depends_on steps to prevent race condition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.9.6
 ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y netcat
 ENV DJANGO_SETTINGS_MODULE=opre_ops.settings.local
 WORKDIR /opre_project
 COPY Pipfile Pipfile.lock /opre_project/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,28 +7,16 @@ services:
     environment:
       - POSTGRES_PASSWORD=local_password
 
-  wait_for_postgres:
-    build: .
-    command: sh wait-for-postgres.sh
-    depends_on:
-      - db
-
   migration:
     build: .
-    command: python manage.py migrate
+    command: bash -c "sh wait-for-postgres.sh && python manage.py migrate && python manage.py loaddata ops_site/fixtures/fake_data.json"
     depends_on:
-      - wait_for_postgres
-
-  data:
-    build: .
-    command: python manage.py loaddata ops_site/fixtures/fake_data.json
-    depends_on:
-      - migration
+      - db
 
   web:
     build: .
     ports:
       - 8080:8080
     depends_on:
-      - data
+      - migration
     command: python manage.py runserver 0.0.0.0:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,6 @@ version: "3.8"
 
 services:
 
-  web:
-    build: .
-    ports:
-      - 8080:8080
-    depends_on:
-      - db
-    command: python manage.py runserver 0.0.0.0:8080
-
   db:
     image: "postgres:11.6"
     environment:
@@ -18,15 +10,19 @@ services:
   migration:
     build: .
     command: python manage.py migrate
-    links:
-      - db
     depends_on:
       - db
 
   data:
     build: .
     command: python manage.py loaddata ops_site/fixtures/fake_data.json
-    links: 
+    depends_on:
       - migration
-    depends_on: 
-      - migration
+
+  web:
+    build: .
+    ports:
+      - 8080:8080
+    depends_on:
+      - data
+    command: python manage.py runserver 0.0.0.0:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,17 @@ services:
     environment:
       - POSTGRES_PASSWORD=local_password
 
+  wait_for_postgres:
+    build: .
+    command: sh wait-for-postgres.sh
+    depends_on:
+      - db
+
   migration:
     build: .
     command: python manage.py migrate
     depends_on:
-      - db
+      - wait_for_postgres
 
   data:
     build: .

--- a/opre_ops/wait-for-postgres.sh
+++ b/opre_ops/wait-for-postgres.sh
@@ -1,0 +1,3 @@
+echo 'checking for database on db:5432';
+until $(nc -zv db 5432); do { printf '.'; sleep 1; }; done
+echo 'found database on db:5432!';


### PR DESCRIPTION
## What does this change? 

Modify our use of docker-compose `depends_on` to set up an order for our services' dependences: 

`db` > `migration` > `data` > `web` 

https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on

When I run `docker-compose up` with this config locally, I see the services start in the right order.