### PR TITLE
funding not budget

### DIFF
--- a/frontend/cypress/e2e/portfolioDetail.cy.js
+++ b/frontend/cypress/e2e/portfolioDetail.cy.js
@@ -9,7 +9,7 @@ it("loads", () => {
     cy.get("p").should("contain", "The promotion of children’s safety, permanence, and well-being");
     cy.get("h2").should("contain", "Portfolio Budget Summary");
     cy.get("h3").should("contain", "Total Budget");
-    cy.get("h3").should("contain", "New Budget");
+    cy.get("h3").should("contain", "New Funding");
     cy.get("h3").should("contain", "Previous FYs Carry-Forward");
     cy.get("h3").should("contain", "Budget Status");
     cy.get("h3").should("contain", "Portfolio CANs");

--- a/frontend/src/components/PortfolioSummaryCards/PortfolioNewFunding.jsx
+++ b/frontend/src/components/PortfolioSummaryCards/PortfolioNewFunding.jsx
@@ -7,7 +7,7 @@ const PortfolioNewFunding = () => {
 
     const newFunding = portfolioBudget.total_funding?.amount - portfolioBudget.carry_over_funding?.amount;
 
-    const headerText = `FY ${fiscalYear.value} New Budget`;
+    const headerText = `FY ${fiscalYear.value} New Funding`;
 
     return <CurrencySummaryCard headerText={headerText} amount={newFunding} />;
 };


### PR DESCRIPTION
## What changed

Re-inserting the word funding instead of budget on the middle summary card of portfolio details after it got lost in some reconciliation of branches

## Issue

#571

