### PR TITLE
Update staging_deploy.yml

### DIFF
--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -1,6 +1,12 @@
 name: Deployment STAGING
 
 on:
+  # Deploy to STAGING nightly, since DEV is updated on each PUSH. This will ensure STAGING remains close to DEV
+  # but doesn't conflict with daily testing.
+  schedule:
+    # cron format: 'minute hour dayofmonth month dayofweek'
+    # this will run at 8AM UTC every day (3am EST / 4am EDT)
+    - cron: '0 8 * * *'
   push:
     branches:
       - staging


### PR DESCRIPTION
## What changed

- Added a `cron` schedule, to deploy to STAGING every night at 8am UTC / 3AM ET

## Issue

- TechDebt

## How to test

- Wait until 3am, see if the action fires off.

## Screenshots

- No screenshot, but here's a picture of an aardvark
- 
![image](https://github.com/HHS/OPRE-OPS/assets/56687505/4c084bd4-207d-48e0-ad5f-2680f593d604)
 

## Links

- You can see if it's worked by going here: [Deploy STAGING Action History](https://github.com/HHS/OPRE-OPS/actions/workflows/staging_deploy.yml)
