### PR TITLE
fixes hover color for a11y contrast issue

### DIFF
--- a/frontend/src/components/UI/Tag/Tag.jsx
+++ b/frontend/src/components/UI/Tag/Tag.jsx
@@ -23,7 +23,7 @@ const Tag = ({ tagStyle = "", text = "", active = false, label = "" }) => {
     } else if (active && label.includes("Funding Received")) {
         activeClass = "bg-brand-data-viz-primary-3 text-white fake-bold";
     } else if (active && label.includes("Funding Expected")) {
-        activeClass = "bg-brand-neutral-lighter text-white fake-bold";
+        activeClass = "bg-brand-neutral-lighter fake-bold";
     } else if (active && label.includes("Carry-Forward")) {
         activeClass = "bg-brand-data-viz-primary-10 fake-bold";
     } else if (active && label.includes("New Funding")) {


### PR DESCRIPTION
## What changed

fixes hover color for a11y contrast issue

## Issue

just noticed one small change needed for user story 597 (improve layout of CAN status and amounts). The font color on hover for the Funding Expected should be changed from white to black (#1B1B1B)

## How to test

hover over `funding expected` in can card and see font color. 

## Screenshots

<img width="591" alt="SCR-20230217-h2l" src="https://user-images.githubusercontent.com/4629398/219747200-565f85a3-9180-4b51-93cd-51fc463e5c47.png">
