### PR TITLE
Migrate frontend Docker base image to alpine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,6 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pipenv'
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: '**/yarn.lock'
       - name: Pipenv install
         run: pip install pipenv
       - name: Install backend dependencies
@@ -36,6 +31,11 @@ jobs:
       - name: Lint backend
         working-directory: ./backend
         run: pipenv run nox -s lint
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
       - name: Install frontend dependencies
         working-directory: ./frontend
         run: yarn install --frozen-lockfile

--- a/.github/workflows/unit_test_reusable.yml
+++ b/.github/workflows/unit_test_reusable.yml
@@ -17,6 +17,9 @@ jobs:
       # - name: Install backend dependencies
       #   working-directory: ./backend
       #   run: pipenv install --dev
+      - name: Build backend containers
+        working-directory: ./backend
+        run: docker-compose build
       - name: Run backend unit tests
         working-directory: ./backend
         run: PYTHONPATH=. docker-compose run backend pytest

--- a/.github/workflows/unit_test_reusable.yml
+++ b/.github/workflows/unit_test_reusable.yml
@@ -8,18 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-          cache: pipenv
-      - name: Pipenv install
-        run: pip install pipenv
-      - name: Install backend dependencies
-        working-directory: ./backend
-        run: pipenv install --dev
+      # - uses: actions/setup-python@v4
+      #   with:
+      #     python-version: '3.9'
+      #     cache: pipenv
+      # - name: Pipenv install
+      #   run: pip install pipenv
+      # - name: Install backend dependencies
+      #   working-directory: ./backend
+      #   run: pipenv install --dev
       - name: Run backend unit tests
         working-directory: ./backend
-        run: PYTHONPATH=. pipenv run pytest -v
+        run: PYTHONPATH=. docker-compose run backend pytest
 
   frontend:
     name: Frontend Unit Tests

--- a/.github/workflows/unit_test_reusable.yml
+++ b/.github/workflows/unit_test_reusable.yml
@@ -23,11 +23,7 @@ jobs:
       - name: Run backend unit tests
         working-directory: ./backend
         run: |
-          PYTHONPATH=. docker-compose run backend pytest |
-          --cov-config=.coveragerc |
-          --cov=ops_site |
-          --cov-report term-missing
-
+          PYTHONPATH=. docker-compose run backend pytest --cov-config=.coveragerc --cov=ops_site --cov-report term-missing
   frontend:
     name: Frontend Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/unit_test_reusable.yml
+++ b/.github/workflows/unit_test_reusable.yml
@@ -17,12 +17,16 @@ jobs:
       # - name: Install backend dependencies
       #   working-directory: ./backend
       #   run: pipenv install --dev
-      - name: Build backend containers
+      - name: Build containers
         working-directory: ./backend
         run: docker-compose build
       - name: Run backend unit tests
         working-directory: ./backend
-        run: PYTHONPATH=. docker-compose run backend pytest
+        run: |
+          PYTHONPATH=. docker-compose run backend pytest |
+          --cov-config=.coveragerc |
+          --cov=ops_site |
+          --cov-report term-missing
 
   frontend:
     name: Frontend Unit Tests

--- a/.github/workflows/unit_test_reusable.yml
+++ b/.github/workflows/unit_test_reusable.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      # - uses: actions/setup-python@v4
-      #   with:
-      #     python-version: '3.9'
-      #     cache: pipenv
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: pipenv
       # - name: Pipenv install
       #   run: pip install pipenv
       # - name: Install backend dependencies

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-07-28T11:54:48Z",
+  "generated_at": "2022-08-04T20:06:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -132,7 +132,7 @@
         "hashed_secret": "60ca8b161ee50e40662c3664e2701456e7eae82b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8,
+        "line_number": 10,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,18 @@
-FROM python:3.9
+FROM python:3.9-slim-bullseye
 RUN apt-get update && apt-get clean && rm -rf /var/lib/apt/lists/*
 WORKDIR /opt/local/
-
-COPY ./ /opt/local/
 
 ENV PYTHONPATH=/opt/local/
 ENV PYTHONUNBUFFERED=1
 ENV DJANGO_SETTINGS_MODULE=opre_ops.django_config.settings.local
 
+# Copy the Pipfile(s) only, so that we can cache dependencies
+# in the next step
+COPY Pipfile Pipfile.lock /opt/local/
 RUN pip install --no-cache-dir --upgrade pip==22.2 pipenv==2022.7.24 && pipenv install --dev --system --deploy
+
+# Now copy the rest of the app files, again to better support caching
+# of prior steps.
+COPY . /opt/local/
 
 CMD ["python", "./opre_ops/manage.py", "runserver", "0.0.0.0:8080"]

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -9,9 +9,10 @@ psycopg2-binary = "==2.9.3"
 cfenv = "==0.5.3"
 djangorestframework = "==3.13.1"
 django-cors-headers = "==3.13.0"
+uvicorn = "*"
 
 [dev-packages]
-pytest = "7.1.2"
+pytest = "==7.1.2"
 pytest-django = "==4.5.2"
 pytest-cov = "==3.0.0"
 nox = "==2022.1.7"
@@ -24,6 +25,7 @@ flake8-bandit = "==3.0.0"
 pyparsing = "==3.0.9"
 pydot = "==1.4.2"
 django-extensions = "==3.2.0"
+model-bakery = "==1.7.0"
 
 [requires]
 python_version = "3.9"

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -9,7 +9,7 @@ psycopg2-binary = "==2.9.3"
 cfenv = "==0.5.3"
 djangorestframework = "==3.13.1"
 django-cors-headers = "==3.13.0"
-uvicorn = "*"
+uvicorn = "==0.18.2"
 
 [dev-packages]
 pytest = "==7.1.2"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fb4034f75706eee398f56d450877b3a80067d1b94582323f286a917502674f50"
+            "sha256": "4657e7dffcc6fa52cd9114844c9328942624bf8f2b6be21576a333164908bf44"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1157,7 +1157,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_full_version < '3.11.0a7'",
+            "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         },
         "typing-extensions": {
@@ -1165,7 +1165,7 @@
                 "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
                 "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version >= '3.7'",
             "version": "==4.3.0"
         },
         "urllib3": {

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d863075ec91372fb9ead6bde08aa10adc23d1ed481eca819fe8766885d9e2772"
+            "sha256": "fb4034f75706eee398f56d450877b3a80067d1b94582323f286a917502674f50"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,6 +31,14 @@
             ],
             "index": "pypi",
             "version": "==0.5.3"
+        },
+        "click": {
+            "hashes": [
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.3"
         },
         "django": {
             "hashes": [
@@ -62,6 +70,14 @@
                 "sha256:9ab425062c4217f9802508e45feb4a83e54324273ac4b202f1850363309666c0"
             ],
             "version": "==2.1.3"
+        },
+        "h11": {
+            "hashes": [
+                "sha256:70813c1135087a248a4d38cc0e1a0181ffab2188141a93eaf567940c3957ff06",
+                "sha256:8ddd78563b633ca55346c8cd41ec0af27d3c79931828beffb46ce70a379e7442"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.13.0"
         },
         "orderedmultidict": {
             "hashes": [
@@ -154,6 +170,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==0.4.2"
+        },
+        "uvicorn": {
+            "hashes": [
+                "sha256:c19a057deb1c5bb060946e2e5c262fc01590c6529c0af2c3d9ce941e89bc30e0",
+                "sha256:cade07c403c397f9fe275492a48c1b869efd175d5d8a692df649e6e7e2ed8f4e"
+            ],
+            "index": "pypi",
+            "version": "==0.18.2"
         }
     },
     "develop": {
@@ -454,11 +478,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:10dc2bae7a9b6ab59111d6dbece2e08fb0015d2e88d296c40323cc0c7aac2c2e",
-                "sha256:98b33b13ad76ee9c7a80d2f56a6c578780e55bf8281790c62d50d4b7fadec2b8"
+                "sha256:3c604c48c3d5b4c63e72134044c0b4fe90ff01ef65280b9fe2d38c8860d99fe5",
+                "sha256:9c2b81b9b1edcc835af72d600f1955e713a065e7cb41d7e51ee762b449d9c65d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.2.0"
+            "version": "==2.2.1"
         },
         "flask-basicauth": {
             "hashes": [
@@ -760,6 +784,14 @@
                 "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
             ],
             "version": "==0.6.1"
+        },
+        "model-bakery": {
+            "hashes": [
+                "sha256:70bc7da3864c28bacfbaaa3f3b0b52020dedc8fec5229a195fc39a4dfa5ec20d",
+                "sha256:9e7e7436174a69892972eb6717a877ac346d70a8a2ada4fd2b583bb3dca2ad7e"
+            ],
+            "index": "pypi",
+            "version": "==1.7.0"
         },
         "msgpack": {
             "hashes": [
@@ -1082,11 +1114,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:d36f579e989a90e8106b9061599c707d912e9cd296b30d62cb6b4dd3567a5ddc",
-                "sha256:db49784825568c9340e45e3322b8b8aed4ca598ce9bbf5277dcae95cc04dc469"
+                "sha256:7c7854ee1429a240090297628dc9f75b35318d193537968e2dc14010ee2f5bca",
+                "sha256:dc2662692f47d99cb8ae15a784529adeed535bcd7c277fee0beccf961522baf6"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==63.4.0"
+            "version": "==63.4.1"
         },
         "six": {
             "hashes": [
@@ -1133,7 +1165,7 @@
                 "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
                 "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.10'",
             "version": "==4.3.0"
         },
         "urllib3": {
@@ -1146,11 +1178,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:0ef5be6d07181946891f5abc8047fda8bc2f0b4b9bf222c64e6e8963baee76db",
-                "sha256:635b272a8e2f77cb051946f46c60a54ace3cb5e25568228bd6b57fc70eca9ff3"
+                "sha256:4193b7bc8a6cd23e4eb251ac64f29b4398ab2c233531e66e40b19a6b7b0d30c1",
+                "sha256:d86ea0bb50e06252d79e6c241507cb904fcd66090c3271381372d6221a3970f9"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==20.16.2"
+            "version": "==20.16.3"
         },
         "werkzeug": {
             "hashes": [

--- a/backend/opre_ops/django_config/settings/common.py
+++ b/backend/opre_ops/django_config/settings/common.py
@@ -87,3 +87,11 @@ PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+REST_FRAMEWORK = {
+    # Use Django's standard `django.contrib.auth` permissions,
+    # or allow read-only access for unauthenticated users.
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+    ]
+}

--- a/backend/opre_ops/django_config/urls.py
+++ b/backend/opre_ops/django_config/urls.py
@@ -18,5 +18,5 @@ from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("ops/", include("ops_site.urls")),
+    path("ops/", include("opre_ops.ops_site.urls")),
 ]

--- a/backend/opre_ops/ops_site/tests/test_helpers.py
+++ b/backend/opre_ops/ops_site/tests/test_helpers.py
@@ -1,0 +1,15 @@
+import pytest
+
+from opre_ops.django_config.settings.helpers import random_string
+
+
+@pytest.mark.parametrize("_length", [10, 256, 9999])
+def test_generate_random_string_length(_length) -> None:
+    """
+    Basic test for the provided parameters, mostly to ensure that pytest
+    is working correctly.
+    :param length: length of the string you want generated
+    :return: None
+    """
+    s = random_string.generate_random_string(_length)
+    assert len(s) == _length  # noqa: S101,S307

--- a/backend/opre_ops/ops_site/tests/test_models.py
+++ b/backend/opre_ops/ops_site/tests/test_models.py
@@ -1,6 +1,21 @@
-def test_foo():
-    pass
+import pytest
+
+from model_bakery import baker
+from urllib import response
+from rest_framework.test import APIClient
+
+from opre_ops.ops_site.cans.models import CommonAccountingNumber as CAN
 
 
-def test_bar():
-    pass
+client = APIClient()
+
+@pytest.fixture()
+def can(db):
+    return baker.make(CAN)
+
+def test_using_can(can):
+    assert isinstance(can, CAN)
+
+def test_api_getAllCans(can):
+    response = client.get('/ops/cans')
+    assert response.status_code == 200

--- a/backend/opre_ops/ops_site/tests/test_models.py
+++ b/backend/opre_ops/ops_site/tests/test_models.py
@@ -1,7 +1,6 @@
 import pytest
 
 from model_bakery import baker
-from urllib import response
 from rest_framework.test import APIClient
 
 from opre_ops.ops_site.cans.models import CommonAccountingNumber as CAN
@@ -9,13 +8,16 @@ from opre_ops.ops_site.cans.models import CommonAccountingNumber as CAN
 
 client = APIClient()
 
+
 @pytest.fixture()
 def can(db):
     return baker.make(CAN)
 
+
 def test_using_can(can):
-    assert isinstance(can, CAN)
+    assert isinstance(can, CAN)  # noqa: S101,S307
+
 
 def test_api_getAllCans(can):
     response = client.get('/ops/cans')
-    assert response.status_code == 200
+    assert response.status_code == 200  # noqa: S101,S307

--- a/backend/opre_ops/ops_site/tests/test_tests.py
+++ b/backend/opre_ops/ops_site/tests/test_tests.py
@@ -2,5 +2,12 @@ import pytest
 
 
 @pytest.mark.parametrize("text_input, result", [("5+5", 10), ("1+4", 5)])
-def test_sum(text_input, result):
+def test_sum(text_input, result) -> None:
+    """
+    Basic test for the provided parameters, mostly to ensure that pytest
+    is working correctly.
+    :param text_input: String representing a Sum operation. Ex: "3+3"
+    :param result: Numeric value of the expected result. Ex: 5
+    :return: None
+    """
     assert eval(text_input) == result  # noqa: S101,S307

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-PYTHONPATH = .
 DJANGO_SETTINGS_MODULE = opre_ops.django_config.settings.local
 python_files = tests.py test_*.py *_tests.py
+addopts = --cov

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
 
   db:
     image: "postgres:14.4"
+    platform: linux/arm64/v8
+    container_name: ops-db
     environment:
       - POSTGRES_PASSWORD=local_password
     healthcheck:
@@ -14,8 +16,13 @@ services:
 
   migration:
     build: ./backend/
-    command: bash -c "python ./opre_ops/manage.py migrate && python ./opre_ops/manage.py loaddata ./opre_ops/ops_site/fixtures/fake_data.json"
-
+    platform: linux/amd64
+    container_name: ops-migration
+    command: >
+      bash -c "
+      python ./opre_ops/manage.py migrate &&
+      python ./opre_ops/manage.py loaddata ./opre_ops/ops_site/fixtures/fake_data.json
+      "
     volumes:
       # See below for an explanation of this volume. The same reasoning applies,
       # but in this case it's so we can run new migrations immediately without
@@ -27,32 +34,25 @@ services:
 
   backend:
     build: ./backend/
+    platform: linux/amd64
+    container_name: ops-backend
     ports:
       - 8080:8080
+    # command: >
+    #   uvicorn opre_ops.django_config.asgi:application
+    #   --host 0.0.0.0
+    #   --port 8080
+    #   --reload
     depends_on:
       - migration
     volumes:
-      # The container copies the source into it when it gets built, so it's at
-      # /opre_project by default. However, in development, we would prefer to
-      # map local source into the container so changes show up immediately.
-      #
-      # However, our CI environment uses a remote Docker runner, which does not
-      # have access to "local" source. If we map local source to /opre_project
-      # in CI, the source that was copied in at build-time will be overriden
-      # with an empty directory.
-      #
-      # To work around this, we'll prepend the value of the CI environment
-      # variable to the destination of the map. In most CI environments, this
-      # value will be some variation of "true", so instead of replacing the
-      # /opre_project directory with an empty directory (because the remote
-      # Docker runner doesn't have access to the local source), we'll instead
-      # make /trueopre_project (or something similar) an empty directory, which
-      # is fine because we don't use that directory for anything. It's just
-      # temporary cruft in the CI container.
+      # /opt/local is the WORK_DIR
       - ./backend/opre_ops:/opt/local/opre_ops
 
   frontend:
     build: ./frontend/
+    platform: linux/amd64
+    container_name: ops-frontend
     ports:
       - 3000:3000
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:18.7.0-alpine3.16
 WORKDIR /frontend
 COPY ./ /frontend/
 RUN yarn install && yarn cache clean


### PR DESCRIPTION
## What changed

- Migrated the `frontend/Dockerfile` to use `node:18.7.0-alpine3.16` instead of the generic `node:18`. This significantly reduces the footprint, and as a result security posture of the base image.

