### PR TITLE
Ops 674 only agreement id required bli

### DIFF
--- a/backend/models/cans.py
+++ b/backend/models/cans.py
@@ -3,12 +3,11 @@ from enum import Enum
 from typing import Any
 
 import sqlalchemy as sa
-from models.base import BaseData, BaseModel, currency, intpk, optional_str, reg, required_str
+from models.base import BaseModel
 from models.portfolios import Portfolio, shared_portfolio_cans
-from models.research_projects import ResearchProject
 from models.users import User
 from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Identity, Integer, Numeric, String, Table, Text
-from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
+from sqlalchemy.orm import column_property, relationship
 from typing_extensions import override
 
 
@@ -114,7 +113,10 @@ class Agreement(BaseModel):
     name = Column(String, nullable=False)
     number = Column(String, nullable=False)
     description = Column(String, nullable=True)
-    product_service_code = Column(Integer, ForeignKey("product_service_code.id", name="fk_agreement_product_service_code"))
+    product_service_code = Column(
+        Integer,
+        ForeignKey("product_service_code.id", name="fk_agreement_product_service_code"),
+    )
     agreement_reason = Column(sa.Enum(AgreementReason))
     incumbent = Column(String, nullable=True)
     project_officer = Column(
@@ -128,8 +130,14 @@ class Agreement(BaseModel):
     agreement_type = Column(sa.Enum(AgreementType))
     research_project_id = Column(Integer, ForeignKey("research_project.id"))
     research_project = relationship("ResearchProject", back_populates="agreements")
-    budget_line_items = relationship("BudgetLineItem", back_populates="agreement", lazy=True)
-    procurment_shop = Column(Integer, ForeignKey("procurement_shop.id", name="fk_agreement_procurement_shop"), nullable=True)
+    budget_line_items = relationship(
+        "BudgetLineItem", back_populates="agreement", lazy=True
+    )
+    procurment_shop = Column(
+        Integer,
+        ForeignKey("procurement_shop.id", name="fk_agreement_procurement_shop"),
+        nullable=True,
+    )
     type = Column(String)
 
     __mapper_args__ = {
@@ -151,7 +159,9 @@ class Agreement(BaseModel):
                 else None,
                 "budget_line_items": [bli.to_dict() for bli in self.budget_line_items],
                 "team_members": [tm.to_dict() for tm in self.team_members],
-                "research_project": self.research_project.to_dict() if self.research_project else None,
+                "research_project": self.research_project.to_dict()
+                if self.research_project
+                else None,
             }
         )
 
@@ -201,8 +211,12 @@ class ContractAgreement(Agreement):
 
         d.update(
             {
-                "contract_type": self.contract_type.name if self.contract_type else None,
-                "support_contacts": [contacts.to_dict() for contacts in self.support_contacts],
+                "contract_type": self.contract_type.name
+                if self.contract_type
+                else None,
+                "support_contacts": [
+                    contacts.to_dict() for contacts in self.support_contacts
+                ],
             }
         )
 
@@ -337,7 +351,7 @@ class BudgetLineItem(BaseModel):
     __tablename__ = "budget_line_item"
 
     id = Column(Integer, Identity(), primary_key=True)
-    line_description = Column(String, nullable=False)
+    line_description = Column(String)
     comments = Column(Text)
 
     agreement_id = Column(Integer, ForeignKey("agreement.id"))

--- a/backend/ops_api/ops/resources/budget_line_items.py
+++ b/backend/ops_api/ops/resources/budget_line_items.py
@@ -23,11 +23,14 @@ from typing_extensions import override
 
 @dataclass
 class RequestBody:
-    line_description: str
     agreement_id: int
-    can_id: int
-    amount: float
-    date_needed: str
+    line_description: Optional[str] = None
+    can_id: Optional[int] = None
+    amount: Optional[float] = None
+    date_needed: Optional[date] = fields.Date(
+        format="%Y-%m-%d",
+        default=None,
+    )
     status: Optional[BudgetLineItemStatus] = fields.Enum(BudgetLineItemStatus)
     comments: Optional[str] = None
     psc_fee_amount: Optional[float] = None
@@ -159,7 +162,6 @@ class BudgetLineItemsListAPI(BaseListAPI):
 
                 data = self._post_schema.load(request.json)
                 # convert str param to date
-                data.date_needed = datetime.fromisoformat(data.date_needed)
                 new_bli = BudgetLineItem(**data.__dict__)
 
                 token = verify_jwt_in_request()

--- a/backend/ops_api/tests/ops/can/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/can/test_budget_line_item.py
@@ -194,3 +194,13 @@ def test_post_budget_line_items_auth_required(client):
     )
     response = client.post("/api/v1/budget-line-items/", json=data.__dict__)
     assert response.status_code == 401
+
+
+@pytest.mark.usefixtures("app_ctx")
+@pytest.mark.usefixtures("loaded_db")
+def test_post_budget_line_items_only_agreement_id_required(auth_client):
+    data = {"agreement_id": 1}
+    response = auth_client.post("/api/v1/budget-line-items/", json=data)
+    assert response.status_code == 201
+    assert response.json["id"] is not None
+    assert response.json["agreement_id"] == 1


### PR DESCRIPTION
## What changed

Backend: Allow creating a BudgetLineItem with only an `agreement_id` (all other attributes are optional)

## Issue

https://app.zenhub.com/workspaces/opre-ops-62d197b4c468970013bcd2ec/issues/gh/hhs/opre-ops/674

## How to test

- POST to  `/budget-line-items` with a body of `{"agreement_id": 1}`
- You should get a 201 response back like:
```
{
    "agreement_id": 1,
    "amount": null,
    "can_id": null,
    "comments": null,
    "created_by": 12,
    "created_on": "2023-04-18T15:54:07.969886",
    "date_needed": null,
    "id": 20,
    "line_description": null,
    "psc_fee_amount": null,
    "status": null,
    "updated_on": "2023-04-18T15:54:07.969886"
}
```