### PR TITLE
376: Assert that the portfolio serializes a list of CANs

### DIFF
--- a/backend/tests/ops_site/portfolios/test_portfolio_controller.py
+++ b/backend/tests/ops_site/portfolios/test_portfolio_controller.py
@@ -7,3 +7,9 @@ def test_Portfolio_serializer_has_depth_of_one():
 
 def test_Portfolio_serializer_returns_all_models_fields():
     assert PortfolioSerializer.Meta.fields == "__all__"
+
+def test_Portfolio_serializer_returns_cans_fields():
+    portfolio_serializer_fields = PortfolioSerializer().get_fields()
+
+    assert 'cans' in portfolio_serializer_fields
+    assert portfolio_serializer_fields['cans'] is not None

--- a/backend/tests/ops_site/portfolios/test_portfolio_controller.py
+++ b/backend/tests/ops_site/portfolios/test_portfolio_controller.py
@@ -8,8 +8,9 @@ def test_Portfolio_serializer_has_depth_of_one():
 def test_Portfolio_serializer_returns_all_models_fields():
     assert PortfolioSerializer.Meta.fields == "__all__"
 
+
 def test_Portfolio_serializer_returns_cans_fields():
     portfolio_serializer_fields = PortfolioSerializer().get_fields()
 
-    assert 'cans' in portfolio_serializer_fields
-    assert portfolio_serializer_fields['cans'] is not None
+    assert "cans" in portfolio_serializer_fields
+    assert portfolio_serializer_fields["cans"] is not None


### PR DESCRIPTION
## What changed

Added another unit test to ensure that our `PorfolioSerializer` includes the list of CANs.

## Issue

#376.

## How to test

`pipenv run pytest`