### PR TITLE
Specify memory, don't use zero-downtime-push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
               export PATH=$HOME/bin:$PATH
               cf login -a https://api.fr.cloud.gov -u $DEV_USER -p $DEV_PASSWORD -o $ORG_NAME -s $SPACE_NAME
               echo "Login successful."
-              cf zero-downtime-push opre-ops-test -f manifest.yml
+              cf push opre-ops-test -f manifest.yml
               echo "Deploy successful."
             else
               echo "Skipped"

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
   - name: opre-ops-test
+    memory: 1024M
     buildpack: python_buildpack
     # TODO: Django docs say not to use the `runserver` command in prod;
     # switch over to a production-ready webserver like gunicorn


### PR DESCRIPTION
## What changes

Specified memory for deployment in manifest.yml and used a lighter-weight push command

## Issue

 addressing the error "app requested more memory than available"

## How to test

By deploying with CircleCI

