### PR TITLE
add health checks for the database and OAuth server (to /api/v1/health/)

### DIFF
--- a/backend/ops_api/ops/resources/health_check.py
+++ b/backend/ops_api/ops/resources/health_check.py
@@ -9,18 +9,8 @@ from ops_api.ops.utils.health_check import check_all
 class HealthCheckAPI(MethodView):
     def get(self) -> Response:
         checks = asyncio.run(check_all())
-        max_alarm_level = max(checks.values(), key=lambda obj: obj["alarm_level"])[
-            "alarm_level"
-        ]
-        status = (
-            "OK"
-            if max_alarm_level == 0
-            else "BAD"
-            if max_alarm_level > 1
-            else "Maybe problems"
-        )
-        response = jsonify(
-            {"status": status, "alarm_level": max_alarm_level, "checks": checks}
-        )
+        max_alarm_level = max(checks.values(), key=lambda obj: obj["alarm_level"])["alarm_level"]
+        status = "OK" if max_alarm_level == 0 else "BAD" if max_alarm_level > 1 else "Maybe problems"
+        response = jsonify({"status": status, "alarm_level": max_alarm_level, "checks": checks})
         response.headers.add("Access-Control-Allow-Origin", "*")
         return response

--- a/backend/ops_api/ops/resources/health_check.py
+++ b/backend/ops_api/ops/resources/health_check.py
@@ -1,9 +1,26 @@
+import asyncio
+
 from flask import Response, jsonify
 from flask.views import MethodView
+
+from ops_api.ops.utils.health_check import check_all
 
 
 class HealthCheckAPI(MethodView):
     def get(self) -> Response:
-        response = jsonify({"status": "OK"})
+        checks = asyncio.run(check_all())
+        max_alarm_level = max(checks.values(), key=lambda obj: obj["alarm_level"])[
+            "alarm_level"
+        ]
+        status = (
+            "OK"
+            if max_alarm_level == 0
+            else "BAD"
+            if max_alarm_level > 1
+            else "Maybe problems"
+        )
+        response = jsonify(
+            {"status": status, "alarm_level": max_alarm_level, "checks": checks}
+        )
         response.headers.add("Access-Control-Allow-Origin", "*")
         return response

--- a/backend/ops_api/ops/resources/health_check.py
+++ b/backend/ops_api/ops/resources/health_check.py
@@ -4,6 +4,7 @@ from flask import Response, jsonify
 from flask.views import MethodView
 
 from ops_api.ops.utils.health_check import check_all
+from ops_api.ops.utils.response import make_response_with_headers
 
 
 class HealthCheckAPI(MethodView):
@@ -12,5 +13,5 @@ class HealthCheckAPI(MethodView):
         max_alarm_level = max(checks.values(), key=lambda obj: obj["alarm_level"])["alarm_level"]
         status = "OK" if max_alarm_level == 0 else "BAD" if max_alarm_level > 1 else "Maybe problems"
         response = jsonify({"status": status, "alarm_level": max_alarm_level, "checks": checks})
-        response.headers.add("Access-Control-Allow-Origin", "*")
+        make_response_with_headers(response)
         return response

--- a/backend/ops_api/ops/utils/health_check.py
+++ b/backend/ops_api/ops/utils/health_check.py
@@ -17,10 +17,8 @@ async def check_auth_services() -> dict:
     try:
         authlib_client_config = current_app.config["AUTHLIB_OAUTH_CLIENTS"]["logingov"]
         server_metadata_url = authlib_client_config["server_metadata_url"]
-        print(server_metadata_url)
         r = requests.get(server_metadata_url, timeout=10)
         resp["status_code"] = r.status_code
-        print(f"{r.status_code=}, {type(r.status_code)=}")
         if r.status_code != 200:
             resp["alarm_level"] = 1
     except Exception as e:
@@ -37,7 +35,6 @@ async def check_db_conn() -> dict:
     resp = {"db_conn_is_ok": True, "alarm_level": 0}
     try:
         sess = current_app.db_session
-        print(type(sess))
         current_app.db_session.execute(
             text("SELECT 'OK';"),
             execution_options={"timeout": 5},  # just pool wait timeout ?

--- a/backend/ops_api/ops/utils/health_check.py
+++ b/backend/ops_api/ops/utils/health_check.py
@@ -7,7 +7,8 @@ from sqlalchemy import text
 
 
 async def check_auth_services() -> dict:
-    """check the health of the OAuth server with a GET of the server_metadata_url
+    """check the health of the OAuth server with a GET of the
+    OAuth server_metadata_url
     Returns:
         dict: with alarm_level>0 if there is a problem
     """

--- a/backend/ops_api/ops/utils/health_check.py
+++ b/backend/ops_api/ops/utils/health_check.py
@@ -34,7 +34,6 @@ async def check_db_conn() -> dict:
     """
     resp = {"db_conn_is_ok": True, "alarm_level": 0}
     try:
-        sess = current_app.db_session
         current_app.db_session.execute(
             text("SELECT 'OK';"),
             execution_options={"timeout": 5},  # just pool wait timeout ?

--- a/backend/ops_api/ops/utils/health_check.py
+++ b/backend/ops_api/ops/utils/health_check.py
@@ -1,0 +1,69 @@
+import asyncio
+import logging
+
+import requests
+from flask import current_app
+from sqlalchemy import text
+
+
+async def check_auth_services() -> dict:
+    """check the health of the OAuth server with a GET of the server_metadata_url
+    Returns:
+        dict: with alarm_level>0 if there is a problem
+    """
+
+    resp = {"status_code": None, "alarm_level": 0}
+    try:
+        authlib_client_config = current_app.config["AUTHLIB_OAUTH_CLIENTS"]["logingov"]
+        server_metadata_url = authlib_client_config["server_metadata_url"]
+        print(server_metadata_url)
+        r = requests.get(server_metadata_url, timeout=10)
+        resp["status_code"] = r.status_code
+        print(f"{r.status_code=}, {type(r.status_code)=}")
+        if r.status_code != 200:
+            resp["alarm_level"] = 1
+    except Exception as e:
+        logging.error("Auth Services check failed: " + str(e), exc_info=True)
+        resp["alarm_level"] = 2
+    return resp
+
+
+async def check_db_conn() -> dict:
+    """check the DB by executing a test query
+    Returns:
+        dict: alarm_level>0 if there is a problem
+    """
+    resp = {"db_conn_is_ok": True, "alarm_level": 0}
+    try:
+        sess = current_app.db_session
+        print(type(sess))
+        current_app.db_session.execute(
+            text("SELECT 'OK';"),
+            execution_options={"timeout": 5},  # just pool wait timeout ?
+        )
+    except Exception as e:
+        logging.error("Database test query failed: " + str(e), exc_info=True)
+        resp["db_conn_is_ok"] = False
+        resp["alarm_level"] = 2
+    try:
+        pool = current_app.engine.pool
+        pool_status = {
+            "size": pool.size(),
+            "checked_in": pool.checkedin(),
+            "overflow": pool.overflow(),
+            "checked_out": pool.checkedout(),
+        }
+        resp["pool_status"] = pool_status
+    except Exception as e:
+        logging.error("Connection pool status failed: " + str(e), exc_info=True)
+    return resp
+
+
+async def check_all() -> dict:
+    """run all checks (DB and Auth services)
+    Returns:
+        dict: a map of the responses from each check
+    """
+    auth, db_conn = await asyncio.gather(check_auth_services(), check_db_conn())
+    checks = {"auth_services": auth, "database_connection": db_conn}
+    return checks

--- a/backend/ops_api/tests/ops/health_check/test_health.py
+++ b/backend/ops_api/tests/ops/health_check/test_health.py
@@ -1,0 +1,114 @@
+import pytest
+from unittest.mock import patch, Mock
+from flask import current_app
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_get_health(auth_client):
+    """
+    test /api/v1/health/ for several scenarios
+    Currently, this could work without docker/db, but it's in the session
+    already (from 'ops/conftest'). It does need the Flask app. If we end up
+    creating a separate folder for Flask tests with no docker, then we could
+    move this there.
+    """
+
+    # mock response for auth services check
+    mock_auth_resp = Mock()
+    mock_auth_resp.status_code = 200
+    mock_auth_resp.json.return_value = {"key": "value"}
+
+    with patch("requests.get") as mock_auth_get, patch.object(
+        current_app.db_session, "execute"
+    ) as mock_execute:
+        mock_auth_get.return_value = mock_auth_resp
+
+        # test with all checks are good
+        response = auth_client.get("/api/v1/health/")
+        assert response.status_code == 200
+        resp_json = response.json
+        assert "status" in resp_json
+        assert resp_json["status"] == "OK"
+        assert "checks" in resp_json
+        db_conn_is_ok = (
+            resp_json.get("checks", {})
+            .get("database_connection", {})
+            .get("db_conn_is_ok", None)
+        )
+        assert db_conn_is_ok is True
+        assert 0 == resp_json.get("checks", {}).get("auth_services", {}).get(
+            "alarm_level", None
+        )
+        assert 0 == resp_json.get("checks", {}).get("database_connection", {}).get(
+            "alarm_level", None
+        )
+        assert 0 == resp_json.get("alarm_level", None)
+
+        # test with failure from db execution
+        mock_execute.side_effect = Exception("Fake Error for session.execute")
+        response = auth_client.get("/api/v1/health/")
+        resp_json = response.json
+        db_conn_is_ok = (
+            resp_json.get("checks", {})
+            .get("database_connection", {})
+            .get("db_conn_is_ok", None)
+        )
+        assert db_conn_is_ok is False
+        assert 0 == resp_json.get("checks", {}).get("auth_services", {}).get(
+            "alarm_level", None
+        )
+        assert 2 == resp_json.get("checks", {}).get("database_connection", {}).get(
+            "alarm_level", None
+        )
+        assert 2 == resp_json.get("alarm_level", None)
+
+        # test with failure from auth services check (and db OK)
+        mock_auth_get.side_effect = Exception("Fake Error for auth GET")
+        mock_execute.side_effect = None
+        response = auth_client.get("/api/v1/health/")
+        resp_json = response.json
+        assert 2 == resp_json.get("checks", {}).get("auth_services", {}).get(
+            "alarm_level", None
+        )
+        assert 0 == resp_json.get("checks", {}).get("database_connection", {}).get(
+            "alarm_level", None
+        )
+        assert 2 == resp_json.get("alarm_level", None)
+
+        # test with failures from auth services check and db execution
+        mock_auth_get.side_effect = Exception("Fake Error for auth GET")
+        mock_execute.side_effect = Exception("Fake Error for session.execute")
+        # also trip the pool stats exception (for coverage)
+        with patch.object(current_app.engine.pool, "size") as mock_pool_size:
+            mock_pool_size.side_effect = Exception("Fake Error for pool stats")
+            response = auth_client.get("/api/v1/health/")
+            resp_json = response.json
+            assert 2 == resp_json.get("checks", {}).get("auth_services", {}).get(
+                "alarm_level", None
+            )
+            assert 2 == resp_json.get("checks", {}).get("database_connection", {}).get(
+                "alarm_level", None
+            )
+            assert 2 == resp_json.get("alarm_level", None)
+            assert "pool_status" not in resp_json.get("checks", {}).get(
+                "database_connection", {}
+            )
+
+        # test alarm_level=1, example for maybe something less than failure,
+        # but may be a problem
+        mock_execute.side_effect = None
+        mock_auth_get.side_effect = None
+        mock_auth_resp.status_code = 418
+
+        response = auth_client.get("/api/v1/health/")
+        resp_json = response.json
+        assert 0 == resp_json.get("checks", {}).get("database_connection", {}).get(
+            "alarm_level", None
+        )
+        assert 1 == resp_json.get("checks", {}).get("auth_services", {}).get(
+            "alarm_level", None
+        )
+        assert 1 == resp_json.get("alarm_level", None)
+        assert "pool_status" in resp_json.get("checks", {}).get(
+            "database_connection", {}
+        )

--- a/backend/ops_api/tests/ops/health_check/test_health.py
+++ b/backend/ops_api/tests/ops/health_check/test_health.py
@@ -18,9 +18,7 @@ def test_get_health(auth_client):
     mock_auth_resp.status_code = 200
     mock_auth_resp.json.return_value = {"key": "value"}
 
-    with patch("requests.get") as mock_auth_get, patch.object(
-        current_app.db_session, "execute"
-    ) as mock_execute:
+    with patch("requests.get") as mock_auth_get, patch.object(current_app.db_session, "execute") as mock_execute:
         mock_auth_get.return_value = mock_auth_resp
 
         # test with all checks are good
@@ -30,36 +28,20 @@ def test_get_health(auth_client):
         assert "status" in resp_json
         assert resp_json["status"] == "OK"
         assert "checks" in resp_json
-        db_conn_is_ok = (
-            resp_json.get("checks", {})
-            .get("database_connection", {})
-            .get("db_conn_is_ok", None)
-        )
+        db_conn_is_ok = resp_json.get("checks", {}).get("database_connection", {}).get("db_conn_is_ok", None)
         assert db_conn_is_ok is True
-        assert 0 == resp_json.get("checks", {}).get("auth_services", {}).get(
-            "alarm_level", None
-        )
-        assert 0 == resp_json.get("checks", {}).get("database_connection", {}).get(
-            "alarm_level", None
-        )
+        assert 0 == resp_json.get("checks", {}).get("auth_services", {}).get("alarm_level", None)
+        assert 0 == resp_json.get("checks", {}).get("database_connection", {}).get("alarm_level", None)
         assert 0 == resp_json.get("alarm_level", None)
 
         # test with failure from db execution
         mock_execute.side_effect = Exception("Fake Error for session.execute")
         response = auth_client.get("/api/v1/health/")
         resp_json = response.json
-        db_conn_is_ok = (
-            resp_json.get("checks", {})
-            .get("database_connection", {})
-            .get("db_conn_is_ok", None)
-        )
+        db_conn_is_ok = resp_json.get("checks", {}).get("database_connection", {}).get("db_conn_is_ok", None)
         assert db_conn_is_ok is False
-        assert 0 == resp_json.get("checks", {}).get("auth_services", {}).get(
-            "alarm_level", None
-        )
-        assert 2 == resp_json.get("checks", {}).get("database_connection", {}).get(
-            "alarm_level", None
-        )
+        assert 0 == resp_json.get("checks", {}).get("auth_services", {}).get("alarm_level", None)
+        assert 2 == resp_json.get("checks", {}).get("database_connection", {}).get("alarm_level", None)
         assert 2 == resp_json.get("alarm_level", None)
 
         # test with failure from auth services check (and db OK)
@@ -67,12 +49,8 @@ def test_get_health(auth_client):
         mock_execute.side_effect = None
         response = auth_client.get("/api/v1/health/")
         resp_json = response.json
-        assert 2 == resp_json.get("checks", {}).get("auth_services", {}).get(
-            "alarm_level", None
-        )
-        assert 0 == resp_json.get("checks", {}).get("database_connection", {}).get(
-            "alarm_level", None
-        )
+        assert 2 == resp_json.get("checks", {}).get("auth_services", {}).get("alarm_level", None)
+        assert 0 == resp_json.get("checks", {}).get("database_connection", {}).get("alarm_level", None)
         assert 2 == resp_json.get("alarm_level", None)
 
         # test with failures from auth services check and db execution
@@ -83,16 +61,10 @@ def test_get_health(auth_client):
             mock_pool_size.side_effect = Exception("Fake Error for pool stats")
             response = auth_client.get("/api/v1/health/")
             resp_json = response.json
-            assert 2 == resp_json.get("checks", {}).get("auth_services", {}).get(
-                "alarm_level", None
-            )
-            assert 2 == resp_json.get("checks", {}).get("database_connection", {}).get(
-                "alarm_level", None
-            )
+            assert 2 == resp_json.get("checks", {}).get("auth_services", {}).get("alarm_level", None)
+            assert 2 == resp_json.get("checks", {}).get("database_connection", {}).get("alarm_level", None)
             assert 2 == resp_json.get("alarm_level", None)
-            assert "pool_status" not in resp_json.get("checks", {}).get(
-                "database_connection", {}
-            )
+            assert "pool_status" not in resp_json.get("checks", {}).get("database_connection", {})
 
         # test alarm_level=1, example for maybe something less than failure,
         # but may be a problem
@@ -102,13 +74,7 @@ def test_get_health(auth_client):
 
         response = auth_client.get("/api/v1/health/")
         resp_json = response.json
-        assert 0 == resp_json.get("checks", {}).get("database_connection", {}).get(
-            "alarm_level", None
-        )
-        assert 1 == resp_json.get("checks", {}).get("auth_services", {}).get(
-            "alarm_level", None
-        )
+        assert 0 == resp_json.get("checks", {}).get("database_connection", {}).get("alarm_level", None)
+        assert 1 == resp_json.get("checks", {}).get("auth_services", {}).get("alarm_level", None)
         assert 1 == resp_json.get("alarm_level", None)
-        assert "pool_status" in resp_json.get("checks", {}).get(
-            "database_connection", {}
-        )
+        assert "pool_status" in resp_json.get("checks", {}).get("database_connection", {})


### PR DESCRIPTION
## What changed

The health check endpoint, /api/v1/health/, now performs simple checks for the database and the auth server.
This is a experimental feature, but I don't think the /health endpoint is being used yet.
The pool_status may not make sense since it's only for the node it's executed on and you might have more than one in prod.  However, I put a timeout on the test query, so when the pool is busy it shouldn't wait for ages to respond.  It such a case seeing the pool is all checked out when the db conn test failed would be meaningful.

## How to test

Run the app and check http://127.0.0.1:8081/api/v1/health/

With both the database and OAuth server working the response would be

```json
{
  "alarm_level": 0,
  "checks": {
    "auth_services": {
      "alarm_level": 0,
      "status_code": 200
    },
    "database_connection": {
      "alarm_level": 0,
      "db_conn_is_ok": true,
      "pool_status": {
        "checked_in": 0,
        "checked_out": 1,
        "overflow": -4,
        "size": 5
      }
    }
  },
  "status": "OK"
}
```

With the database down (and the OAuth server working), the response would be

```json
{
  "alarm_level": 2,
  "checks": {
    "auth_services": {
      "alarm_level": 0,
      "status_code": 200
    },
    "database_connection": {
      "alarm_level": 2,
      "db_conn_is_ok": false,
      "pool_status": {
        "checked_in": 0,
        "checked_out": 0,
        "overflow": -5,
        "size": 5
      }
    }
  },
  "status": "BAD"
}
```

If you alter server_metadata_url in default_settings.py to something invalid (and if the database is working) the response would be 

```json
{
  "alarm_level": 2,
  "checks": {
    "auth_services": {
      "alarm_level": 2,
      "status_code": null
    },
    "database_connection": {
      "alarm_level": 0,
      "db_conn_is_ok": true,
      "pool_status": {
        "checked_in": 0,
        "checked_out": 1,
        "overflow": -4,
        "size": 5
      }
    }
  },
  "status": "BAD"
}
```

