### PR TITLE
TeckDebt - Create vscode launch/tasks for debugging Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,10 @@ yarn-error.log*
 .DS_Store
 
 # IDE
-.vscode
+.vscode/*
+# allow vscode launch/tasks to be shared
+!.vscode/launch.json
+!.vscode/tasks.json
 .idea
 
 # HTTP-Client

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Remote Attach (Docker Compose)",
+      "type": "python",
+      "request": "attach",
+      "connect": { "host": "localhost", "port": 5678 },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}/backend",
+          "remoteRoot": "/home/app"
+        }
+      ],
+      "justMyCode": true
+    },
+    {
+      "name": "Javascript: Remote Attach (Docker Compose)",
+      "type": "node",
+      "request": "attach",
+      "restart": true,
+      "remoteRoot": "/home/app",
+      "localRoot": "${workspaceFolder}/frontend",
+      "port": 9229,
+      "address": "localhost",
+      "sourceMaps": true
+    },
+    {
+      "name": "Launch Chrome against localhost",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/frontend"
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Python: Remote Attach (Docker Compose)",
+      "name": "Python: Attach OPS API",
       "type": "python",
       "request": "attach",
       "connect": { "host": "localhost", "port": 5678 },
@@ -12,25 +12,8 @@
           "remoteRoot": "/home/app"
         }
       ],
-      "justMyCode": true
-    },
-    {
-      "name": "Javascript: Remote Attach (Docker Compose)",
-      "type": "node",
-      "request": "attach",
-      "restart": true,
-      "remoteRoot": "/home/app",
-      "localRoot": "${workspaceFolder}/frontend",
-      "port": 9229,
-      "address": "localhost",
-      "sourceMaps": true
-    },
-    {
-      "name": "Launch Chrome against localhost",
-      "type": "chrome",
-      "request": "launch",
-      "url": "http://localhost:3000",
-      "webRoot": "${workspaceFolder}/frontend"
+      "justMyCode": true,
+      "preLaunchTask": "Check and Start Docker Container"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,51 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "docker-run",
+      "label": "docker-run: debug",
+      "dependsOn": ["docker-build"],
+      "dockerRun": {
+        "containerName": "ops-api",
+        "image": "ops-api:debug-latest",
+        "env": {
+          "FLASK_APP": "ops_api.ops",
+          "FLASK_ENV": "development",
+          "FLASK_DEBUG": "true"
+        },
+        "volumes": [
+          {
+            "containerPath": "/home/app",
+            "localPath": "${workspaceFolder}/backend"
+          }
+        ],
+        "ports": [
+          {
+            "containerPort": 8080,
+            "hostPort": 8080
+          }
+        ]
+      },
+      "python": {
+        "args": [
+          "python",
+          "-m",
+          "gunicorn",
+          "-b",
+          ":8080",
+          "ops_api.ops:create_app()"
+        ],
+        "module": "flask"
+      }
+    },
+    {
+      "label": "docker-build",
+      "type": "docker-build",
+      "dockerBuild": {
+        "context": "${workspaceFolder}",
+        "dockerfile": "${workspaceFolder}/backend/Dockerfile.debug",
+        "tag": "ops-api:debug-latest"
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -46,6 +46,24 @@
         "dockerfile": "${workspaceFolder}/backend/Dockerfile.debug",
         "tag": "ops-api:debug-latest"
       }
+    },
+    {
+      "label": "Check and Start Docker Container",
+      "type": "shell",
+      "command": "bash",
+      "args": [
+        "-c",
+        "if [[ $(docker inspect --format='{{.State.Status}}' ops-backend) != 'running' ]]; then docker-compose -f ${workspaceFolder}/docker-compose.debug.yml up --build -d; fi"
+      ],
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
     }
   ]
 }

--- a/backend/Dockerfile.debug
+++ b/backend/Dockerfile.debug
@@ -11,9 +11,7 @@ RUN pipenv install --dev --system --deploy && chown -R app:app .
 
 # Now copy the rest of the app files, again to better support caching
 # of prior steps.
-# For debugging, we're using a volume mount, so we don't need to copy
-# See .vscode/tasks.json
-# COPY . /home/app
+COPY . /home/app
 
 # RUN chown -R app:app .
 USER app

--- a/backend/Dockerfile.debug
+++ b/backend/Dockerfile.debug
@@ -1,0 +1,26 @@
+FROM python:3.10-slim
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get -y install curl --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir --upgrade pip==23.0.0 pipenv==2023.2.4 && useradd -ms /bin/bash app
+WORKDIR /home/app
+
+# Copy the Pipfile(s) only, so that we can cache dependencies
+# in the next step
+COPY ./ops_api/Pipfile ./ops_api/Pipfile.lock /home/app/
+RUN pipenv install --dev --system --deploy && chown -R app:app .
+
+# Now copy the rest of the app files, again to better support caching
+# of prior steps.
+# For debugging, we're using a volume mount, so we don't need to copy
+# See .vscode/tasks.json
+# COPY . /home/app
+
+# RUN chown -R app:app .
+USER app
+
+ENV PYTHONPATH=/home/app
+ENV PYTHONUNBUFFERED=1
+ENV FLASK_APP=ops_api.ops
+ENV FLASK_DEBUG=true
+
+CMD ["python", "-m", "gunicorn", "-b", ":8080", "ops_api.ops:create_app()"]

--- a/backend/data_tools/environment/local.py
+++ b/backend/data_tools/environment/local.py
@@ -12,4 +12,4 @@ class LocalConfig(DataToolsConfig):
 
     @property
     def verbosity(self) -> bool:
-        return True
+        return False

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,96 @@
+version: "3.8"
+
+services:
+
+  db:
+    image: "postgres:12"
+    platform: linux/amd64
+    container_name: ops-db
+    security_opt:
+      - no-new-privileges:true  # Resolve semgrep https://sg.run/0n8q
+    environment:
+      - POSTGRES_PASSWORD=local_password
+    read_only: true  # Resolve semgrep https://sg.run/e4JE
+    tmpfs: /var/run/postgresql/
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  data-import:
+    build:
+      context: ./backend/
+      dockerfile: Dockerfile.data-tools
+    platform: linux/amd64
+    container_name: ops-data-import
+    environment:
+      - ENV=local
+    command: >
+      bash -c "
+      python ./data_tools/src/import_static_data/load_db.py &&
+      DATA=./data_tools/data/portfolio_data.json5 python ./data_tools/src/import_static_data/import_data.py &&
+      DATA=./data_tools/data/funding_partner_data.json5 python ./data_tools/src/import_static_data/import_data.py &&
+      DATA=./data_tools/data/funding_source_data.json5 python ./data_tools/src/import_static_data/import_data.py &&
+      DATA=./data_tools/data/research_project_data.json5 python ./data_tools/src/import_static_data/import_data.py &&
+      DATA=./data_tools/data/can_data.json5 python ./data_tools/src/import_static_data/import_data.py &&
+      DATA=./data_tools/data/user_data.json5 python ./data_tools/src/import_static_data/import_data.py &&
+      DATA=./data_tools/data/agreements_and_blin_data.json5 python ./data_tools/src/import_static_data/import_data.py &&
+      DATA=./data_tools/data/team_leader_data.json5 python ./data_tools/src/import_static_data/import_data.py
+      "
+
+    volumes:
+      # See below for an explanation of this volume. The same reasoning applies,
+      # but in this case it's so we can run new migrations immediately without
+      # having to rebuild the migration container.
+      - ./backend/ops_api:/home/app/ops_api
+    depends_on:
+      db:
+        condition: service_healthy
+
+  backend:
+    build:
+      context: ./backend/
+      dockerfile: Dockerfile.ops-api
+    platform: linux/amd64
+    container_name: ops-backend
+    ports:
+      - 8080:8080
+      - 5678:5678
+    # command: ["python", "-m", "flask", "run", "--debug", "--host=0.0.0.0", "--port=8080"]
+    command: ["sh", "-c", "pip install debugpy -t /tmp && python /tmp/debugpy --wait-for-client --listen 0.0.0.0:5678 -m flask run --host=0.0.0.0 --port=8080"]
+    environment:
+      - JWT_PRIVATE_KEY
+      - JWT_PUBLIC_KEY
+      - OPS_CONFIG=environment/local/container.py
+    volumes:
+      - ./backend/ops_api/ops:/home/app/ops
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
+  frontend:
+    build:
+      context: ./frontend/
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    container_name: ops-frontend
+    environment:
+      - REACT_APP_BACKEND_DOMAIN=http://localhost:8080
+      - NODE_ENV=development
+      - CHOKIDAR_USEPOLLING=true
+    command: ["yarn", "start:debug"]
+    ports:
+      - 3000:3000
+      - 9229:9229
+    depends_on:
+      - backend
+    volumes:
+      - ./frontend/:/home/app

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,4 +8,4 @@ COPY ./package.json ./yarn.lock /home/app/
 RUN yarn install --production --network-timeout 100000 && yarn cache clean
 
 COPY ./ /home/app/
-ENTRYPOINT ["yarn", "start"]
+CMD ["yarn", "start"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.0",
     "license": "CC0-1.0",
     "private": true,
+
     "dependencies": {
         "@fortawesome/fontawesome-svg-core": "6.4.0",
         "@fortawesome/free-regular-svg-icons": "6.4.0",
@@ -46,6 +47,7 @@
     },
     "scripts": {
         "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",
+        "start:debug": "DISABLE_ESLINT_PLUGIN=true react-scripts --inspect=0.0.0.0:9229 start",
         "build": "DISABLE_ESLINT_PLUGIN=true react-scripts build",
         "test": "react-scripts test",
         "test:coverage": "react-scripts test --coverage",


### PR DESCRIPTION
## What changed

* Added `.vscode/launch.json` to allow VSCode to attach to running docker process and enable remote debugging.
* Added `.vscode/tasks.json` with a tasks that checks to see if the `ops-backend` container is running, if not, executes `docker compose up`
* Created `debug` versions of `docker-compose.yml` and `Dockerfile.debug` to facilitate opening ports, and installing `pydebug`

## How to test

Within VSCode:

1. Go to a file you wish to debug ex: `backend/ops_api/ops/__init__.py`
2. Place a breakpoint on the line you'd like to pause on, ex: line 39: `log_level = "INFO"...`
3. Press `F5` to enter debugging (or RUN --> Start Debugging)
  * This should switch to the debug view
  * You should see a terminal open, checking to see if `ops-backend` container is running. If it is, then it should continue, and you should see progress in the `DEBUG Console` and your code should pause at the break point.
* NOTE: If `ops-backend` was not already running, you may need to hit `F5` again after it's started, to re-attempt to connect, minor bug I'm looking into.

## Screenshots

![image](https://github.com/HHS/OPRE-OPS/assets/56687505/0e9e7f90-4508-4098-a9bb-bcdcbd0a5663)

## Links

