### PR TITLE
Ops 674 post bli from frontend

### DIFF
--- a/frontend/src/api/postBudgetLineItems.js
+++ b/frontend/src/api/postBudgetLineItems.js
@@ -1,0 +1,55 @@
+import ApplicationContext from "../applicationContext/ApplicationContext";
+
+export const postBudgetLineItem = async (item) => {
+    const api_version = ApplicationContext.get().helpers().backEndConfig.apiVersion;
+
+    console.log("item", item);
+
+    // TODO: These are hacks to transform the state into a valid BLI for the backend
+    const data = { ...item }; // make a copy - item is read only
+
+    if (data.date_needed === "--") {
+        data.date_needed = null;
+    }
+
+    delete data.can;
+    delete data.id;
+
+    console.log("item", data);
+
+    const responseData = ApplicationContext.get()
+        .helpers()
+        .callBackend(`/api/${api_version}/budget-line-items/`, "POST", data)
+        .then(function (response) {
+            console.log(response);
+        })
+        .catch(function (error) {
+            if (error.response) {
+                // The request was made and the server responded with a status code
+                // that falls out of the range of 2xx
+                console.log(error.response.data);
+                console.log(error.response.status);
+                console.log(error.response.headers);
+            } else if (error.request) {
+                // The request was made but no response was received
+                // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+                // http.ClientRequest in node.js
+                console.log(error.request);
+            } else {
+                // Something happened in setting up the request that triggered an Error
+                console.log("Error", error.message);
+            }
+            console.log(error.config);
+        });
+
+    return responseData;
+};
+
+export const postBudgetLineItems = async (items) => {
+    console.log("items", items);
+    return Promise.all(
+        items.map((item) => {
+            postBudgetLineItem(item);
+        })
+    );
+};

--- a/frontend/src/pages/budgetLines/CreateBudgetLine.jsx
+++ b/frontend/src/pages/budgetLines/CreateBudgetLine.jsx
@@ -156,7 +156,6 @@ const StepTwo = ({ goBack, goToNext }) => {
                     status: "DRAFT",
                     date_needed: `${enteredYear}-${enteredMonth}-${enteredDay}` || null,
                     psc_fee_amount: selectedProcurementShop?.fee || null,
-                    // created_on: new Date().toISOString().slice(0, -1) + (Date.now() % 1000).toString().padStart(3, "0"),
                 },
             ])
         );

--- a/frontend/src/pages/budgetLines/CreateBudgetLine.jsx
+++ b/frontend/src/pages/budgetLines/CreateBudgetLine.jsx
@@ -31,6 +31,7 @@ import { getProcurementShopList } from "../../api/getProcurementShopList";
 import { Alert } from "../../components/UI/Alert/Alert";
 import { Modal } from "../../components/UI/Modal/Modal";
 import { ProjectAgreementSummaryCard } from "./ProjectAgreementSummaryCard";
+import { postBudgetLineItems } from "../../api/postBudgetLineItems";
 
 const StepOne = ({ goToNext }) => {
     const selectedResearchProject = useSelector((state) => state.createBudgetLine.selected_project);
@@ -155,7 +156,7 @@ const StepTwo = ({ goBack, goToNext }) => {
                     status: "DRAFT",
                     date_needed: `${enteredYear}-${enteredMonth}-${enteredDay}` || null,
                     psc_fee_amount: selectedProcurementShop?.fee || null,
-                    created_on: new Date().toISOString().slice(0, -1) + (Date.now() % 1000).toString().padStart(3, "0"),
+                    // created_on: new Date().toISOString().slice(0, -1) + (Date.now() % 1000).toString().padStart(3, "0"),
                 },
             ])
         );
@@ -169,6 +170,15 @@ const StepTwo = ({ goBack, goToNext }) => {
         dispatch(setEnteredDay(""));
         dispatch(setEnteredYear(""));
         dispatch(setEnteredComments(""));
+    };
+
+    const saveBudgetLineItems = (event) => {
+        event.preventDefault();
+        const newBudgetLineItems = budgetLinesAdded.filter(
+            // eslint-disable-next-line no-prototype-builtins
+            (budgetLineItem) => !budgetLineItem.hasOwnProperty("created_on")
+        );
+        postBudgetLineItems(newBudgetLineItems).then(() => console.log("Created New BLIs."));
     };
 
     return (
@@ -348,7 +358,7 @@ const StepTwo = ({ goBack, goToNext }) => {
                 >
                     Back
                 </button>
-                <button className="usa-button" onClick={() => goToNext()}>
+                <button className="usa-button" onClick={saveBudgetLineItems}>
                     Continue
                 </button>
             </div>

--- a/frontend/src/pages/budgetLines/PreviewTable.jsx
+++ b/frontend/src/pages/budgetLines/PreviewTable.jsx
@@ -36,7 +36,7 @@ export const PreviewTable = ({ handleDeleteBudgetLine = () => {} }) => {
             : formatted_today;
         let formatted_date_needed;
         let fiscalYear;
-        if (bl?.date_needed !== "--") {
+        if (bl?.date_needed !== "--" && bl?.date_needed !== null) {
             let date_needed = new Date(bl?.date_needed);
             formatted_date_needed = formatDate(date_needed);
             // FY will automate based on the Need by Date. Anything after September 30th rolls over into the next FY.
@@ -123,7 +123,7 @@ export const PreviewTable = ({ handleDeleteBudgetLine = () => {} }) => {
                     <td style={{ backgroundColor: isRowActive && "#F0F0F0" }}>{bl?.can?.number}</td>
                     <td style={{ backgroundColor: isRowActive && "#F0F0F0" }}>
                         <CurrencyFormat
-                            value={bl?.amount}
+                            value={bl?.amount || 0}
                             displayType={"text"}
                             thousandSeparator={true}
                             prefix={"$"}

--- a/frontend/src/pages/budgetLines/createBudgetLineSlice.js
+++ b/frontend/src/pages/budgetLines/createBudgetLineSlice.js
@@ -94,7 +94,6 @@ const createBudgetLineSlice = createSlice({
                     ...action.payload,
                     id: crypto.getRandomValues(new Uint32Array(1))[0],
                     status: "DRAFT",
-                    created_on: new Date().toISOString().slice(0, -1) + (Date.now() % 1000).toString().padStart(3, "0"),
                 };
 
                 return {


### PR DESCRIPTION
## What changed

Add click handler/function to POST to `budget-line-items`. 

## Issue

https://app.zenhub.com/workspaces/opre-ops-62d197b4c468970013bcd2ec/issues/gh/hhs/opre-ops/674

## How to test

- Go to the Add New Budget Lines wizard and add a few BLIs to the Preview Table.
- Click Continue
- You should see the BLIs created in the logs in the back end.
