### PR TITLE
Ops 1005/wording create project

### DIFF
--- a/frontend/src/components/UI/Modal/Modal.jsx
+++ b/frontend/src/components/UI/Modal/Modal.jsx
@@ -2,10 +2,11 @@ import { useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 
 export const Modal = ({
-    heading = "",
+    heading,
     description = "",
     setShowModal = () => {},
     actionButtonText,
+    secondaryButtonText = "Cancel",
     handleConfirm = () => {},
 }) => {
     const modalRef = useRef(null);
@@ -44,7 +45,6 @@ export const Modal = ({
         currentModalRef.addEventListener("keydown", handleKeydown);
 
         // clean up the event listener when the component unmounts
-
         return () => {
             currentModalRef.removeEventListener("keydown", handleKeydown);
         };
@@ -91,7 +91,7 @@ export const Modal = ({
                                                 className="usa-button usa-button--unstyled padding-105 text-center"
                                                 onClick={() => setShowModal(false)}
                                             >
-                                                Cancel
+                                                {secondaryButtonText}
                                             </button>
                                         </li>
                                     </ul>
@@ -112,5 +112,6 @@ Modal.propTypes = {
     description: PropTypes.string,
     setShowModal: PropTypes.func.isRequired,
     actionButtonText: PropTypes.string.isRequired,
+    secondaryButtonText: PropTypes.string,
     handleConfirm: PropTypes.func.isRequired,
 };

--- a/frontend/src/components/UI/Modal/Modal.jsx
+++ b/frontend/src/components/UI/Modal/Modal.jsx
@@ -54,21 +54,21 @@ export const Modal = ({
             <div
                 className="usa-modal-wrapper is-visible"
                 role="dialog"
-                id="example-modal-1"
-                aria-labelledby="modal-1-heading"
-                aria-describedby="modal-1-description"
+                id="ops-modal"
+                aria-labelledby="ops-modal-heading"
+                aria-describedby="ops-modal-description"
                 onClick={() => setShowModal(false)}
             >
-                <div className="usa-modal-overlay" aria-controls="example-modal-1">
+                <div className="usa-modal-overlay" aria-controls="ops-modal">
                     <div className="usa-modal" tabIndex="-1" onClick={(e) => e.stopPropagation()} ref={modalRef}>
                         <div className="usa-modal__content">
                             <div className="usa-modal__main">
-                                <h2 className="usa-modal__heading" id="modal-1-heading">
+                                <h2 className="usa-modal__heading font-family-sans" id="ops-modal-heading">
                                     {heading}
                                 </h2>
                                 {description && (
                                     <div className="usa-prose">
-                                        <p id="modal-1-description">{description}</p>
+                                        <p id="ops-modal-description">{description}</p>
                                     </div>
                                 )}
                                 <div className="usa-modal__footer">

--- a/frontend/src/pages/projects/CreateProject.jsx
+++ b/frontend/src/pages/projects/CreateProject.jsx
@@ -57,11 +57,11 @@ export const CreateProject = () => {
     }
 
     const handleCancel = () => {
-        // TODO: Add cancel stuff
         setShowModal(true);
         setModalProps({
             heading: "Are you sure you want to cancel? Your project will not be saved.",
             actionButtonText: "Cancel",
+            secondaryButtonText: "Continue Editing",
             handleConfirm: () => {
                 handleClearingForm();
                 navigate("/");
@@ -88,6 +88,7 @@ export const CreateProject = () => {
                     setShowModal={setShowModal}
                     actionButtonText={modalProps.actionButtonText}
                     handleConfirm={modalProps.handleConfirm}
+                    secondaryButtonText={modalProps.secondaryButtonText}
                 />
             )}
             <h2 className="font-sans-lg margin-top-7">Select the Project Type</h2>

--- a/frontend/src/pages/projects/CreateProject.jsx
+++ b/frontend/src/pages/projects/CreateProject.jsx
@@ -92,7 +92,7 @@ export const CreateProject = () => {
                 />
             )}
             <h2 className="font-sans-lg margin-top-7">Select the Project Type</h2>
-            <p>Select the type of project you are creating.</p>
+            <p>Select the type of project you’d like to create.</p>
             <ProjectTypeSelect
                 selectedProjectType={selectedProjectType}
                 onChangeProjectTypeSelection={setSelectedProjectType}


### PR DESCRIPTION
## What changed

- adds secondary text to cancel option for Modals
- updates instruction text for create Project

## Issue

#1005 

## How to test

Goto create a project and hit cancel

## Screenshots

<img width="748" alt="image" src="https://github.com/HHS/OPRE-OPS/assets/4629398/b0f03279-be88-4c4b-ade6-c1b80c17e3f8">

