### PR TITLE
Fix Frontend Linting

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -13,6 +13,10 @@
     },
     "plugins": [
     ],
+    "ignorePatterns": [
+        "**/*.css",
+        "**/*.svg"
+    ],
     "settings" : {
         "import/resolver": {
             "node": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "test:coverage": "react-scripts test --coverage",
     "test:e2e": "REACT_APP_BACKEND_DOMAIN=http://localhost:8080 cypress run --config-file ./cypress.config.js --headless --",
     "eject": "react-scripts eject",
-    "lint": "eslint ./src/"
+    "lint": "eslint './src/**'"
   },
   "jest": {
     "coverageThreshold": {

--- a/frontend/src/pages/cans/detail/CanDetail.jsx
+++ b/frontend/src/pages/cans/detail/CanDetail.jsx
@@ -18,7 +18,7 @@ const CanDetail = () => {
             <section className="flex">
                 <div className="one-flex">
                     <div className="info-head">
-                        <a className="right-float" href="#">
+                        <a className="right-float" href="/custom-report">
                             Download custom report
                         </a>
                         <h1>
@@ -96,16 +96,8 @@ const CanDetail = () => {
                             </td>
                             <td>$1,000,000</td>
                             <td>80%</td>
-                            <td>
-                                <a href="#" className="cartouche">
-                                    CAN
-                                </a>
-                            </td>
-                            <td>
-                                <a href="#" className="cartouche">
-                                    Area
-                                </a>
-                            </td>
+                            <td>CAN</td>
+                            <td>Area</td>
                             <td>👤 Person</td>
                         </tr>
                     </tbody>

--- a/frontend/src/pages/portfolios/list/PortfolioList.jsx
+++ b/frontend/src/pages/portfolios/list/PortfolioList.jsx
@@ -25,9 +25,7 @@ const PortfolioList = () => {
                         {portfolioList.map((portfolio) => (
                             <tr key={portfolio.id}>
                                 <td>
-                                    <Link to={"./" + portfolio.id}>
-                                        {portfolio.name}
-                                    </Link>
+                                    <Link to={"./" + portfolio.id}>{portfolio.name}</Link>
                                 </td>
                                 <td>{portfolio.status}</td>
                                 <td>{portfolio.description}</td>


### PR DESCRIPTION
## What changed

Our frontend linting was not actually linting anything.  It wasn't traversing the directory structure.  Now it does.

Now that ESLint traverses everything, I need to tell it to ignore CSS and SVG files since it doesn't know how to lint those files.

I also fixed some of the findings.

## How to test

`yarn lint`