### PR TITLE
fixing header language when creating agreement

### DIFF
--- a/frontend/src/pages/agreements/StepCreateAgreement.jsx
+++ b/frontend/src/pages/agreements/StepCreateAgreement.jsx
@@ -137,7 +137,7 @@ export const StepCreateAgreement = ({ goBack, goToNext, wizardSteps }) => {
                     handleConfirm={modalProps.handleConfirm}
                 />
             )}
-            <h1 className="font-sans-lg">Create New Budget Line</h1>
+            <h1 className="font-sans-lg">Create New Agreement</h1>
             <p>Step Two: Creating a new Agreement</p>
             <StepIndicator steps={wizardSteps} currentStep={2} />
             <ProjectSummaryCard selectedResearchProject={selectedResearchProject} />

--- a/frontend/src/pages/agreements/StepCreateAgreement.jsx
+++ b/frontend/src/pages/agreements/StepCreateAgreement.jsx
@@ -138,11 +138,11 @@ export const StepCreateAgreement = ({ goBack, goToNext, wizardSteps }) => {
                 />
             )}
             <h1 className="font-sans-lg">Create New Agreement</h1>
-            <p>Step Two: Creating a new Agreement</p>
+            <p>Follow the steps to create an agreement</p>
             <StepIndicator steps={wizardSteps} currentStep={2} />
             <ProjectSummaryCard selectedResearchProject={selectedResearchProject} />
             <h2 className="font-sans-lg">Select the Agreement Type</h2>
-            <p>Select the type of agreement you would like to create.</p>
+            <p>Select the type of agreement you&#39;d like to create.</p>
             <AgreementTypeSelect />
             <h2 className="font-sans-lg margin-top-3">Agreement Details</h2>
             <label className="usa-label" htmlFor="agreement-title">

--- a/frontend/src/pages/agreements/StepSelectProject.jsx
+++ b/frontend/src/pages/agreements/StepSelectProject.jsx
@@ -55,12 +55,12 @@ export const StepSelectProject = ({ goToNext, wizardSteps }) => {
                 />
             )}
             <h1 className="font-sans-lg">Create New Agreement</h1>
-            <p>Step One: Text explaining this page</p>
+            <p>Follow the steps to create an agreement</p>
             <StepIndicator steps={wizardSteps} currentStep={1} />
             <h2 className="font-sans-lg">Select a Project</h2>
             <p>
-                Select the project this budget line should be associated with. If you need to create a new project,
-                click Add New Project.
+                Select a project the agreement should be associated with. If you need to create a new project, click Add
+                New Project.
             </p>
             <ProjectSelect
                 researchProjects={projects}

--- a/frontend/src/pages/agreements/StepSelectProject.jsx
+++ b/frontend/src/pages/agreements/StepSelectProject.jsx
@@ -54,7 +54,7 @@ export const StepSelectProject = ({ goToNext, wizardSteps }) => {
                     handleConfirm={modalProps.handleConfirm}
                 />
             )}
-            <h1 className="font-sans-lg">Create New Budget Line</h1>
+            <h1 className="font-sans-lg">Create New Agreement</h1>
             <p>Step One: Text explaining this page</p>
             <StepIndicator steps={wizardSteps} currentStep={1} />
             <h2 className="font-sans-lg">Select a Project</h2>


### PR DESCRIPTION
## What changed

There's a header at the top of the page when creating an agreement that's actually saying "Create Budget Lines" before they've actually started doing that. Specifically, it's on the step 1 (select project) and 2 (create agreement) pages. Additionally, some of the instruction text needed to be altered slightly to avoid placeholder text or reflect the latest designs.

## Issue

#775 

This came up in a conversation with UX team on Monday.

## How to test

Attempt to create a new agreement and check the header on step 1 and 2

## Screenshots

From `development` where the branch is deployed:

<img width="1015" alt="Screenshot 2023-05-09 at 12 33 18 AM" src="https://user-images.githubusercontent.com/928984/236994774-4cb75eb8-4282-42e6-af06-0efd0e16b1ee.png">
<img width="1139" alt="Screenshot 2023-05-09 at 12 33 00 AM" src="https://user-images.githubusercontent.com/928984/236994778-53990d52-fc06-4cf5-b99b-76626abd273b.png">


## Links

https://docs.google.com/document/d/1Poj3OAnXZY3518gUNlbUoAyaoZjJkqUghcRTxOFKWTY/edit
