### PR TITLE
Remove Django minor version specification in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a prototpye of OPRE's research Portfolio management System, or **OPS**. 
 
 Technologies used in this prototype:
 * Python
-* Django 4.0
+* Django 4.x
 * React
 * PostgreSQL
 * Cloud.gov


### PR DESCRIPTION
## What changed

README update to reflect that Django got auto-updated in PR #359 and thusly maybe it's not super-wise to mention specific minor versions in the documentation.

Every time a README goes out of date, we lament. And then update it. 