### PR TITLE
Ops 809 total summary cards

### DIFF
--- a/frontend/src/pages/budgetLines/PreviewTable.jsx
+++ b/frontend/src/pages/budgetLines/PreviewTable.jsx
@@ -229,7 +229,7 @@ export const PreviewTable = ({ handleDeleteBudgetLine = () => {} }) => {
                     ))}
                 </tbody>
             </table>
-            <TotalSummaryCard budgetLines={budgetLines}></TotalSummaryCard>
+            <TotalSummaryCard budgetLines={sortedBudgetLines}></TotalSummaryCard>
         </>
     );
 };

--- a/frontend/src/pages/budgetLines/PreviewTable.jsx
+++ b/frontend/src/pages/budgetLines/PreviewTable.jsx
@@ -6,6 +6,7 @@ import { faChevronDown, faChevronUp, faPen, faTrash } from "@fortawesome/free-so
 import { faClock, faClone } from "@fortawesome/free-regular-svg-icons";
 import Tag from "../../components/UI/Tag/Tag";
 import { editBudgetLineAdded, duplicateBudgetLineAdded } from "./createBudgetLineSlice";
+import { TotalSummaryCard } from "./TotalSummaryCard";
 import "./PreviewTable.scss";
 
 export const PreviewTable = ({ handleDeleteBudgetLine = () => {} }) => {
@@ -206,26 +207,29 @@ export const PreviewTable = ({ handleDeleteBudgetLine = () => {} }) => {
     };
 
     return (
-        <table className="usa-table usa-table--borderless width-full">
-            <thead>
-                <tr>
-                    <th scope="col">Description</th>
-                    <th scope="col">Need By</th>
-                    <th scope="col">FY</th>
-                    <th scope="col">CAN</th>
-                    <th scope="col">Amount</th>
-                    <th scope="col">Fee</th>
-                    <th scope="col">Total</th>
-                    <th scope="col" className="padding-0" style={{ width: "6.25rem" }}>
-                        Status
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                {sortedBudgetLines.map((bl) => (
-                    <TableRow key={bl?.id} bl={bl} />
-                ))}
-            </tbody>
-        </table>
+        <>
+            <table className="usa-table usa-table--borderless width-full">
+                <thead>
+                    <tr>
+                        <th scope="col">Description</th>
+                        <th scope="col">Need By</th>
+                        <th scope="col">FY</th>
+                        <th scope="col">CAN</th>
+                        <th scope="col">Amount</th>
+                        <th scope="col">Fee</th>
+                        <th scope="col">Total</th>
+                        <th scope="col" className="padding-0" style={{ width: "6.25rem" }}>
+                            Status
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {sortedBudgetLines.map((bl) => (
+                        <TableRow key={bl?.id} bl={bl} />
+                    ))}
+                </tbody>
+            </table>
+            <TotalSummaryCard budgetLines={budgetLines}></TotalSummaryCard>
+        </>
     );
 };

--- a/frontend/src/pages/budgetLines/TotalSummaryCard.jsx
+++ b/frontend/src/pages/budgetLines/TotalSummaryCard.jsx
@@ -1,3 +1,5 @@
+import CurrencyFormat from "react-currency-format";
+
 export const TotalSummaryCard = ({ budgetLines }) => {
     let currentDate = new Date();
     let month = currentDate.getMonth();
@@ -37,33 +39,56 @@ export const TotalSummaryCard = ({ budgetLines }) => {
         totals["Agreement"]["total"] += total;
     });
 
-    const TotalBlock = (title, data) => {
+    const TotalBlock = ({ title, data }) => {
         if (title === "FY") {
             title = "FY " + currentFiscalYear;
         }
         return (
-            <div className="flex-column flex-4">
-                <div>{title + " Total"}</div>
-                <div className="grid-container">
-                    <div className="grid-row">
-                        <div className="grid-col-2">Subtotal</div>
-                        <div className="grid-col-2">{data.subtotal}</div>
+            <div
+                className="bg-base-lightest font-family-sans font-12px border-1px border-base-light radius-sm margin-left-4 padding-y-2 padding-x-105"
+                style={{ minWidth: "206px" }}
+            >
+                <h3 className="text-base-dark text-normal font-12px">{title + " Total"}</h3>
+                <dl className="margin-0 padding-bottom-105">
+                    <div className="grid-row padding-y-1">
+                        <dt className="margin-0 text-base-dark grid-col-5">Subtotal</dt>
+                        <dd className="text-semibold margin-0 grid-col-5">
+                            <CurrencyFormat
+                                value={data.subtotal}
+                                displayType={"text"}
+                                thousandSeparator={true}
+                                prefix={"$"}
+                            />
+                        </dd>
                     </div>
-                    <div className="grid-row">
-                        <div className="grid-col-2">Fees</div>
-                        <div className="grid-col-2">{data.fees}</div>
+                    <div className="grid-row padding-y-05">
+                        <dt className="margin-0 text-base-dark grid-col-5">Fees</dt>
+                        <dd className="text-semibold margin-0 grid-col-5">
+                            <CurrencyFormat
+                                value={data.fees}
+                                displayType={"text"}
+                                thousandSeparator={true}
+                                prefix={"$"}
+                            />
+                        </dd>
                     </div>
-                </div>
-                <div>{data.total}</div>
+                </dl>
+                <CurrencyFormat
+                    value={data.total}
+                    displayType={"text"}
+                    thousandSeparator={true}
+                    prefix={"$ "}
+                    renderText={(value) => <span className="text-semibold font-sans-lg padding-y-105">{value}</span>}
+                />
             </div>
         );
     };
 
     return (
-        <div className="flex-align-end">
+        <summary className="display-flex flex-justify-end margin-y-4">
             <TotalBlock title="Draft" data={totals["Draft"]}></TotalBlock>
             <TotalBlock title="FY" data={totals["FY"]}></TotalBlock>
             <TotalBlock title="Agreement" data={totals["Agreement"]}></TotalBlock>
-        </div>
+        </summary>
     );
 };

--- a/frontend/src/pages/budgetLines/TotalSummaryCard.jsx
+++ b/frontend/src/pages/budgetLines/TotalSummaryCard.jsx
@@ -1,0 +1,69 @@
+export const TotalSummaryCard = ({ budgetLines }) => {
+    let currentDate = new Date();
+    let month = currentDate.getMonth();
+    let year = currentDate.getFullYear();
+    const currentFiscalYear = month > 8 ? year + 1 : year;
+
+    const totals = {
+        Draft: { subtotal: 0, fees: 0, total: 0 },
+        FY: { subtotal: 0, fees: 0, total: 0 },
+        Agreement: { subtotal: 0, fees: 0, total: 0 },
+    };
+
+    budgetLines.forEach((bl) => {
+        let date_needed = new Date(bl?.date_needed);
+        let month = date_needed.getMonth();
+        let year = date_needed.getFullYear();
+        let fiscalYear = month > 8 ? year + 1 : year;
+        let amount = bl?.amount;
+        let fee = amount * (bl?.psc_fee_amount / 10);
+        let total = amount + fee;
+        let status = bl?.status.charAt(0).toUpperCase() + bl?.status.slice(1).toLowerCase();
+
+        if (status === "Draft") {
+            totals["Draft"]["subtotal"] += amount;
+            totals["Draft"]["fees"] += fee;
+            totals["Draft"]["total"] += total;
+        }
+
+        if (fiscalYear === currentFiscalYear) {
+            totals["FY"]["subtotal"] += amount;
+            totals["FY"]["fees"] += fee;
+            totals["FY"]["total"] += total;
+        }
+
+        totals["Agreement"]["subtotal"] += amount;
+        totals["Agreement"]["fees"] += fee;
+        totals["Agreement"]["total"] += total;
+    });
+
+    const TotalBlock = (title, data) => {
+        if (title === "FY") {
+            title = "FY " + currentFiscalYear;
+        }
+        return (
+            <div className="flex-column flex-4">
+                <div>{title + " Total"}</div>
+                <div className="grid-container">
+                    <div className="grid-row">
+                        <div className="grid-col-2">Subtotal</div>
+                        <div className="grid-col-2">{data.subtotal}</div>
+                    </div>
+                    <div className="grid-row">
+                        <div className="grid-col-2">Fees</div>
+                        <div className="grid-col-2">{data.fees}</div>
+                    </div>
+                </div>
+                <div>{data.total}</div>
+            </div>
+        );
+    };
+
+    return (
+        <div className="flex-align-end">
+            <TotalBlock title="Draft" data={totals["Draft"]}></TotalBlock>
+            <TotalBlock title="FY" data={totals["FY"]}></TotalBlock>
+            <TotalBlock title="Agreement" data={totals["Agreement"]}></TotalBlock>
+        </div>
+    );
+};


### PR DESCRIPTION
## What changed

Added summary blocks for Drafts, current fiscal year, and total agreements in the create new budget line/budget lines section.

## Issue

[Create BLI Details - "Total Summary Cards" Components #809](https://app.zenhub.com/workspaces/opre-ops-62d197b4c468970013bcd2ec/issues/gh/hhs/opre-ops/809)

## How to test

Go to site, choose "Create Budget Line", follow prompts until you get to the budget lines section, and the three blocks appear under the table of budget lines on that page. Adding/removing/changing budget lines affects the totals appropriately.

## Screenshots

![image](https://user-images.githubusercontent.com/881707/232113469-425c986e-9a10-402b-8063-fc776072f14c.png)

## Links


