### PR TITLE
Go up another directory in my attempt to correctly locate /static

### DIFF
--- a/opre_ops/opre_ops/settings/common.py
+++ b/opre_ops/opre_ops/settings/common.py
@@ -103,7 +103,7 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 
-PROJECT_DIR = '/home/vcap/app/opre_ops/opre_ops'
+PROJECT_DIR = '/home/vcap/app/opre_ops'
 STATIC_ROOT = os.path.join(PROJECT_DIR, 'static')
 
 # Default primary key field type


### PR DESCRIPTION
## What changes

Go up another directory (into the outer `opre_ops` directory) in another attempt to put static files in the expected place
