### PR TITLE
304: More Pre-commit Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,12 +29,6 @@ repos:
   #   -   id: black
   - repo: local
     hooks:
-      - id: nox-black
-        name: nox-black
-        entry: pipenv run nox -f ./backend/noxfile.py -s black
-        language: system
-        types: [python]
-        pass_filenames: false
       - id: nox-flake8
         name: nox-flake8
         entry: cd ./backend/ && pipenv run nox -s lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,4 +41,7 @@ repos:
         language: system
         types:
           - javascript
+          - jsx
+          - css
+          - html
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,10 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      - id: eslint
+        name: eslint
+        entry: cd ./frontend/ && yarn lint
+        language: system
+        types:
+          - javascript
+        pass_filenames: false


### PR DESCRIPTION
## What changed

- Added the frontend linting to the pre-commit hooks.
- Removed the Black formatting from the pre-commit hooks because a) it will actually change your file formatting, and b) the backend linting will already fail if there is a Black formatting issue.

## Issue

#304

## How to test

`pre-commit run --all-files`