### PR TITLE
issue-minor-cleanup

### DIFF
--- a/.github/workflows/security_codeql.yml
+++ b/.github/workflows/security_codeql.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
-          languages: [ 'javascript', 'python' ]
+          languages: javascript, python
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/security_codeql.yml
+++ b/.github/workflows/security_codeql.yml
@@ -13,8 +13,6 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix:
-        language: [ 'javascript', 'python' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
@@ -26,7 +24,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
-          languages: ${{ matrix.language }}
+          languages: [ 'javascript', 'python' ]
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-09-06T15:58:36Z",
+  "generated_at": "2022-09-06T19:31:35Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -92,7 +92,7 @@
         "hashed_secret": "60ca8b161ee50e40662c3664e2701456e7eae82b",
         "is_secret": true,
         "is_verified": false,
-        "line_number": 28,
+        "line_number": 20,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/backend/opre_ops/django_config/settings/local.py
+++ b/backend/opre_ops/django_config/settings/local.py
@@ -8,14 +8,6 @@ These are settings for local development only, not cloud or production environme
 from opre_ops.django_config.settings.common import *  # noqa: F403, F401
 from opre_ops.django_config.settings.helpers.random_string import generate_random_string
 
-__all__ = [
-    "DATABASES",
-    "SECRET_KEY",
-    "DEBUG",
-    "ALLOWED_HOSTS",
-    "CORS_ALLOWED_ORIGIN_REGEXES",
-    "INSTALLED_APPS",
-]
 
 # Local database config for use with Docker Compose
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases


### PR DESCRIPTION
## What changed

- cleanup from late reviews by @halprin ;) 
- tested, and looks like combining `language` on `codeql` saves ~30 seconds; mostly from standup/teardown of the job. I still like the separation; but will let it run-as is (combined) for now.
- cleaned up `local.py` - my goof
