### PR TITLE
Add comma separated display of roles in django admin

### DIFF
--- a/opre_ops/ops_site/admin.py
+++ b/opre_ops/ops_site/admin.py
@@ -1,5 +1,6 @@
 
 from django.contrib import admin
+
 from ops_site.models import Agency
 from ops_site.models import Role
 from ops_site.models import Person
@@ -15,4 +16,8 @@ class RoleAdmin(admin.ModelAdmin):
 
 @admin.register(Person)
 class PersonAdmin(admin.ModelAdmin):
-    list_display = ("display_name", "division")
+    list_display = ("display_name", "show_roles", "division")
+
+    def show_roles(self, obj):
+        return ", ".join([role.name for role in obj.roles.all()])
+    show_roles.short_description = "Roles"


### PR DESCRIPTION
Adds comma separated display of roles for Person in Django Admin.

**note**: could not figure out an elegant/easy way to display the roles on newlines. I tried using `"\n"` in the string builder in the `show_roles()` function as well as injecting `html` using the django `linebreaks()` function and neither produced desired results. 

I landed on comma separation (see below) but open to other's thoughts about how best to proceed.

<img width="675" alt="Screen Shot 2021-09-15 at 1 25 08 PM" src="https://user-images.githubusercontent.com/10871517/133496742-acdc3ae4-1c0a-4838-9326-02cf14170e9e.png">
