### PR TITLE
editing yaml frontmatter on issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.md
+++ b/.github/ISSUE_TEMPLATE/bugs.md
@@ -1,3 +1,11 @@
+---
+name: Bug report
+about: Use this template for reporting details about an application bug
+title: ''
+labels: bug
+assignees: ''
+---
+
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Expected Behavior

--- a/.github/ISSUE_TEMPLATE/feature_work_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_work_template.md
@@ -2,13 +2,13 @@
 name: Feature work template
 about: Use this template to capture the User Story, Acceptance Criteria, Tasks, and Definition of Done associated with feature work
 title: ''
-labels: ''
+labels: draft, story
 assignees: ''
 
 ---
 
 ### User Story
-_As a [type of user], I want to [do something] so that [this outcome]_
+_As a [type of user], I want to [do something] [to produce this outcome]_
 
 ### Acceptance Criteria
 - [ ] _How will we know when this story is done?  List here the desired behavior that must be enabled for this story to be considered done_

--- a/.github/ISSUE_TEMPLATE/generic-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/generic-issue-template.md
@@ -1,7 +1,6 @@
 ---
 name: Generic issue template
-about: Use this template to request work and provide Goals, Tasks, Additional Context,
-  and/or Resources
+about: Use this template for devex/opex or tech debt backlog item that isn't a user story meeting a business need
 title: ''
 labels: ''
 assignees: ''


### PR DESCRIPTION
## What changed

* Adding or editing YAML frontmatter on GH issue templates
* Removing the overly prescriptive "so that" clause of the user story statement

## Issue

N/A

## How to test

* Create a new issue from one of the types

## Screenshots

N/A

## Links

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates
