### PR TITLE
304: Slow Renovate's Python Updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,5 +18,9 @@
         "groupName": "patch dependencies",
         "groupSlug": "all-patch",
         "stabilityDays": 0
-    }
+    },
+    "packageRules": [{
+        "matchPackageNames": ["python"],
+        "automerge": false
+    }]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.9
 ENV PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y netcat
 ENV DJANGO_SETTINGS_MODULE=opre_ops.settings.local


### PR DESCRIPTION
## What changes

Renovate now will not automatically merge Python updates.  It requires more than just the one file that Renovate updates to update Python in this project.  The PR will still be created, but we can keep it from merging, improve it, and merge it manually ourselves when we're ready.

## Issue

#304