### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,13 @@
         "groupSlug": "all-patch",
         "stabilityDays": 0
     },
+    "digest": {
+        "automerge": true,
+        "groupName": "digest dependencies",
+        "groupSlug": "all-digest",
+        "platformAutomerge": true,
+        "stabilityDays": 0
+    },
     "packageRules": [{
         "matchPackageNames": ["python"],
         "enabled": false


### PR DESCRIPTION
Updated to add `automerge: true` for `digest` updates; which we're using for our GitHub Action version pinning. To help reduce the need for manual intervention.

## What changed

* Added a `digest` section, with configurations for `automerge: true`
