### PR TITLE
Issue 304 e2e test

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-07-28T11:54:48Z",
+  "generated_at": "2022-08-04T20:06:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -132,7 +132,7 @@
         "hashed_secret": "60ca8b161ee50e40662c3664e2701456e7eae82b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8,
+        "line_number": 10,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,18 @@
-FROM python:3.9
+FROM python:3.9-slim-bullseye
 RUN apt-get update && apt-get clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /opt/local/
-
-COPY ./ /opt/local/
 
 ENV PYTHONPATH=/opt/local/
 ENV PYTHONUNBUFFERED=1
 ENV DJANGO_SETTINGS_MODULE=opre_ops.django_config.settings.local
 
+# Copy the Pipfile(s) only, so that we can cache dependencies
+# in the next step
+COPY Pipfile Pipfile.lock /opt/local/
 RUN pip install --no-cache-dir --upgrade pip==22.2 pipenv==2022.7.24 && pipenv install --dev --system --deploy
+
+# Now copy the rest of the app files, again to better support caching
+# of prior steps.
+COPY . /opt/local/
 
 CMD ["python", "./opre_ops/manage.py", "runserver", "0.0.0.0:8080"]

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -9,9 +9,10 @@ psycopg2-binary = "==2.9.3"
 cfenv = "==0.5.3"
 djangorestframework = "==3.13.1"
 django-cors-headers = "==3.13.0"
+uvicorn = "*"
 
 [dev-packages]
-pytest = "7.1.2"
+pytest = "==7.1.2"
 pytest-django = "==4.5.2"
 pytest-cov = "==3.0.0"
 nox = "==2022.1.7"
@@ -24,6 +25,7 @@ flake8-bandit = "==3.0.0"
 pyparsing = "==3.0.9"
 pydot = "==1.4.2"
 django-extensions = "==3.2.0"
+model-bakery = "==1.7.0"
 
 [requires]
 python_version = "3.9"

--- a/backend/opre_ops/django_config/settings/common.py
+++ b/backend/opre_ops/django_config/settings/common.py
@@ -87,3 +87,11 @@ PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    # Use Django's standard `django.contrib.auth` permissions,
+    # or allow read-only access for unauthenticated users.
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+    ]
+}

--- a/backend/opre_ops/django_config/urls.py
+++ b/backend/opre_ops/django_config/urls.py
@@ -18,5 +18,5 @@ from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("ops/", include("ops_site.urls")),
+    path("ops/", include("opre_ops.ops_site.urls")),
 ]

--- a/backend/opre_ops/ops_site/tests/test_helpers.py
+++ b/backend/opre_ops/ops_site/tests/test_helpers.py
@@ -1,0 +1,15 @@
+import pytest
+
+from opre_ops.django_config.settings.helpers import random_string
+
+
+@pytest.mark.parametrize("_length", [10, 256, 9999])
+def test_generate_random_string_length(_length) -> None:
+    """
+    Basic test for the provided parameters, mostly to ensure that pytest
+    is working correctly.
+    :param length: length of the string you want generated
+    :return: None
+    """
+    s = random_string.generate_random_string(_length)
+    assert len(s) == _length  # noqa: S101,S307

--- a/backend/opre_ops/ops_site/tests/test_models.py
+++ b/backend/opre_ops/ops_site/tests/test_models.py
@@ -1,6 +1,21 @@
-def test_foo():
-    pass
+import pytest
+
+from model_bakery import baker
+from urllib import response
+from rest_framework.test import APIClient
+
+from opre_ops.ops_site.cans.models import CommonAccountingNumber as CAN
 
 
-def test_bar():
-    pass
+client = APIClient()
+
+@pytest.fixture()
+def can(db):
+    return baker.make(CAN)
+
+def test_using_can(can):
+    assert isinstance(can, CAN)
+
+def test_api_getAllCans(can):
+    response = client.get('/ops/cans')
+    assert response.status_code == 200

--- a/backend/opre_ops/ops_site/tests/test_tests.py
+++ b/backend/opre_ops/ops_site/tests/test_tests.py
@@ -2,5 +2,12 @@ import pytest
 
 
 @pytest.mark.parametrize("text_input, result", [("5+5", 10), ("1+4", 5)])
-def test_sum(text_input, result):
+def test_sum(text_input, result) -> None:
+    """
+    Basic test for the provided parameters, mostly to ensure that pytest
+    is working correctly.
+    :param text_input: String representing a Sum operation. Ex: "3+3"
+    :param result: Numeric value of the expected result. Ex: 5
+    :return: None
+    """
     assert eval(text_input) == result  # noqa: S101,S307

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-PYTHONPATH = .
 DJANGO_SETTINGS_MODULE = opre_ops.django_config.settings.local
 python_files = tests.py test_*.py *_tests.py
+addopts = --cov

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
 
   db:
     image: "postgres:14.4"
+    platform: linux/arm64/v8
+    container_name: ops-db
     environment:
       - POSTGRES_PASSWORD=local_password
     healthcheck:
@@ -14,8 +16,13 @@ services:
 
   migration:
     build: ./backend/
-    command: bash -c "python ./opre_ops/manage.py migrate && python ./opre_ops/manage.py loaddata ./opre_ops/ops_site/fixtures/fake_data.json"
-
+    platform: linux/amd64
+    container_name: ops-migration
+    command: >
+      bash -c "
+      python ./opre_ops/manage.py migrate &&
+      python ./opre_ops/manage.py loaddata ./opre_ops/ops_site/fixtures/fake_data.json
+      "
     volumes:
       # See below for an explanation of this volume. The same reasoning applies,
       # but in this case it's so we can run new migrations immediately without
@@ -27,32 +34,25 @@ services:
 
   backend:
     build: ./backend/
+    platform: linux/amd64
+    container_name: ops-backend
     ports:
       - 8080:8080
+    # command: >
+    #   uvicorn opre_ops.django_config.asgi:application
+    #   --host 0.0.0.0
+    #   --port 8080
+    #   --reload
     depends_on:
       - migration
     volumes:
-      # The container copies the source into it when it gets built, so it's at
-      # /opre_project by default. However, in development, we would prefer to
-      # map local source into the container so changes show up immediately.
-      #
-      # However, our CI environment uses a remote Docker runner, which does not
-      # have access to "local" source. If we map local source to /opre_project
-      # in CI, the source that was copied in at build-time will be overriden
-      # with an empty directory.
-      #
-      # To work around this, we'll prepend the value of the CI environment
-      # variable to the destination of the map. In most CI environments, this
-      # value will be some variation of "true", so instead of replacing the
-      # /opre_project directory with an empty directory (because the remote
-      # Docker runner doesn't have access to the local source), we'll instead
-      # make /trueopre_project (or something similar) an empty directory, which
-      # is fine because we don't use that directory for anything. It's just
-      # temporary cruft in the CI container.
+      # /opt/local is the WORK_DIR
       - ./backend/opre_ops:/opt/local/opre_ops
 
   frontend:
     build: ./frontend/
+    platform: linux/amd64
+    container_name: ops-frontend
     ports:
       - 3000:3000
     depends_on:


### PR DESCRIPTION
## What changed

- [optimized Dockerfile for better caching](https://github.com/HHS/OPRE-OPS/commit/e0b5f5a373118ce863e9c96f9ec5849ee5db0953)
- [added uvicorn and model-bakery](https://github.com/HHS/OPRE-OPS/commit/188796e754811c24f6f3fd83f45228cf3aca4308)
- [added pytest -cov to default](https://github.com/HHS/OPRE-OPS/commit/382ec93cf47ee04d1bf94dedbf7f6a9aca0f7453)
- [fixed namespace for /ops/](https://github.com/HHS/OPRE-OPS/commit/66d7348054489de72da3c9ae35c7d1a35388f969)
- [Updated REST_FRAMEWORK default permissions](https://github.com/HHS/OPRE-OPS/commit/c05042247612c3cf0e46166dec8e1bb80fd41672)
- [Created test for generate_random_string](https://github.com/HHS/OPRE-OPS/commit/7d4d8abf7faa6f2a36cdb8eb4fe8117049d6b610)
- [updated the test-test](https://github.com/HHS/OPRE-OPS/commit/db5febe88d6f059b5728a9a406e543d84a7d50ac)
- [inital attempt at CAN model tests](https://github.com/HHS/OPRE-OPS/commit/951f68edefd8371eb1475eb8d024b36ee7732fb6)
- [added platform and names, and format cleanup](https://github.com/HHS/OPRE-OPS/commit/51f60224d6b0816335f69f9aa5aa676f4cda3749)

## Issue

#304 

## How to test

With the addition of the `test_models.py` some tests require the use of the DB. This re-introduced the need to run tests out of the containers, to ensure all services where running.
