### PR TITLE
Ops 1030 backend agreements filtering params

### DIFF
--- a/backend/models/cans.py
+++ b/backend/models/cans.py
@@ -182,7 +182,7 @@ contract_support_contacts = Table(
     BaseModel.metadata,
     Column(
         "contract_id",
-        ForeignKey("contract_agreement.contract_id"),
+        ForeignKey("contract_agreement.id"),
         primary_key=True,
     ),
     Column("users_id", ForeignKey("users.id"), primary_key=True),
@@ -199,8 +199,7 @@ class ContractAgreement(Agreement):
 
     __tablename__ = "contract_agreement"
 
-    id = Column(Integer, ForeignKey("agreement.id"))
-    contract_id = Column(Integer, Identity(), primary_key=True)
+    id = Column(Integer, ForeignKey("agreement.id"), primary_key=True)
     contract_number = Column(String)
     vendor = Column(String)
     delivered_status = Column(Boolean, default=False)
@@ -239,8 +238,7 @@ class GrantAgreement(Agreement):
 
     __tablename__ = "grant_agreement"
 
-    id = Column(Integer, ForeignKey("agreement.id"))
-    grant_id = Column(Integer, Identity(), primary_key=True)
+    id = Column(Integer, ForeignKey("agreement.id"), primary_key=True)
     foa = Column(String)
 
     __mapper_args__ = {
@@ -255,8 +253,7 @@ class IaaAgreement(Agreement):
 
     __tablename__ = "iaa_agreement"
 
-    id = Column(Integer, ForeignKey("agreement.id"))
-    iaa_id = Column(Integer, Identity(), primary_key=True)
+    id = Column(Integer, ForeignKey("agreement.id"), primary_key=True)
     iaa = Column(String)
 
     __mapper_args__ = {
@@ -271,8 +268,7 @@ class IaaAaAgreement(Agreement):
 
     __tablename__ = "iaa_aa_agreement"
 
-    id = Column(Integer, ForeignKey("agreement.id"))
-    iaa_aa_id = Column(Integer, Identity(), primary_key=True)
+    id = Column(Integer, ForeignKey("agreement.id"), primary_key=True)
     iaa_aa = Column(String)
 
     __mapper_args__ = {
@@ -285,8 +281,7 @@ class DirectAgreement(Agreement):
 
     __tablename__ = "direct_agreement"
 
-    id = Column(Integer, ForeignKey("agreement.id"))
-    direct_id = Column(Integer, Identity(), primary_key=True)
+    id = Column(Integer, ForeignKey("agreement.id"), primary_key=True)
     payee = Column(String, nullable=False)
 
     __mapper_args__ = {

--- a/backend/models/cans.py
+++ b/backend/models/cans.py
@@ -147,7 +147,7 @@ class Agreement(BaseModel):
 
     notes = Column(Text, nullable=True)
 
-    __mapper_args__ = {
+    __mapper_args__: dict[str, str | AgreementType] = {
         "polymorphic_identity": "agreement",
         "polymorphic_on": "agreement_type",
     }

--- a/backend/ops_api/ops/db.py
+++ b/backend/ops_api/ops/db.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session, scoped_session, sessionmaker
 def init_db(
     conn_string: str, is_unit_test: Optional[bool] = False
 ) -> tuple[scoped_session[Session | Any], Engine]:  # noqa: F405
-    engine = create_engine(conn_string, echo=True)
+    engine = create_engine(conn_string)
     db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
     Base = declarative_base(cls=BaseModel)  # noqa: F405
     BaseModel.query = db_session.query_property()  # noqa: F405

--- a/backend/ops_api/ops/db.py
+++ b/backend/ops_api/ops/db.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session, scoped_session, sessionmaker
 def init_db(
     conn_string: str, is_unit_test: Optional[bool] = False
 ) -> tuple[scoped_session[Session | Any], Engine]:  # noqa: F405
-    engine = create_engine(conn_string)
+    engine = create_engine(conn_string, echo=True)
     db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
     Base = declarative_base(cls=BaseModel)  # noqa: F405
     BaseModel.query = db_session.query_property()  # noqa: F405

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -61,7 +61,7 @@ class ContractAgreementData(AgreementData):
 
 
 @dataclass(kw_only=True)
-class ContractAgreementPatchBody(ContractAgreementRequestBody):
+class ContractAgreementPatchBody(ContractAgreementData):
     name: Optional[str] = None
     number: Optional[str] = None
 
@@ -72,21 +72,21 @@ class GrantAgreementData(AgreementData):
 
 
 @dataclass
-class GrantAgreementPatchBody(GrantAgreementRequestBody):
+class GrantAgreementPatchBody(GrantAgreementData):
     name: Optional[str] = None
     number: Optional[str] = None
 
 
 REQUEST_SCHEMAS = {
-    AgreementType.CONTRACT: {"PUT": ContractAgreementRequestBody, "PATCH": ContractAgreementPatchBody},
-    AgreementType.GRANT: {"PUT": GrantAgreementRequestBody, "PATCH": GrantAgreementPatchBody},
+    AgreementType.CONTRACT: {"PUT": ContractAgreementData, "PATCH": ContractAgreementPatchBody},
+    AgreementType.GRANT: {"PUT": GrantAgreementData, "PATCH": GrantAgreementPatchBody},
 }
 
 
 def pick_schema_class(
     agreement_type: AgreementType, method: str
 ) -> Type[
-    ContractAgreementRequestBody | ContractAgreementPatchBody | GrantAgreementRequestBody | GrantAgreementPatchBody
+    ContractAgreementData | ContractAgreementPatchBody | GrantAgreementData | GrantAgreementPatchBody
 ]:
     type_methods = REQUEST_SCHEMAS.get(agreement_type)
     if not type_methods:

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -250,7 +250,7 @@ class AgreementListAPI(BaseListAPI):
                 query_helper.return_none()
 
             case {"search": search, **filter_args}:
-                query_helper.add_column_equals(polymorphic_agreement.name, search)
+                query_helper.add_search(polymorphic_agreement.name, search)
 
             case {**filter_args}:
                 pass

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -85,9 +85,7 @@ REQUEST_SCHEMAS = {
 
 def pick_schema_class(
     agreement_type: AgreementType, method: str
-) -> Type[
-    ContractAgreementData | ContractAgreementPatchBody | GrantAgreementData | GrantAgreementPatchBody
-]:
+) -> Type[ContractAgreementData | ContractAgreementPatchBody | GrantAgreementData | GrantAgreementPatchBody]:
     type_methods = REQUEST_SCHEMAS.get(agreement_type)
     if not type_methods:
         raise ValueError(f"Invalid agreement_type ({agreement_type})")
@@ -255,7 +253,7 @@ class AgreementListAPI(BaseListAPI):
             case {**filter_args}:
                 pass
 
-        if(filter_args):
+        if filter_args:
             # This part is necessary because otherwise the system gets confused. Need to
             # know what table to use to look up parameters from for filtering.
             contract_keys = {field.name for field in dc_fields(ContractAgreementData)}

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -250,7 +250,7 @@ class AgreementListAPI(BaseListAPI):
         self._get_schema = desert.schema(QueryParameters)
 
     @staticmethod
-    def _get_query(search=None, research_project_id=None, **args):
+    def _get_query(**args):
         stmt = select(Agreement).order_by(Agreement.id)
         query_helper = QueryHelper(stmt)
 
@@ -273,7 +273,7 @@ class AgreementListAPI(BaseListAPI):
                 arg_dataclass = QueryParameters
 
         filter_keys = set(filter_args.keys())
-        expected_keys = {field.name for field in dc_fields(arg_dataclass)}
+        expected_keys = {field.name for field in dc_fields(arg_dataclass)} | {"research_project_id"}
         bad_keys = filter_keys - expected_keys
         if bad_keys:
             current_app.logger.error(f"GET /agreements: Incorrect filter Query Params: {bad_keys}")
@@ -301,15 +301,6 @@ class AgreementListAPI(BaseListAPI):
         is_authorized = self.auth_gateway.is_authorized(identity, ["GET_AGREEMENTS"])
 
         if is_authorized:
-            #errors = self._get_schema.validate(request.args)
-
-            #if errors:
-            #    current_app.logger.error(f"GET /agreements: Query Params failed validation: {errors}")
-            #    return make_response_with_headers(errors, 400)
-
-            #search = request.args.get("search")
-            #research_project_id = request.args.get("research_project_id")
-
             stmt = self._get_query(**request.args)
 
             result = current_app.db_session.execute(stmt).all()

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -239,7 +239,7 @@ class AgreementListAPI(BaseListAPI):
         self._schema_grant = desert.schema(GrantAgreementData)
 
     @staticmethod
-    def _get_query(**args):
+    def _get_query(args):
         stmt = select(Agreement).order_by(Agreement.id)
         query_helper = QueryHelper(stmt)
 
@@ -274,7 +274,7 @@ class AgreementListAPI(BaseListAPI):
             return make_response_with_headers([f"Invalid Key: {key}" for key in bad_keys], 400)
 
         schema = desert.schema(arg_dataclass)
-        errors = schema.validate(request.args, partial=True)
+        errors = schema.validate(filter_args, partial=True)
         if errors:
             current_app.logger.error(f"GET /agreements: Query Params failed validation: {errors}")
             return make_response_with_headers(errors, 400)
@@ -283,7 +283,7 @@ class AgreementListAPI(BaseListAPI):
             query_helper.add_column_equals(getattr(agreement_class, key), value)
 
         stmt = query_helper.get_stmt()
-        current_app.logger.debug(f"SQL: {stmt}")
+        current_app.logger.info(f"SQL: {stmt}")
 
         return stmt
 
@@ -294,7 +294,7 @@ class AgreementListAPI(BaseListAPI):
         is_authorized = self.auth_gateway.is_authorized(identity, ["GET_AGREEMENTS"])
 
         if is_authorized:
-            stmt = self._get_query(**request.args)
+            stmt = self._get_query(request.args)
 
             result = current_app.db_session.execute(stmt).all()
 

--- a/backend/ops_api/ops/utils/query_helpers.py
+++ b/backend/ops_api/ops/utils/query_helpers.py
@@ -22,7 +22,7 @@ class QueryHelper:
         if not self.where_clauses:
             ret_stmt = self.stmt
         elif len(self.where_clauses) == 1:
-            ret_stmt =  self.stmt.where(*self.where_clauses)
+            ret_stmt = self.stmt.where(*self.where_clauses)
         else:
             ret_stmt = self.stmt.where(and_(*self.where_clauses))
 

--- a/backend/ops_api/ops/utils/query_helpers.py
+++ b/backend/ops_api/ops/utils/query_helpers.py
@@ -1,21 +1,29 @@
 from typing import Any, cast
 
-from sqlalchemy import ColumnElement, Select
+from sqlalchemy import ColumnElement, Select, and_
 from sqlalchemy.orm import InstrumentedAttribute
 
 
 class QueryHelper:
     def __init__(self, stmt: Select[Any]):
         self.stmt = stmt
+        self.where_clauses = []
 
     def add_search(self, column: InstrumentedAttribute, search_term: str):
-        self.stmt = self.stmt.where(column.ilike(f"%{search_term}%"))
+        self.where_clauses.append(column.ilike(f"%{search_term}%"))
 
     def add_column_equals(self, column: InstrumentedAttribute, value: str):
-        self.stmt = self.stmt.where(column == value)
+        self.where_clauses.append(column == value)
 
     def return_none(self):
-        self.stmt = self.stmt.where(cast(ColumnElement, False))
+        self.where_clauses.append(cast(ColumnElement, False))
 
     def get_stmt(self):
-        return self.stmt
+        if not self.where_clauses:
+            ret_stmt = self.stmt
+        elif len(self.where_clauses) == 1:
+            ret_stmt =  self.stmt.where(*self.where_clauses)
+        else:
+            ret_stmt = self.stmt.where(and_(*self.where_clauses))
+
+        return ret_stmt

--- a/backend/ops_api/ops/utils/query_helpers.py
+++ b/backend/ops_api/ops/utils/query_helpers.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import InstrumentedAttribute
 class QueryHelper:
     def __init__(self, stmt: Select[Any]):
         self.stmt = stmt
-        self.where_clauses = []
+        self.where_clauses: list[Any] = []
 
     def add_search(self, column: InstrumentedAttribute, search_term: str):
         self.where_clauses.append(column.ilike(f"%{search_term}%"))

--- a/backend/ops_api/tests/ops/agreement/test_agreement.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement.py
@@ -96,6 +96,28 @@ def test_agreements_with_research_project_found(auth_client, loaded_db):
     assert response.json[1]["id"] == 2
 
 
+@pytest.mark.parametrize("key,value",(
+    ("agreement_reason", "NEW_REQ"),
+    ("contract_number", "CT00XX1"),
+    ("contract_type", "RESEARCH"),
+    ("delivered_status", False),
+    ("number", "AGR0001"),
+    ("procurement_shop_id", 1),
+    ("project_officer", 1),
+    ("research_project_id", 1),
+))
+@pytest.mark.usefixtures("app_ctx")
+def test_agreements_with_filter(auth_client, key, value, loaded_db):
+    response = auth_client.get(f"/api/v1/agreements/?agreement_type=CONTRACT&{key}={value}")
+    assert response.status_code == 200
+    from pprint import pprint
+    success = all(item[key] == value for item in response.json)
+    if not success:
+        pprint([item[key] for item in response.json])
+        pprint(value)
+    assert success
+
+
 @pytest.mark.usefixtures("app_ctx")
 def test_agreements_with_research_project_not_found(auth_client, loaded_db):
     response = auth_client.get("/api/v1/agreements/?research_project_id=1000")

--- a/backend/ops_api/tests/ops/agreement/test_agreement.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement.py
@@ -130,7 +130,7 @@ def test_agreement_search(auth_client, loaded_db):
     assert response.status_code == 200
     assert len(response.json) == 0
 
-    response = auth_client.get("/api/v1/agreements/?search=Contract")
+    response = auth_client.get("/api/v1/agreements/?search=contract")
     assert response.status_code == 200
     assert len(response.json) == 2
 

--- a/backend/ops_api/tests/ops/agreement/test_agreement.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement.py
@@ -101,16 +101,19 @@ def test_agreements_with_research_project_found(auth_client, loaded_db):
         ("agreement_reason", "NEW_REQ"),
         ("contract_number", "CT00XX1"),
         ("contract_type", "RESEARCH"),
+        ("agreement_type", "CONTRACT"),
         ("delivered_status", False),
         ("number", "AGR0001"),
         ("procurement_shop_id", 1),
         ("project_officer", 1),
         ("research_project_id", 1),
+        ("foa", "This is an FOA value"),
+        ("name", "Contract #1: African American Child and Family Research Center"),
     ),
 )
 @pytest.mark.usefixtures("app_ctx")
 def test_agreements_with_filter(auth_client, key, value, loaded_db):
-    response = auth_client.get(f"/api/v1/agreements/?agreement_type=CONTRACT&{key}={value}")
+    response = auth_client.get(f"/api/v1/agreements/?{key}={value}")
     assert response.status_code == 200
     from pprint import pprint
 

--- a/backend/ops_api/tests/ops/agreement/test_agreement.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement.py
@@ -57,7 +57,6 @@ def test_agreements_serialization(auth_client, loaded_db):
     assert json_to_compare == {
         "agreement_reason": "NEW_REQ",
         "agreement_type": "CONTRACT",
-        "contract_id": 1,
         "contract_number": "CT00XX1",
         "contract_type": "RESEARCH",
         "created_by": None,
@@ -168,7 +167,6 @@ def test_agreement_create_contract_agreement(loaded_db):
     contract_agreement = ContractAgreement(
         name="CTXX12399",
         number="AGRXX003459217-B",
-        contract_id=99,
         contract_number="CT0002",
         contract_type=ContractType.RESEARCH,
         product_service_code_id=2,

--- a/backend/ops_api/tests/ops/agreement/test_agreement.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement.py
@@ -95,21 +95,25 @@ def test_agreements_with_research_project_found(auth_client, loaded_db):
     assert response.json[1]["id"] == 2
 
 
-@pytest.mark.parametrize("key,value",(
-    ("agreement_reason", "NEW_REQ"),
-    ("contract_number", "CT00XX1"),
-    ("contract_type", "RESEARCH"),
-    ("delivered_status", False),
-    ("number", "AGR0001"),
-    ("procurement_shop_id", 1),
-    ("project_officer", 1),
-    ("research_project_id", 1),
-))
+@pytest.mark.parametrize(
+    "key,value",
+    (
+        ("agreement_reason", "NEW_REQ"),
+        ("contract_number", "CT00XX1"),
+        ("contract_type", "RESEARCH"),
+        ("delivered_status", False),
+        ("number", "AGR0001"),
+        ("procurement_shop_id", 1),
+        ("project_officer", 1),
+        ("research_project_id", 1),
+    ),
+)
 @pytest.mark.usefixtures("app_ctx")
 def test_agreements_with_filter(auth_client, key, value, loaded_db):
     response = auth_client.get(f"/api/v1/agreements/?agreement_type=CONTRACT&{key}={value}")
     assert response.status_code == 200
     from pprint import pprint
+
     success = all(item[key] == value for item in response.json)
     if not success:
         pprint([item[key] for item in response.json])

--- a/backend/ops_api/tests/ops/agreement/test_agreement.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement.py
@@ -130,8 +130,7 @@ def test_agreement_search(auth_client, loaded_db):
     assert response.status_code == 200
     assert len(response.json) == 0
 
-    response = auth_client.get("/api/v1/agreements/?search=contract")
-
+    response = auth_client.get("/api/v1/agreements/?search=Contract")
     assert response.status_code == 200
     assert len(response.json) == 2
 
@@ -187,7 +186,6 @@ def test_agreement_create_grant_agreement(loaded_db):
     grant_agreement = GrantAgreement(
         name="GNTXX12399",
         number="AGRXX003459217-A",
-        grant_id=99,
         foa="NIH",
         agreement_type=AgreementType.GRANT,
     )


### PR DESCRIPTION
## What changed

* Added filtering (AND-type) on any combination of fields defined in the dataclasses for the different Agreement types.
* Restructured QueryHelper to allow for multiple WHERE clauses to be defined and then added to the query statement it returns.
* Updated tests to validate that it works. Improved query for GET /agreements to be able to dynamically choose the right class for a record from any of the Agreement model classes.

## Issue

#1030 

## How to test

1. `pytest`
2. Can also use the various parameters from a GET for `/agreements`. Like: GET `/agreements?contract_number=CT00XX1`

## Screenshots

N/A

## Links

N/A
