### PR TITLE
Add static directory and use relative pathname

### DIFF
--- a/opre_ops/opre_ops/settings/common.py
+++ b/opre_ops/opre_ops/settings/common.py
@@ -101,7 +101,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = 'static/'
 
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 STATIC_ROOT = os.path.join(PROJECT_DIR, 'static')

--- a/opre_ops/opre_ops/settings/static/.gitignore
+++ b/opre_ops/opre_ops/settings/static/.gitignore
@@ -1,0 +1,3 @@
+# Ignore everything in this directory, added to allow collectstatic to put
+# static files someplace
+!.gitignore

--- a/opre_ops/opre_ops/settings/static/.gitignore
+++ b/opre_ops/opre_ops/settings/static/.gitignore
@@ -1,3 +1,0 @@
-# Ignore everything in this directory, added to allow collectstatic to put
-# static files someplace
-!.gitignore


### PR DESCRIPTION
## What changes

Two modifications suggested to fix CSS/JS assets not showing up in the admin interface:
1. adding a (nearly) empty `static` directory
2. using a relative path (`static/`) instead of absolute (`/static/`) for the STATIC_URL

## Issue

The CSS in the Django admin interface is visibly broken, and the links to assets return 404

## How to test

Deploy and look at the [admin interface](https://opre-ops-test.app.cloud.gov/admin) to see if the CSS works

