### PR TITLE
OPS-996 convert type codes to display text

### DIFF
--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -20,3 +20,27 @@ export const formatDate = (date) => {
 
     return date.toLocaleDateString("en-US", options);
 };
+
+const codesToDisplayText = {
+    AgreementType: {
+        CONTRACT: "Contract",
+        GRANT: "Grant",
+        DIRECT_ALLOCATION: "Direct Allocation",
+        IAA: "IAA",
+        MISCELLANEOUS: "Misc",
+    },
+    AgreementReason: {
+        NEW_REQ: "New Req",
+        RECOMPETE: "Recompete",
+        LOGICAL_FOLLOW_ON: "Local Follow On",
+    },
+};
+
+export const convertCodeForDisplay = (list_name, code) => {
+    const code_map = codesToDisplayText[list_name];
+    if (code_map) {
+        const display_text = code_map[code];
+        if (display_text) return display_text;
+    }
+    return code;
+};

--- a/frontend/src/helpers/utils.test.js
+++ b/frontend/src/helpers/utils.test.js
@@ -1,4 +1,4 @@
-import { getCurrentFiscalYear, calculatePercent } from "./utils";
+import { getCurrentFiscalYear, calculatePercent, convertCodeForDisplay } from "./utils";
 
 test("current federal fiscal year is calculated correctly", async () => {
     const lastDay = new Date("September 30, 2022");
@@ -13,4 +13,11 @@ test("percent is calculated correctly", async () => {
     expect(calculatePercent(3, 4)).toEqual(75);
     expect(calculatePercent(7, 4)).toEqual(175);
     expect(calculatePercent(0, 4)).toEqual(0);
+});
+
+test("codes are converted for display correctly", async () => {
+    expect(convertCodeForDisplay("__foo__", "test_code")).toEqual("test_code");
+    expect(convertCodeForDisplay("AgreementType", "__foo__")).toEqual("__foo__");
+    expect(convertCodeForDisplay("AgreementType", "GRANT")).toEqual("Grant");
+    expect(convertCodeForDisplay("AgreementReason", "NEW_REQ")).toEqual("New Req");
 });

--- a/frontend/src/pages/agreements/AgreementReasonSelect.jsx
+++ b/frontend/src/pages/agreements/AgreementReasonSelect.jsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setAgreementReasonsList, setSelectedAgreementReason, setAgreementIncumbent } from "./createAgreementSlice";
 import { getAgreementReasons } from "../../api/getAgreements";
-import {convertCodeForDisplay} from "../../helpers/utils";
+import { convertCodeForDisplay } from "../../helpers/utils";
 
 export const AgreementReasonSelect = () => {
     const dispatch = useDispatch();
@@ -52,7 +52,7 @@ export const AgreementReasonSelect = () => {
                     <option value={0}>- Select Agreement Reason -</option>
                     {agreementReasons.map((reason, index) => (
                         <option key={index + 1} value={reason}>
-                            {convertCodeForDisplay('AgreementReason', reason)}
+                            {convertCodeForDisplay("AgreementReason", reason)}
                         </option>
                     ))}
                 </select>

--- a/frontend/src/pages/agreements/AgreementReasonSelect.jsx
+++ b/frontend/src/pages/agreements/AgreementReasonSelect.jsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setAgreementReasonsList, setSelectedAgreementReason, setAgreementIncumbent } from "./createAgreementSlice";
 import { getAgreementReasons } from "../../api/getAgreements";
+import {convertCodeForDisplay} from "../../helpers/utils";
 
 export const AgreementReasonSelect = () => {
     const dispatch = useDispatch();
@@ -51,7 +52,7 @@ export const AgreementReasonSelect = () => {
                     <option value={0}>- Select Agreement Reason -</option>
                     {agreementReasons.map((reason, index) => (
                         <option key={index + 1} value={reason}>
-                            {reason}
+                            {convertCodeForDisplay('AgreementReason', reason)}
                         </option>
                     ))}
                 </select>

--- a/frontend/src/pages/agreements/AgreementTypeSelect.jsx
+++ b/frontend/src/pages/agreements/AgreementTypeSelect.jsx
@@ -1,4 +1,5 @@
 import { useGetAgreementTypesQuery } from "../../api/opsAPI";
+import { convertCodeForDisplay } from "../../helpers/utils";
 
 export const AgreementTypeSelect = ({ selectedAgreementType, setSelectedAgreementType }) => {
     const {
@@ -36,7 +37,7 @@ export const AgreementTypeSelect = ({ selectedAgreementType, setSelectedAgreemen
                     <option value={0}>- Select Agreement Type -</option>
                     {agreementTypes.map((type, index) => (
                         <option key={index + 1} value={type}>
-                            {type}
+                            {convertCodeForDisplay('AgreementType', type)}
                         </option>
                     ))}
                 </select>

--- a/frontend/src/pages/agreements/AgreementTypeSelect.jsx
+++ b/frontend/src/pages/agreements/AgreementTypeSelect.jsx
@@ -37,7 +37,7 @@ export const AgreementTypeSelect = ({ selectedAgreementType, setSelectedAgreemen
                     <option value={0}>- Select Agreement Type -</option>
                     {agreementTypes.map((type, index) => (
                         <option key={index + 1} value={type}>
-                            {convertCodeForDisplay('AgreementType', type)}
+                            {convertCodeForDisplay("AgreementType", type)}
                         </option>
                     ))}
                 </select>

--- a/frontend/src/pages/agreements/list/AgreementTableRow.jsx
+++ b/frontend/src/pages/agreements/list/AgreementTableRow.jsx
@@ -8,7 +8,7 @@ import Tag from "../../../components/UI/Tag/Tag";
 import "./AgreementsList.scss";
 import { getUser } from "../../../api/getUser";
 import icons from "../../../uswds/img/sprite.svg";
-import {convertCodeForDisplay, formatDate} from "../../../helpers/utils";
+import { convertCodeForDisplay, formatDate } from "../../../helpers/utils";
 
 export const AgreementTableRow = ({ agreement }) => {
     const [user, setUser] = useState({});
@@ -20,7 +20,7 @@ export const AgreementTableRow = ({ agreement }) => {
     const researchProjectName = agreement?.research_project?.title;
 
     let agreementType;
-    agreementType = convertCodeForDisplay("AgreementType", agreement?.agreement_type)
+    agreementType = convertCodeForDisplay("AgreementType", agreement?.agreement_type);
 
     const agreementSubTotal = agreement?.budget_line_items?.reduce((n, { amount }) => n + amount, 0);
     const procurementShopSubTotal = agreement?.budget_line_items?.reduce(

--- a/frontend/src/pages/agreements/list/AgreementTableRow.jsx
+++ b/frontend/src/pages/agreements/list/AgreementTableRow.jsx
@@ -8,7 +8,7 @@ import Tag from "../../../components/UI/Tag/Tag";
 import "./AgreementsList.scss";
 import { getUser } from "../../../api/getUser";
 import icons from "../../../uswds/img/sprite.svg";
-import { formatDate } from "../../../helpers/utils";
+import {convertCodeForDisplay, formatDate} from "../../../helpers/utils";
 
 export const AgreementTableRow = ({ agreement }) => {
     const [user, setUser] = useState({});
@@ -20,25 +20,7 @@ export const AgreementTableRow = ({ agreement }) => {
     const researchProjectName = agreement?.research_project?.title;
 
     let agreementType;
-    switch (agreement?.agreement_type) {
-        case "CONTRACT":
-            agreementType = "Contract";
-            break;
-        case "GRANT":
-            agreementType = "Grant";
-            break;
-        case "DIRECT_ALLOCATION":
-            agreementType = "Direct Allocation";
-            break;
-        case "IAA":
-            agreementType = "IAA";
-            break;
-        case "MISCELLANEOUS":
-            agreementType = "Misc";
-            break;
-        default:
-            agreementType = "Unknown Type";
-    }
+    agreementType = convertCodeForDisplay("AgreementType", agreement?.agreement_type)
 
     const agreementSubTotal = agreement?.budget_line_items?.reduce((n, { amount }) => n + amount, 0);
     const procurementShopSubTotal = agreement?.budget_line_items?.reduce(


### PR DESCRIPTION
## What changed

Codes in ALL_CAPS (from ENUMs) were used as the display text of select boxes.  This changes those to use standardized friendly text using a method that can be used for any other situation where text needs to converted for display. 

## Issue

[OPS-996](https://github.com/HHS/OPRE-OPS/issues/996)

## How to test

View the Agreement Type and Agreement Reason select boxes in the create agreement form to see value like "CONTRACT" has been replace with "Contract".   And complete the create agreement process to verify that the valid codes are still being submitted.

