### PR TITLE
461: "show less" functionality on portfolio descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,6 @@ We have a Docker Compose configuration that makes it easy to run the application
 docker compose up
 ```
 
-To create an admin user, use the Django management tool from within the container.
-
-```shell
-docker compose exec backend python ./ops_api/manage.py createsuperuser
-```
-
 ## Access
 
 Whether you run the application through Docker or locally, you can access the frontend at `http://localhost:3000` and

--- a/frontend/src/components/PortfolioDescription/PortfolioDescription.jsx
+++ b/frontend/src/components/PortfolioDescription/PortfolioDescription.jsx
@@ -25,13 +25,19 @@ const PortfolioDescription = () => {
         setButtonStyle(styles.hidden);
     };
 
+    const collapseExpand = () => {
+        setTextStyle(styles.hidden);
+        setButtonStyle(styles.visible);
+    };
+
     return (
         <div>
-            <button onClick={expandCollapse} style={buttonStyle}>
-                <p>
-                    {portfolio.description?.[0].text}...<span className={cssStyles.readMore}>read more</span>
-                </p>
-            </button>
+            <p style={buttonStyle}>
+                {portfolio.description?.[0].text}...
+                <span className={cssStyles.readMore} onClick={expandCollapse}>
+                    read more
+                </span>
+            </p>
             <span style={textStyle}>
                 {portfolio.description?.map(
                     (description_line) =>
@@ -47,6 +53,11 @@ const PortfolioDescription = () => {
                         </a>
                     </p>
                 ))}
+                <p>
+                    <span className={cssStyles.readMore} onClick={collapseExpand}>
+                        read less
+                    </span>
+                </p>
             </span>
         </div>
     );

--- a/frontend/src/components/PortfolioDescription/PortfolioDescription.jsx
+++ b/frontend/src/components/PortfolioDescription/PortfolioDescription.jsx
@@ -57,7 +57,7 @@ const PortfolioDescription = () => {
                 ))}
                 <p>
                     <span className={cssStyles.readMore} onClick={collapseExpand}>
-                        read less
+                        show less
                     </span>
                 </p>
             </span>

--- a/frontend/src/components/PortfolioDescription/PortfolioDescription.jsx
+++ b/frontend/src/components/PortfolioDescription/PortfolioDescription.jsx
@@ -32,12 +32,14 @@ const PortfolioDescription = () => {
 
     return (
         <div>
-            <p style={buttonStyle}>
-                {portfolio.description?.[0].text}...
-                <span className={cssStyles.readMore} onClick={expandCollapse}>
-                    read more
-                </span>
-            </p>
+            <button onClick={expandCollapse} style={buttonStyle}>
+                <p>
+                    {portfolio.description?.[0].text}...
+                    <span className={cssStyles.readMore} onClick={expandCollapse}>
+                        read more
+                    </span>
+                </p>
+            </button>
             <span style={textStyle}>
                 {portfolio.description?.map(
                     (description_line) =>


### PR DESCRIPTION
## What changed

- Added functionality for a user to click "show less" after having previously clicked "read more" or anywhere in the block of collapsed description text to see a full portfolio's description.  Clicking "show less" will collapse the description down to the original state. 
- Removed a now-outdated portion of repo README referencing Django 

## Issue

#461 

## How to test

Access a portfolio, click on "read more" and then click on "read less", ad infinitum

## Screenshots

![Screen Shot 2022-11-28 at 12 39 47 PM](https://user-images.githubusercontent.com/928984/204344599-44bad9ce-83ed-4b2d-92fe-8b8791c39ed7.png)


