### PR TITLE
376: Dumb Portfolio List View

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,12 @@ function App() {
                                     <th>Path</th>
                                 </tr>
                                 <tr>
+                                    <td>Portfolios</td>
+                                    <td>
+                                        <Link to="portfolios">/portfolios</Link>
+                                    </td>
+                                </tr>
+                                <tr>
                                     <td>CANs</td>
                                     <td>
                                         <Link to="cans">/cans</Link>

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,17 +1,20 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import "./index.css";
-import App from "./App";
-import CanList from "./pages/cans/list/CanList";
 import reportWebVitals from "./reportWebVitals";
 
 import { Provider } from "react-redux";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import store from "./store";
-import CanDetail from "./pages/cans/detail/CanDetail";
+
 import ApplicationContext from "./applicationContext/ApplicationContext";
 import DeployedApplicationContext from "./applicationContext/DeployedApplicationContext";
+
+import "./index.css";
+import App from "./App";
+import CanList from "./pages/cans/list/CanList";
+import CanDetail from "./pages/cans/detail/CanDetail";
+import PortfolioList from "./pages/portfolios/list/PortfolioList";
 
 ApplicationContext.registerApplicationContext(DeployedApplicationContext);
 
@@ -22,6 +25,7 @@ root.render(
             <BrowserRouter>
                 <Routes>
                     <Route path="/" element={<App />} />
+                    <Route path="/portfolios" element={<PortfolioList />} />
                     <Route path="/cans" element={<CanList />}>
                         <Route path="/cans/:id" element={<CanDetail />} />
                     </Route>

--- a/frontend/src/pages/portfolios/list/PortfolioList.jsx
+++ b/frontend/src/pages/portfolios/list/PortfolioList.jsx
@@ -5,7 +5,7 @@ import { useEffect } from "react";
 
 const PortfolioList = () => {
     const dispatch = useDispatch();
-    const canList = useSelector((state) => state.canList.cans);
+    const portfolioList = useSelector((state) => state.portfolioList.portfolios);
 
     useEffect(() => {
         dispatch(getPortfolioList());
@@ -14,21 +14,23 @@ const PortfolioList = () => {
     return (
         <>
             <main>
-                <table id="can-list">
-                    <caption>List of all CANs</caption>
+                <table id="portfolio-list">
+                    <caption>List of all Portfolios</caption>
                     <tbody>
                         <tr>
-                            <th>number</th>
+                            <th>name</th>
+                            <th>status</th>
                             <th>description</th>
                         </tr>
-                        {canList.map((can) => (
-                            <tr key={can.id}>
+                        {portfolioList.map((portfolio) => (
+                            <tr key={portfolio.id}>
                                 <td>
-                                    <Link id="lnkCans" to={"./" + can.id}>
-                                        {can.number}
+                                    <Link to={"./" + portfolio.id}>
+                                        {portfolio.name}
                                     </Link>
                                 </td>
-                                <td>{can.description}</td>
+                                <td>{portfolio.status}</td>
+                                <td>{portfolio.description}</td>
                             </tr>
                         ))}
                     </tbody>

--- a/frontend/src/pages/portfolios/list/PortfolioList.jsx
+++ b/frontend/src/pages/portfolios/list/PortfolioList.jsx
@@ -1,0 +1,42 @@
+import { useSelector, useDispatch } from "react-redux";
+import { Link, Outlet } from "react-router-dom";
+import { getPortfolioList } from "./getPortfolioList";
+import { useEffect } from "react";
+
+const PortfolioList = () => {
+    const dispatch = useDispatch();
+    const canList = useSelector((state) => state.canList.cans);
+
+    useEffect(() => {
+        dispatch(getPortfolioList());
+    }, [dispatch]);
+
+    return (
+        <>
+            <main>
+                <table id="can-list">
+                    <caption>List of all CANs</caption>
+                    <tbody>
+                        <tr>
+                            <th>number</th>
+                            <th>description</th>
+                        </tr>
+                        {canList.map((can) => (
+                            <tr key={can.id}>
+                                <td>
+                                    <Link id="lnkCans" to={"./" + can.id}>
+                                        {can.number}
+                                    </Link>
+                                </td>
+                                <td>{can.description}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </main>
+            <Outlet />
+        </>
+    );
+};
+
+export default PortfolioList;

--- a/frontend/src/pages/portfolios/list/getPortfolioList.js
+++ b/frontend/src/pages/portfolios/list/getPortfolioList.js
@@ -1,9 +1,9 @@
-import { setCanList } from "./portfolioListSlice";
+import { setPortfolioList } from "./portfolioListSlice";
 import ApplicationContext from "../../../applicationContext/ApplicationContext";
 
 export const getPortfolioList = () => {
     return async (dispatch, getState) => {
-        const responseData = await ApplicationContext.get().helpers().callBackend("/ops/cans", "get");
-        dispatch(setCanList(responseData));
+        const responseData = await ApplicationContext.get().helpers().callBackend("/ops/portfolios", "get");
+        dispatch(setPortfolioList(responseData));
     };
 };

--- a/frontend/src/pages/portfolios/list/getPortfolioList.js
+++ b/frontend/src/pages/portfolios/list/getPortfolioList.js
@@ -1,0 +1,9 @@
+import { setCanList } from "./portfolioListSlice";
+import ApplicationContext from "../../../applicationContext/ApplicationContext";
+
+export const getPortfolioList = () => {
+    return async (dispatch, getState) => {
+        const responseData = await ApplicationContext.get().helpers().callBackend("/ops/cans", "get");
+        dispatch(setCanList(responseData));
+    };
+};

--- a/frontend/src/pages/portfolios/list/getPortfolioList.test.js
+++ b/frontend/src/pages/portfolios/list/getPortfolioList.test.js
@@ -1,0 +1,34 @@
+import { getPortfolioList } from "./getPortfolioList";
+import store from "../../../store";
+import TestApplicationContext from "../../../applicationContext/TestApplicationContext";
+import { dispatchUsecase } from "../../../helpers/test";
+
+test("successfully gets the CAN list from the backend and directly puts it into state", async () => {
+    const mockBackendResponse = [
+        {
+            id: 1,
+            number: "G99HRF2",
+            otherStuff: "Moof",
+        },
+        {
+            id: 2,
+            number: "G99IA14",
+            otherStuff: "DogCow",
+        },
+        {
+            id: 3,
+            number: "G99PHS9",
+            otherStuff: "Clarus",
+        },
+    ];
+    TestApplicationContext.helpers().callBackend.mockImplementation(async () => {
+        return mockBackendResponse;
+    });
+
+    const actualGetCanList = getPortfolioList();
+
+    await dispatchUsecase(actualGetCanList);
+
+    const canList = store.getState().canList.cans;
+    expect(canList).toEqual(mockBackendResponse);
+});

--- a/frontend/src/pages/portfolios/list/getPortfolioList.test.js
+++ b/frontend/src/pages/portfolios/list/getPortfolioList.test.js
@@ -3,21 +3,27 @@ import store from "../../../store";
 import TestApplicationContext from "../../../applicationContext/TestApplicationContext";
 import { dispatchUsecase } from "../../../helpers/test";
 
-test("successfully gets the CAN list from the backend and directly puts it into state", async () => {
+test("successfully gets the portfolio list from the backend and directly puts it into state", async () => {
     const mockBackendResponse = [
         {
             id: 1,
-            number: "G99HRF2",
+            name: "Children",
+            status: "Not-Started",
+            description: "Portfolio on children",
             otherStuff: "Moof",
         },
         {
             id: 2,
-            number: "G99IA14",
+            name: "Families",
+            status: "In-Process",
+            description: "Portfolio on families",
             otherStuff: "DogCow",
         },
         {
             id: 3,
-            number: "G99PHS9",
+            name: "Other stuff",
+            status: "Sandbox",
+            description: "The best portfolio",
             otherStuff: "Clarus",
         },
     ];
@@ -25,10 +31,10 @@ test("successfully gets the CAN list from the backend and directly puts it into 
         return mockBackendResponse;
     });
 
-    const actualGetCanList = getPortfolioList();
+    const actualGetPortfolioList = getPortfolioList();
 
-    await dispatchUsecase(actualGetCanList);
+    await dispatchUsecase(actualGetPortfolioList);
 
-    const canList = store.getState().canList.cans;
-    expect(canList).toEqual(mockBackendResponse);
+    const portfolioList = store.getState().portfolioList.portfolios;
+    expect(portfolioList).toEqual(mockBackendResponse);
 });

--- a/frontend/src/pages/portfolios/list/portfolioListSlice.js
+++ b/frontend/src/pages/portfolios/list/portfolioListSlice.js
@@ -5,7 +5,7 @@ const initialState = {
 };
 
 const portfolioListSlice = createSlice({
-    name: "canList",
+    name: "portfolioList",
     initialState,
     reducers: {
         setPortfolioList: (state, action) => {

--- a/frontend/src/pages/portfolios/list/portfolioListSlice.js
+++ b/frontend/src/pages/portfolios/list/portfolioListSlice.js
@@ -1,0 +1,19 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const initialState = {
+    portfolios: [],
+};
+
+const portfolioListSlice = createSlice({
+    name: "canList",
+    initialState,
+    reducers: {
+        setPortfolioList: (state, action) => {
+            state.portfolios = action.payload;
+        },
+    },
+});
+
+export const { setPortfolioList } = portfolioListSlice.actions;
+
+export default portfolioListSlice.reducer;

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -2,11 +2,13 @@ import { configureStore } from "@reduxjs/toolkit";
 import canListSlice from "./pages/cans/list/canListSlice";
 import canDetailSlice from "./pages/cans/detail/canDetailSlice";
 import canFiscalYearSlice from "./pages/cans/detail/budgetSummary/canFiscalYearSlice";
+import portfolioListSlice from "./pages/portfolios/list/portfolioListSlice";
 
 export default configureStore({
     reducer: {
         canList: canListSlice,
         canDetail: canDetailSlice,
         canFiscalYearDetail: canFiscalYearSlice,
+        portfolioList: portfolioListSlice,
     },
 });


### PR DESCRIPTION
## What changed

- Added a dev view to see the list of portfolios.
  - This added a unit test and some state.
- A link on the front page to the list.

## Issue

#376.

## How to test

`docker compose up` and navigate to http://localhost:3000/

## Screenshots

![The list of portfolios; very basic table](https://user-images.githubusercontent.com/16943066/186482749-b0dd4b59-e72b-4cb9-8813-294c4b2b6931.png)
