### PR TITLE
Remove explicit eslint-plugin-react dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-prettier": "4.2.1",
-    "eslint-plugin-react": "7.30.1",
     "prettier": "2.7.1"
   },
   "scripts": {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4269,7 +4269,7 @@ eslint-plugin-react-hooks@^4.3.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
-eslint-plugin-react@7.30.1, eslint-plugin-react@^7.27.1:
+eslint-plugin-react@^7.27.1:
   version "7.30.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.30.1.tgz#2be4ab23ce09b5949c6631413ba64b2810fd3e22"
   integrity sha512-NbEvI9jtqO46yJA3wcRF9Mo0lF9T/jhdHqhCHXiXtD+Zcb98812wvokjWpU7Q4QH5edo6dmqrukxVvWWXHlsUg==


### PR DESCRIPTION
## What changed

#391 is failing due ESLint not knowing what version of `eslint-plugin-react` to use.  It is already included as part of our `create-react-app` dependency, so I removed our explicit dev dependency.  Linting should start working again.

## How to test

`yarn lint` continues to work.