### PR TITLE
ignore pipfile.lock on secrets scanning

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       hooks:
       -   id: detect-secrets
           args: ['--baseline', '.secrets.baseline']
-
+          exclude: Pipfile.lock
   - repo: https://github.com/hadolint/hadolint
     rev: v2.10.0
     hooks:


### PR DESCRIPTION
## What changed

Added pipfile.lock to the exclude list for `detect-secrets`

#304 
