### PR TITLE
Create first view, a home page placeholder

### DIFF
--- a/opre_ops/opre_ops/urls.py
+++ b/opre_ops/opre_ops/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('ops/', include('ops_site.urls')),
 ]

--- a/opre_ops/ops_site/urls.py
+++ b/opre_ops/ops_site/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('home', views.home),
+]

--- a/opre_ops/ops_site/views.py
+++ b/opre_ops/ops_site/views.py
@@ -1,3 +1,10 @@
 from django.shortcuts import render
+from django.http import HttpResponse
+import datetime
 
 # Create your views here.
+
+def home(request):
+    now = datetime.datetime.now()
+    html = "<html><body><h1>OPRE OPS</h1><p>Page created at %s.</p></body></html>" % now
+    return HttpResponse(html)


### PR DESCRIPTION
## What changes

Create a home page, the first view in the prototype app aside from admin views. Create and include a URLconf (`ops_site/urls.py`) for prototype views.

## How to test

Visit `/ops/home` and see a bare-bones landing page

