### PR TITLE
Add CSRF_TRUSTED_ORIGINS to hopefully fix deployment login

### DIFF
--- a/opre_ops/opre_ops/settings/cloudgov.py
+++ b/opre_ops/opre_ops/settings/cloudgov.py
@@ -48,3 +48,4 @@ SECRET_KEY = env.get_credential('APP_SECRET_KEY', generate_random_string(50))
 DEBUG = False
 
 ALLOWED_HOSTS = [".cloud.gov"]
+CSRF_TRUSTED_ORIGINS = ['https://opre-ops-test.app.cloud.gov']


### PR DESCRIPTION
## What changes

Set CSRF_TRUSTED_ORIGINS to a value of the URL at which we deploy the prototype

## Issue

To fix the error `CSRF verification failed. Request aborted.`

## How to test

Test by logging in to the deployed environment

