### PR TITLE
tech-debt: Refactor GitHub Actions

### DIFF
--- a/.github/actions/deploy-backend/action.yml
+++ b/.github/actions/deploy-backend/action.yml
@@ -1,0 +1,29 @@
+name: Deploy Backend
+description: Deploy backend code to Cloud.gov environment.
+inputs:
+  USERNAME:
+    description: Cloud.gov user to authenticate with.
+    required: true
+  PASSWORD:
+    description: Cloud.gov authentication password.
+    required: true
+  ORG_NAME:
+    description: Cloud.gov Organization Name.
+    required: true # Default to our Org once setup.
+  SPACE_NAME:
+    description: Cloud.gov Space (environment) Name.
+    required: true
+  APP_NAME:
+    description: Applicaiton name (from manifest.yml).
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Deploy to Cloud.gov
+      run: |
+          export PATH=$HOME/bin:$PATH
+          cf login -a https://api.fr.cloud.gov -u ${{ inputs.USERNAME }} -p ${{ inputs.PASSWORD }} -o ${{ inputs.ORG_NAME }} -s ${{ inputs.SPACE_NAME }}
+          cf push ${{ inputs.APP_NAME }} -f manifest.yml
+          BACKEND_GUID=$(cf app opre-ops-test --guid)
+          BACKEND_DOMAIN=$(cf curl /v3/apps/$BACKEND_GUID/env | jq -r .application_env_json.VCAP_APPLICATION.application_uris[0])
+          echo "::set-output name=BACKEND_DOMAIN::${BACKEND_DOMAIN}"

--- a/.github/actions/deploy-backend/action.yml
+++ b/.github/actions/deploy-backend/action.yml
@@ -24,6 +24,6 @@ runs:
           export PATH=$HOME/bin:$PATH
           cf login -a https://api.fr.cloud.gov -u ${{ inputs.USERNAME }} -p ${{ inputs.PASSWORD }} -o ${{ inputs.ORG_NAME }} -s ${{ inputs.SPACE_NAME }}
           cf push ${{ inputs.APP_NAME }} -f manifest.yml
-          BACKEND_GUID=$(cf app opre-ops-test --guid)
+          BACKEND_GUID=$(cf app ${{ inputs.APP_NAME }} --guid)
           BACKEND_DOMAIN=$(cf curl /v3/apps/$BACKEND_GUID/env | jq -r .application_env_json.VCAP_APPLICATION.application_uris[0])
           echo "::set-output name=BACKEND_DOMAIN::${BACKEND_DOMAIN}"

--- a/.github/actions/deploy-backend/action.yml
+++ b/.github/actions/deploy-backend/action.yml
@@ -16,6 +16,10 @@ inputs:
   APP_NAME:
     description: Applicaiton name (from manifest.yml).
     required: true
+outputs:
+  BACKEND_DOMAIN:
+    description: Uri of the deployed backend.
+    value: ${{ steps.deploy-backend.outputs.BACKEND_DOMAIN }}
 runs:
   using: composite
   steps:

--- a/.github/actions/deploy-frontend/action.yml
+++ b/.github/actions/deploy-frontend/action.yml
@@ -16,19 +16,13 @@ inputs:
   APP_NAME:
     description: Applicaiton name (from manifest.yml).
     required: true
-outputs:
-  BACKEND_DOMAIN:
-    description: Uri of the deployed backend.
-    value: ${{ steps.deploy-backend.outputs.BACKEND_DOMAIN }}
+
 runs:
   using: composite
   steps:
     - name: Deploy to Cloud.gov
-      id: deploy-backend
+      id: deploy-frontend
       run: |
-          export PATH=$HOME/bin:$PATH
-          cf login -a https://api.fr.cloud.gov -u ${{ inputs.USERNAME }} -p ${{ inputs.PASSWORD }} -o ${{ inputs.ORG_NAME }} -s ${{ inputs.SPACE_NAME }}
-          cf push ${{ inputs.APP_NAME }} -f manifest.yml
-          BACKEND_GUID=$(cf app ${{ inputs.APP_NAME }} --guid)
-          BACKEND_DOMAIN=$(cf curl /v3/apps/$BACKEND_GUID/env | jq -r .application_env_json.VCAP_APPLICATION.application_uris[0])
-          echo "::set-output name=BACKEND_DOMAIN::${BACKEND_DOMAIN}"
+        export PATH=$HOME/bin:$PATH
+        cf login -a https://api.fr.cloud.gov -u ${{ inputs.USERNAME }} -p ${{ inputs.PASSWORD }} -o ${{ inputs.ORG_NAME }} -s ${{ inputs.SPACE_NAME }}
+        cf push ${{ inputs.APP_NAME }} -f manifest.yml

--- a/.github/actions/deploy-frontend/action.yml
+++ b/.github/actions/deploy-frontend/action.yml
@@ -1,0 +1,34 @@
+name: Deploy Frontend
+description: Deploy frontend code to Cloud.gov environment.
+inputs:
+  USERNAME:
+    description: Cloud.gov user to authenticate with.
+    required: true
+  PASSWORD:
+    description: Cloud.gov authentication password.
+    required: true
+  ORG_NAME:
+    description: Cloud.gov Organization Name.
+    required: true # Default to our Org once setup.
+  SPACE_NAME:
+    description: Cloud.gov Space (environment) Name.
+    required: true
+  APP_NAME:
+    description: Applicaiton name (from manifest.yml).
+    required: true
+outputs:
+  BACKEND_DOMAIN:
+    description: Uri of the deployed backend.
+    value: ${{ steps.deploy-backend.outputs.BACKEND_DOMAIN }}
+runs:
+  using: composite
+  steps:
+    - name: Deploy to Cloud.gov
+      id: deploy-backend
+      run: |
+          export PATH=$HOME/bin:$PATH
+          cf login -a https://api.fr.cloud.gov -u ${{ inputs.USERNAME }} -p ${{ inputs.PASSWORD }} -o ${{ inputs.ORG_NAME }} -s ${{ inputs.SPACE_NAME }}
+          cf push ${{ inputs.APP_NAME }} -f manifest.yml
+          BACKEND_GUID=$(cf app ${{ inputs.APP_NAME }} --guid)
+          BACKEND_DOMAIN=$(cf curl /v3/apps/$BACKEND_GUID/env | jq -r .application_env_json.VCAP_APPLICATION.application_uris[0])
+          echo "::set-output name=BACKEND_DOMAIN::${BACKEND_DOMAIN}"

--- a/.github/actions/run-full-stack/action.yml
+++ b/.github/actions/run-full-stack/action.yml
@@ -1,0 +1,8 @@
+name: Run Full Stack
+description: Runs the full stack from the docker-compose.yml
+runs:
+  using: composite
+  steps:
+    - name: Start Stack
+      shell: bash
+      run: docker-compose up --build -d

--- a/.github/actions/setup-cloudfoundry/action.yml
+++ b/.github/actions/setup-cloudfoundry/action.yml
@@ -1,0 +1,10 @@
+name: Setup Cloud Foundry
+description: Download the cloud foundary binary
+runs:
+  using: composite
+  steps:
+    - name: Install CF
+      run: |
+        mkdir -p $HOME/bin
+        export PATH=$HOME/bin:$PATH
+        curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary" | tar xzv -C $HOME/bin

--- a/.github/actions/setup-javascript/action.yml
+++ b/.github/actions/setup-javascript/action.yml
@@ -1,0 +1,15 @@
+name: Set up Javascript
+description: Installs Node.js and dependencies defined in package.json
+runs:
+  using: composite
+  steps:
+    - name: Set up node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 18
+        cache: 'yarn'
+        cache-dependency-path: '**/yarn.lock'
+    - name: Install yarn dependencies
+      shell: bash
+      working-directory: ./frontend
+      run: yarn install --frozen-lockfile

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,0 +1,14 @@
+name: Set up Python
+description: Installs Python3 and dependencies defined in the Pipfile
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+        cache: pipenv
+    - name: Install Pipenv dependencies
+      shell: bash
+      working-directory: ./backend
+      run: pipenv install --dev

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -7,7 +7,10 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.9'
-
+        cache: pipenv
+    - name: Install Pipenv
+      shell: bash
+      run: pip install pipenv
     - name: Install Pipenv dependencies
       shell: bash
       working-directory: ./backend

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -7,7 +7,7 @@ runs:
       uses: actions/setup-python@v4
       with:
         python-version: '3.9'
-        cache: pipenv
+
     - name: Install Pipenv dependencies
       shell: bash
       working-directory: ./backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-          cache: 'pipenv'
-
-      - name: Pipenv install
-        run: pip install pipenv
+      - uses: ./.github/actions/setup-python
 
       - name: Install backend dependencies
         working-directory: ./backend
@@ -51,15 +45,7 @@ jobs:
         working-directory: ./backend
         run: pipenv run nox -s lint
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: '**/yarn.lock'
-
-      - name: Install frontend dependencies
-        working-directory: ./frontend
-        run: yarn install --frozen-lockfile
+      - uses: ./.github/actions/setup-javascript
 
       - name: Lint frontend
         working-directory: ./frontend

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -23,12 +23,6 @@ jobs:
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-javascript
       - uses: ./.github/actions/setup-cloudfoundry
-      # - name: Install CF CLI
-      #   run: |
-      #     mkdir -p $HOME/bin
-      #     export PATH=$HOME/bin:$PATH
-      #     curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary" | tar xzv -C $HOME/bin
-
 
       - name: Deploy Backend
         uses: ./.github/actions/deploy-backend
@@ -38,15 +32,6 @@ jobs:
           ORG_NAME: ${{ secrets.ORG_NAME }}
           SPACE_NAME: ${{ secrets.SPACE_NAME }}
           APP_NAME: opre-ops-test
-      # - name: Deploy backend to Cloud.gov
-      #   id: backend-deploy
-      #   run: |
-      #     export PATH=$HOME/bin:$PATH
-      #     cf login -a https://api.fr.cloud.gov -u ${{ secrets.DEV_USER }} -p ${{ secrets.DEV_PASSWORD }} -o ${{ secrets.ORG_NAME }} -s ${{ secrets.SPACE_NAME }}
-      #     cf push opre-ops-test -f manifest.yml
-      #     BACKEND_GUID=$(cf app opre-ops-test --guid)
-      #     BACKEND_DOMAIN=$(cf curl /v3/apps/$BACKEND_GUID/env | jq -r .application_env_json.VCAP_APPLICATION.application_uris[0])
-      #     echo "::set-output name=BACKEND_DOMAIN::${BACKEND_DOMAIN}"
 
       - name: Build frontend
         working-directory: ./frontend
@@ -62,9 +47,3 @@ jobs:
           ORG_NAME: ${{ secrets.ORG_NAME }}
           SPACE_NAME: ${{ secrets.SPACE_NAME }}
           APP_NAME: opre-ops-frontend-test
-
-      # - name: Deploy frontend to Cloud.gov
-      #   run: |
-      #     export PATH=$HOME/bin:$PATH
-      #     cf login -a https://api.fr.cloud.gov -u ${{ secrets.DEV_USER }} -p ${{ secrets.DEV_PASSWORD }} -o ${{ secrets.ORG_NAME }} -s ${{ secrets.SPACE_NAME }}
-      #     cf push opre-ops-frontend-test -f manifest.yml

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -20,37 +20,51 @@ jobs:
       NODE_ENV: production
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-javascript
+      - uses: ./.github/actions/setup-cloudfoundry
+      # - name: Install CF CLI
+      #   run: |
+      #     mkdir -p $HOME/bin
+      #     export PATH=$HOME/bin:$PATH
+      #     curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary" | tar xzv -C $HOME/bin
+
+
+      - name: Deploy Backend
+        uses: ./.github/actions/deploy-backend
         with:
-          python-version: '3.x'
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: '**/yarn.lock'
-      - name: Install CF CLI
-        run: |
-          mkdir -p $HOME/bin
-          export PATH=$HOME/bin:$PATH
-          curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary" | tar xzv -C $HOME/bin
-      - name: Install frontend dependencies
-        working-directory: ./frontend
-        run: yarn install --production --frozen-lockfile
-      - name: Deploy backend to Cloud.gov
-        id: backend-deploy
-        run: |
-          export PATH=$HOME/bin:$PATH
-          cf login -a https://api.fr.cloud.gov -u ${{ secrets.DEV_USER }} -p ${{ secrets.DEV_PASSWORD }} -o ${{ secrets.ORG_NAME }} -s ${{ secrets.SPACE_NAME }}
-          cf push opre-ops-test -f manifest.yml
-          BACKEND_GUID=$(cf app opre-ops-test --guid)
-          BACKEND_DOMAIN=$(cf curl /v3/apps/$BACKEND_GUID/env | jq -r .application_env_json.VCAP_APPLICATION.application_uris[0])
-          echo "::set-output name=BACKEND_DOMAIN::${BACKEND_DOMAIN}"
+          USERNAME: ${{ secrets.DEV_USER }}
+          PASSWORD: ${{ secrets.DEV_PASSWORD }}
+          ORG_NAME: ${{ secrets.ORG_NAME }}
+          SPACE_NAME: ${{ secrets.SPACE_NAME }}
+          APP_NAME: opre-ops-test
+      # - name: Deploy backend to Cloud.gov
+      #   id: backend-deploy
+      #   run: |
+      #     export PATH=$HOME/bin:$PATH
+      #     cf login -a https://api.fr.cloud.gov -u ${{ secrets.DEV_USER }} -p ${{ secrets.DEV_PASSWORD }} -o ${{ secrets.ORG_NAME }} -s ${{ secrets.SPACE_NAME }}
+      #     cf push opre-ops-test -f manifest.yml
+      #     BACKEND_GUID=$(cf app opre-ops-test --guid)
+      #     BACKEND_DOMAIN=$(cf curl /v3/apps/$BACKEND_GUID/env | jq -r .application_env_json.VCAP_APPLICATION.application_uris[0])
+      #     echo "::set-output name=BACKEND_DOMAIN::${BACKEND_DOMAIN}"
+
       - name: Build frontend
         working-directory: ./frontend
-        run: REACT_APP_BACKEND_DOMAIN=https://${{steps.backend-deploy.outputs.BACKEND_DOMAIN}} yarn build
-      - name: Deploy frontend to Cloud.gov
         run: |
-          export PATH=$HOME/bin:$PATH
+          REACT_APP_BACKEND_DOMAIN=https://${{steps.backend-deploy.outputs.BACKEND_DOMAIN}} yarn build
           cp ./frontend/Staticfile ./frontend/build/
-          cf login -a https://api.fr.cloud.gov -u ${{ secrets.DEV_USER }} -p ${{ secrets.DEV_PASSWORD }} -o ${{ secrets.ORG_NAME }} -s ${{ secrets.SPACE_NAME }}
-          cf push opre-ops-frontend-test -f manifest.yml
+
+      - name: Deploy frontend
+        uses: ./.github/actions/deploy-frontend
+        with:
+          USERNAME: ${{ secrets.DEV_USER }}
+          PASSWORD: ${{ secrets.DEV_PASSWORD }}
+          ORG_NAME: ${{ secrets.ORG_NAME }}
+          SPACE_NAME: ${{ secrets.SPACE_NAME }}
+          APP_NAME: opre-ops-frontend-test
+
+      # - name: Deploy frontend to Cloud.gov
+      #   run: |
+      #     export PATH=$HOME/bin:$PATH
+      #     cf login -a https://api.fr.cloud.gov -u ${{ secrets.DEV_USER }} -p ${{ secrets.DEV_PASSWORD }} -o ${{ secrets.ORG_NAME }} -s ${{ secrets.SPACE_NAME }}
+      #     cf push opre-ops-frontend-test -f manifest.yml

--- a/.github/workflows/nightly_scans.yml
+++ b/.github/workflows/nightly_scans.yml
@@ -1,0 +1,25 @@
+name: Nightly Security Analysis
+on:
+  workflow_dispatch:
+  schedule:
+    # cron format: 'minute hour dayofmonth month dayofweek'
+    # this will run at noon UTC every day (3am EST / 4am EDT)
+    - cron: '0 8 * * *'
+
+jobs:
+  dast-scan:
+    name: OWASP Zap Scan
+    runs-on: ubuntu-latest
+    stesp:
+      - uses: actions/checkout@v3
+
+      - id: setup
+        uses: ./.github/actions/run-full-stack
+
+      - name: Run OWASP Zap Scan
+        uses: zaproxy/action-full-scan@v0.4.0
+        with:
+          docker_name: 'owasp/zap2docker-stable'
+          targer: 'http://localhost:3000/'
+          fail_action: true
+          cmd_options: '-I'

--- a/.github/workflows/nightly_scans.yml
+++ b/.github/workflows/nightly_scans.yml
@@ -20,6 +20,6 @@ jobs:
         uses: zaproxy/action-full-scan@v0.4.0
         with:
           docker_name: 'owasp/zap2docker-stable'
-          targer: 'http://localhost:3000/'
+          target: 'http://localhost:3000/'
           fail_action: true
           cmd_options: '-I'

--- a/.github/workflows/nightly_scans.yml
+++ b/.github/workflows/nightly_scans.yml
@@ -10,7 +10,7 @@ jobs:
   dast-scan:
     name: OWASP Zap Scan
     runs-on: ubuntu-latest
-    stesp:
+    steps:
       - uses: actions/checkout@v3
 
       - id: setup

--- a/.github/workflows/nightly_scans.yml
+++ b/.github/workflows/nightly_scans.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   schedule:
     # cron format: 'minute hour dayofmonth month dayofweek'
-    # this will run at noon UTC every day (3am EST / 4am EDT)
+    # this will run at 8AM UTC every day (3am EST / 4am EDT)
     - cron: '0 8 * * *'
 
 jobs:

--- a/.github/workflows/unit_test_reusable.yml
+++ b/.github/workflows/unit_test_reusable.yml
@@ -8,15 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-          cache: pipenv
-      - name: Pipenv install
-        run: pip install pipenv
-      - name: Install backend dependencies
-        working-directory: ./backend
-        run: pipenv install --dev
+      - uses: ./.github/actions/setup-python
       - name: Run backend unit tests
         working-directory: ./backend
         run: pipenv run pytest
@@ -26,14 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: '**/yarn.lock'
-      - name: Install frontend dependencies
-        working-directory: ./frontend
-        run: yarn install --frozen-lockfile
+      - uses: ./.github/actions/setup-javascript
       - name: Run frontend unit tests
         working-directory: ./frontend
         run: yarn test
@@ -45,17 +30,9 @@ jobs:
         uses: actions/checkout@v3
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: '**/yarn.lock'
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: yarn install --frozen-lockfile
+      - uses: ./.github/actions/setup-javascript
       # Stand up the system stack, to have something to poke
-      - name: Start Stack
-        run: docker-compose up --build -d
+      - uses: ./.github/actions/run-full-stack
       # Run the Cypress E2E Tests
       - name: E2E Test
         working-directory: frontend


### PR DESCRIPTION
## What changed

- Major refactor of how the GitHub Actions are organized and run.
- Added a _nightly_ scan action; performs owasp-zap scans nightly

## Why

One driving factor for this was the repetition we had even across multiple `setup-node` or `setup-python`; if we ever changed versions of node or python, we'd have to update in multiple places. Further, I identified a few areas where we'd want to do the same thing multiple times like stand up the full-stack for e2e or DAST testing. So refactored many of the repetitive steps into their own local-actions. This is a first attempt at cleanup.
