### PR TITLE
Ops 742 can search

### DIFF
--- a/backend/models/cans.py
+++ b/backend/models/cans.py
@@ -241,8 +241,8 @@ class CAN(BaseModel):
     budget_line_items = relationship("BudgetLineItem", back_populates="can")
 
     @override
-    def to_dict(self) -> dict[str, Any]:  # type: ignore [override]
-        d: dict[str, Any] = super().to_dict()  # type: ignore [no-untyped-call]
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = super().to_dict()
 
         d.update(
             appropriation_date=self.appropriation_date.strftime("%d/%m/%Y")

--- a/backend/ops_api/ops/history.py
+++ b/backend/ops_api/ops/history.py
@@ -29,7 +29,7 @@ def track_db_history_catch_errors(exception_context):
 def add_obj_to_db_history(objs: IdentitySet, event_type: OpsDBHistoryType):
     result = []
     for obj in objs:
-        if not isinstance(obj, OpsEvent):  # not interested in tracking these
+        if not isinstance(obj, OpsEvent) and not isinstance(obj, OpsDBHistory):  # not interested in tracking these
             ops_db = OpsDBHistory(event_type=event_type, event_details=obj.to_dict())
             result.append(ops_db)
     return result

--- a/backend/ops_api/ops/resources/cans.py
+++ b/backend/ops_api/ops/resources/cans.py
@@ -1,11 +1,21 @@
-from typing import List
+from dataclasses import dataclass
+from typing import List, Optional, cast
 
-from flask import Response, jsonify
+import desert
+from flask import Response, current_app, jsonify, make_response, request
 from flask_jwt_extended import jwt_required
 from models.base import BaseModel
 from models.cans import CAN
 from ops_api.ops.base_views import BaseItemAPI, BaseListAPI
+from ops_api.ops.utils.query_helpers import QueryHelper
+from sqlalchemy import select
+from sqlalchemy.orm import InstrumentedAttribute
 from typing_extensions import override
+
+
+@dataclass
+class ListAPIRequest:
+    search: Optional[str]
 
 
 class CANItemAPI(BaseItemAPI):
@@ -16,11 +26,40 @@ class CANItemAPI(BaseItemAPI):
 class CANListAPI(BaseListAPI):
     def __init__(self, model):
         super().__init__(model)
+        self._get_input_schema = desert.schema(ListAPIRequest)
+
+    @staticmethod
+    def _get_query(search=None):
+        stmt = select(CAN).order_by(CAN.id)
+
+        query_helper = QueryHelper(stmt)
+
+        if search is not None and len(search) == 0:
+            query_helper.return_none()
+        elif search:
+            query_helper.add_search(cast(InstrumentedAttribute, CAN.number), search)
+
+        stmt = query_helper.get_stmt()
+        current_app.logger.debug(f"SQL: {stmt}")
+
+        return stmt
 
     @jwt_required(True)  # For an example case, we're allowing CANs to be queried unauthed
     def get(self) -> Response:
-        items = self.model.query.all()
-        return jsonify([item.to_dict() for item in items])
+        errors = self._get_input_schema.validate(request.args)
+
+        if errors:
+            response = make_response(errors, 400)
+            response.headers.add("Access-Control-Allow-Origin", "*")
+            return response
+
+        request_data: ListAPIRequest = self._get_input_schema.load(request.args)
+        stmt = self._get_query(request_data.search)
+        result = current_app.db_session.execute(stmt).all()
+        response = jsonify([i.to_dict() for item in result for i in item])
+
+        response.headers.add("Access-Control-Allow-Origin", "*")
+        return response
 
 
 class CANsByPortfolioAPI(BaseItemAPI):

--- a/backend/ops_api/ops/utils/query_helpers.py
+++ b/backend/ops_api/ops/utils/query_helpers.py
@@ -1,20 +1,21 @@
-from typing import Any
+from typing import Any, cast
 
-from sqlalchemy import Column, Select
+from sqlalchemy import ColumnElement, Select
+from sqlalchemy.orm import InstrumentedAttribute
 
 
 class QueryHelper:
     def __init__(self, stmt: Select[Any]):
         self.stmt = stmt
 
-    def add_search(self, column: Column, search_term: str) -> Select[Any]:
+    def add_search(self, column: InstrumentedAttribute, search_term: str):
         self.stmt = self.stmt.where(column.ilike(f"%{search_term}%"))
 
-    def add_column_equals(self, column: Column, value: str) -> Select[Any]:
+    def add_column_equals(self, column: InstrumentedAttribute, value: str):
         self.stmt = self.stmt.where(column == value)
 
-    def return_none(self) -> Select[Any]:
-        self.stmt = self.stmt.where(0 == 1)
+    def return_none(self):
+        self.stmt = self.stmt.where(cast(ColumnElement, False))
 
     def get_stmt(self):
         return self.stmt

--- a/backend/ops_api/tests/ops/can/test_can.py
+++ b/backend/ops_api/tests/ops/can/test_can.py
@@ -59,3 +59,20 @@ def test_can_get_portfolio_cans(auth_client, loaded_db):
     assert response.status_code == 200
     assert len(response.json) == 2
     assert response.json[0]["id"] == 2
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_get_cans_search_filter(auth_client, loaded_db):
+    response = auth_client.get("/api/v1/cans/?search=XXX8")
+    assert response.status_code == 200
+    assert len(response.json) == 1
+    assert response.json[0]["id"] == 13
+
+    response = auth_client.get("/api/v1/cans/?search=G99HRF2")
+    assert response.status_code == 200
+    assert len(response.json) == 1
+    assert response.json[0]["id"] == 1
+
+    response = auth_client.get("/api/v1/cans/?search=")
+    assert response.status_code == 200
+    assert len(response.json) == 0


### PR DESCRIPTION
## What changed

Add `search` query param to `/cans` endpoint.

## Issue

https://github.com/HHS/OPRE-OPS/issues/742

## How to test

1. Send GET request to backend: `http://localhost:8080/api/v1/cans?search=XXX8`
2. You should only get back 1 CAN in the response corresponding to `"number": "G99XXX8"`

