### PR TITLE
Development

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
             curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary" | tar xzv -C $HOME/bin
-            cf install-plugin autopilot -f -r CF-Community
       - run:
           name: Deploy to cloud.gov
           command: |


### PR DESCRIPTION
## What changes

Add CSRF_TRUSTED_ORIGINS variable that allows login authentication in version 4 of Django. (Merging to main branch.)

## Issue

Because of (this issue)[https://stackoverflow.com/questions/70285834/forbidden-403-csrf-verification-failed-request-aborted-reason-given-for-fail/70326426#70326426] we were seeing the error:
```
Forbidden (403)
CSRF verification failed. Request aborted.
```

## How to test

Test by logging in at https://opre-ops-test.app.cloud.gov/admin/login
If you don't see the above error message, then it's working
