### PR TITLE
Added workflow pre-condition to deploy on main push

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -1,4 +1,4 @@
-name: Deployment
+name: Deployment DEV
 
 on:
   workflow_run:

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -1,9 +1,13 @@
 name: Deployment
 
 on:
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
+    branches: [main, TechDebt-dev_deploy_main_push] # extra branch for testing only during dev.
   push:
-    branches:
-      - development
+    branches: [development]
 
 jobs:
 

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -1,4 +1,4 @@
-name: Deployment
+name: Deployment STAGING
 
 on:
   push:


### PR DESCRIPTION
## What changed

* Updated the `dev_deploy` to also trigger on the completion of CI workflow in `main`, resulting in the deployment to main, on any successful push to main, after CI completes. i.e.: All merged PRs will be deployed to DEV
