### PR TITLE
Fix Local Pre-commit Hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,13 +33,14 @@ repos:
         name: nox-lint
         entry: cd ./backend/ && pipenv run nox -s lint
         language: system
-        types: [python]
+        types:
+         - python
         pass_filenames: false
       - id: eslint
         name: eslint
         entry: cd ./frontend/ && yarn lint
         language: system
-        types:
+        types_or:
           - javascript
           - jsx
           - css

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,14 +31,14 @@ repos:
     hooks:
       - id: nox-lint
         name: nox-lint
-        entry: cd ./backend/ && pipenv run nox -s lint
+        entry: bash -c 'cd ./backend/ && pipenv run nox -s lint'
         language: system
         types:
          - python
         pass_filenames: false
       - id: eslint
         name: eslint
-        entry: cd ./frontend/ && yarn lint
+        entry: bash -c 'cd ./frontend/ && yarn lint'
         language: system
         types_or:
           - javascript


### PR DESCRIPTION
## What changed

Fixes our pre-commit rules so they actually run our frontend and backend linting on commit.

There were two issues.

- The frontend was using `types` which is _anded_.  This meant that it would only run if a file was `javascript`, `jsx`, `css`, _and_ `html`.  Generally no file is all of those.
- The `entry` is not executed in a shell by default.  Since we were using shell-isms (e.g. `&&`), we needed to be explicit with running our command in `bash`.

## How to test

After making changes that violate our linting rules, do a `git add .` and then run `pre-commit run`.