### PR TITLE
making show less to be inline on the last paragraph of a description

### DIFF
--- a/frontend/src/components/PortfolioDescription/PortfolioDescription.jsx
+++ b/frontend/src/components/PortfolioDescription/PortfolioDescription.jsx
@@ -41,12 +41,20 @@ const PortfolioDescription = () => {
                 </p>
             </button>
             <span style={textStyle}>
-                {portfolio.description?.map(
-                    (description_line) =>
-                        description_line.paragraph_number !== 0 && (
-                            <p key={description_line.id}>{description_line.text}</p>
-                        )
-                )}
+                {portfolio.description?.map((element, index, descriptions) => {
+                    if (element.paragraph_number !== 0 && index < descriptions.length - 1) {
+                        return <p key={element.id}>{element.text}</p>;
+                    } else if (index === descriptions.length - 1) {
+                        return (
+                            <p key={element.id}>
+                                {element.text}{" "}
+                                <span className={cssStyles.readMore} onClick={collapseExpand}>
+                                    show less
+                                </span>
+                            </p>
+                        );
+                    }
+                })}
                 {portfolio.urls?.map((url) => (
                     <p key={url.id}>
                         <a key={url.id} href={url.url}>
@@ -55,11 +63,6 @@ const PortfolioDescription = () => {
                         </a>
                     </p>
                 ))}
-                <p>
-                    <span className={cssStyles.readMore} onClick={collapseExpand}>
-                        show less
-                    </span>
-                </p>
             </span>
         </div>
     );


### PR DESCRIPTION
## What changed

After further review, the "show less" text/span on a portfolio's description is supposed to be inline and immediately following the sentence of the last paragraph of a given description, but before any external link for the portfolio. As opposed to on a new line.  This PR corrects not only the text placement, but because it has to be only printed at the end of the last paragraph, the rendering of each paragraph is no longer equal and is treated conditionally instead. 

## Issue
#461 

## Screenshots

![Screen Shot 2022-11-28 at 8 57 03 PM](https://user-images.githubusercontent.com/928984/204419571-e43821d0-3705-4768-be07-fd900aa748ca.png)

![Screen Shot 2022-11-28 at 8 57 47 PM](https://user-images.githubusercontent.com/928984/204419663-963e1857-90e8-4cca-ba4c-fff6448e88a5.png)

