### PR TITLE
correcting model for product_service_codes

### DIFF
--- a/backend/data_tools/data/agreements_and_blin_data.json5
+++ b/backend/data_tools/data/agreements_and_blin_data.json5
@@ -28,32 +28,16 @@
   product_service_code: [
     {
       id: 1,
-      name: "Service-Code-1",
+      name: "Other Scientific and Technical Consulting Services",
+      naics: 541690,
+      support_code: "R410 - Research",
       description: "",
     },
     {
       id: 2,
-      name: "Service-Code-2",
-      description: "",
-    },
-    {
-      id: 3,
-      name: "Service-Code-3",
-      description: "",
-    },
-    {
-      id: 4,
-      name: "Service-Code-4",
-      description: "",
-    },
-    {
-      id: 5,
-      name: "Service-Code-5",
-      description: "",
-    },
-    {
-      id: 6,
-      name: "Service-Code-6",
+      name: "Convention and Trade Shows",
+      naics: 561920,
+      support_code: "R706 - Support",
       description: "",
     },
   ],

--- a/backend/models/cans.py
+++ b/backend/models/cans.py
@@ -102,6 +102,8 @@ class ProductServiceCode(BaseModel):
 
     id = Column(Integer, primary_key=True)
     name = Column(String, nullable=False)
+    naics = Column(Integer, nullable=True)
+    support_code = Column(String, nullable=True)
     description = Column(String)
 
 

--- a/backend/ops_api/tests/ops/can/test_product_service_code.py
+++ b/backend/ops_api/tests/ops/can/test_product_service_code.py
@@ -14,5 +14,5 @@ def test_product_service_code_lookup(loaded_db):
     psc = loaded_db.query(ProductServiceCode).filter(ProductServiceCode.id == 2).one()
     assert psc is not None
     assert psc.id == 2
-    assert psc.name == "Service-Code-1"
+    assert psc.name == "Convention and Trade Shows"
     assert psc.naics == 561920

--- a/backend/ops_api/tests/ops/can/test_product_service_code.py
+++ b/backend/ops_api/tests/ops/can/test_product_service_code.py
@@ -6,13 +6,13 @@ from models.cans import ProductServiceCode
 def test_get_product_service_code_list(auth_client):
     response = auth_client.get("/api/v1/product-service-codes/")
     assert response.status_code == 200
-    assert len(response.json) == 6
+    assert len(response.json) == 2
 
 
 @pytest.mark.usefixtures("app_ctx")
 def test_product_service_code_lookup(loaded_db):
-    psc = loaded_db.query(ProductServiceCode).filter(ProductServiceCode.id == 1).one()
+    psc = loaded_db.query(ProductServiceCode).filter(ProductServiceCode.id == 2).one()
     assert psc is not None
-    assert psc.id == 1
+    assert psc.id == 2
     assert psc.name == "Service-Code-1"
-    assert psc.description == ""
+    assert psc.naics == 561920


### PR DESCRIPTION
## What changed

The name and NAICS are essentially key/value pairs. There's an additional program support code string that relates back to and derived from the product service code. So I'm updating the model to accommodate and provide the sample values that OPRE has identified that we need.

## Issue

#775 

## How to test

Create an agreement and ideally these values will be present

## Screenshots


## Links

