### PR TITLE
571: minor wording changes based on recent user feedback

### DIFF
--- a/frontend/cypress/e2e/portfolioDetail.cy.js
+++ b/frontend/cypress/e2e/portfolioDetail.cy.js
@@ -9,8 +9,8 @@ it("loads", () => {
     cy.get("p").should("contain", "The promotion of children’s safety, permanence, and well-being");
     cy.get("h2").should("contain", "Portfolio Budget Summary");
     cy.get("h3").should("contain", "Total Budget");
-    cy.get("h3").should("contain", "New Funding");
-    cy.get("h3").should("contain", "Carry-Forward Funding");
+    cy.get("h3").should("contain", "New Budget");
+    cy.get("h3").should("contain", "Previous FYs Carry-Forward");
     cy.get("h3").should("contain", "Budget Status");
     cy.get("h3").should("contain", "Portfolio CANs");
     cy.get("#portfolioCANChart").should("be.visible");

--- a/frontend/src/components/PortfolioSummaryCards/PortfolioCarryForwardFunding.jsx
+++ b/frontend/src/components/PortfolioSummaryCards/PortfolioCarryForwardFunding.jsx
@@ -6,7 +6,7 @@ const PortfolioCarryForwardFunding = () => {
 
     const carryForwardFunding = portfolioFunding.carry_over_funding?.amount || 0;
 
-    return <CurrencySummaryCard headerText="Carry-Forward Funding" amount={carryForwardFunding} />;
+    return <CurrencySummaryCard headerText="Previous FYs Carry-Forward" amount={carryForwardFunding} />;
 };
 
 export default PortfolioCarryForwardFunding;

--- a/frontend/src/components/PortfolioSummaryCards/PortfolioNewFunding.jsx
+++ b/frontend/src/components/PortfolioSummaryCards/PortfolioNewFunding.jsx
@@ -1,12 +1,14 @@
 import { useSelector } from "react-redux";
 import CurrencySummaryCard from "../UI/CurrencySummaryCard/CurrencySummaryCard";
 
-const PortfolioNewFunding = () => {
+const PortfolioNewFunding = ({ fiscalYear }) => {
     const portfolioFunding = useSelector((state) => state.portfolioFundingSummary.portfolioFunding);
 
     const newFunding = portfolioFunding.total_funding?.amount - portfolioFunding.carry_over_funding?.amount;
 
-    return <CurrencySummaryCard headerText="New Funding" amount={newFunding} />;
+    const headerText = `FY ${fiscalYear} New Budget`;
+
+    return <CurrencySummaryCard headerText={headerText} amount={newFunding} />;
 };
 
 export default PortfolioNewFunding;


### PR DESCRIPTION
## What changed

Updates to the wording on a couple of the Portfolio Summary cards on the Portfolio Details page to match updated designs and based on recent user feedback and PO requests earlier this week. 

## Issue

#571 

## How to test

It's currently deployed [in the dev environment](https://ops-dev.fr.cloud.gov/portfolios/6).

## Screenshots

<img width="1040" alt="Screen Shot 2022-12-15 at 12 16 47 AM" src="https://user-images.githubusercontent.com/928984/207778439-a446f787-61c0-4e7f-af7b-8f5cd4eb8cd7.png">
_



