### PR TITLE
304: Disable Python Updates by Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,6 +21,6 @@
     },
     "packageRules": [{
         "matchPackageNames": ["python"],
-        "automerge": false
+        "enabled": false
     }]
 }


### PR DESCRIPTION
## What changed

Because Renovate doesn't update all the correct things for Python, and I rather wait until `brew` update its Python package, I want to disable Renovate updating Python.

## Issue

#304