### PR TITLE
correcting subject verb agreement on portfolio details

### DIFF
--- a/frontend/src/components/PortfolioFundingSummary/PortfolioFundingSummary.jsx
+++ b/frontend/src/components/PortfolioFundingSummary/PortfolioFundingSummary.jsx
@@ -41,7 +41,7 @@ const PortfolioFundingSummary = (props) => {
         <section>
             <h2 className="font-sans-lg">Portfolio Budget Summary</h2>
             <p className="font-sans-sm">
-                The graphs below show a summary of the total budget for this portfolio, not including additional funding
+                The graph below shows a summary of the total budget for this portfolio, not including additional funding
                 from other portfolios.
             </p>
             <ul className="usa-card-group grid-gap">


### PR DESCRIPTION
## What changed

The explanatory text about budget summary information to revise the subject verb agreement. The previous text came from a time when there were in fact multiple graphs planned.

## Issue

#460 

## How to test

Visit /portfolios/6 for instance and see that the text is altered. 

## Screenshots


## Links
