### PR TITLE
Ops 1074 implement delete agreements

### DIFF
--- a/backend/models/events.py
+++ b/backend/models/events.py
@@ -16,6 +16,7 @@ class OpsEventType(Enum):
     CREATE_NEW_AGREEMENT = 5
     UPDATE_AGREEMENT = 6
     SEND_BLI_FOR_APPROVAL = 7
+    DELETE_AGREEMENT = 8
 
 
 class OpsEventStatus(Enum):

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -256,7 +256,7 @@ class AgreementItemAPI(BaseItemAPI):
         message_prefix = f"DELETE from {ENDPOINT_STRING}"
 
         identity = get_jwt_identity()
-        is_authorized = self.auth_gateway.is_authorized(identity, ["PATCH_AGREEMENT"])
+        is_authorized = self.auth_gateway.is_authorized(identity, ["DELETE_AGREEMENT"])
         if not is_authorized:
             return make_response_with_headers({}, 401)
 

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -8,7 +8,14 @@ from flask_jwt_extended import get_jwt_identity, jwt_required, verify_jwt_in_req
 from marshmallow import ValidationError, fields, Schema
 from models import ContractType, OpsEventType, User
 from models.base import BaseModel
-from models.cans import Agreement, AgreementReason, AgreementType, ContractAgreement, ProductServiceCode, BudgetLineItemStatus
+from models.cans import (
+    Agreement,
+    AgreementReason,
+    AgreementType,
+    ContractAgreement,
+    ProductServiceCode,
+    BudgetLineItemStatus,
+)
 from ops_api.ops.base_views import BaseItemAPI, BaseListAPI, OPSMethodView
 from ops_api.ops.utils.events import OpsEventHandler
 from ops_api.ops.utils.query_helpers import QueryHelper
@@ -266,6 +273,8 @@ class AgreementItemAPI(BaseItemAPI):
 
                 current_app.db_session.delete(agreement)
                 current_app.db_session.commit()
+
+                meta.metadata.update({"Deleted Agreement": id})
 
                 return make_response_with_headers({"message": "Agreement deleted", "id": agreement.id}, 200)
 

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -15,7 +15,7 @@ from ops_api.ops.utils.query_helpers import QueryHelper
 from ops_api.ops.utils.response import make_response_with_headers
 from ops_api.ops.utils.user import get_user_from_token
 from sqlalchemy.exc import PendingRollbackError, SQLAlchemyError
-from sqlalchemy.future import select, delete
+from sqlalchemy.future import select
 from typing_extensions import Any, override
 
 ENDPOINT_STRING = "/agreements"
@@ -256,6 +256,7 @@ class AgreementItemAPI(BaseItemAPI):
         try:
             with OpsEventHandler(OpsEventType.DELETE_AGREEMENT) as meta:
                 agreement: Agreement = self._get_item(id)
+
                 if not agreement:
                     raise RuntimeError(f"Invalid Agreement id: {id}.")
                 elif agreement.agreement_type != AgreementType.CONTRACT:

--- a/backend/ops_api/ops/utils/events.py
+++ b/backend/ops_api/ops/utils/events.py
@@ -8,6 +8,7 @@ from models import User
 from models.events import OpsEvent, OpsEventStatus, OpsEventType
 from ops_api.ops.utils.user import get_user_from_token
 from sqlalchemy.orm import Session
+from werkzeug.exceptions import UnsupportedMediaType
 
 
 class OpsEventHandler:
@@ -18,13 +19,18 @@ class OpsEventHandler:
     def __enter__(self):
         self.metadata.update(
             {
-                "request.json": request.json,
                 "request.values": request.values,
                 "request.headers": {k: v for k, v in request.headers},
                 "request.remote_addr": request.remote_addr,
                 "request.remote_user": request.remote_user,
             }
         )
+
+        try:
+            self.metadata["request.json"] = request.json
+        except UnsupportedMediaType:
+            if request.data:
+                self.metadata["request.data"] = request.data
 
         return self
 

--- a/backend/ops_api/tests/ops/agreement/test_agreement.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement.py
@@ -464,7 +464,7 @@ def test_agreements_patch_by_id_just_notes(auth_client, loaded_db):
         agreement = loaded_db.execute(stmt)
 
 
-#@pytest.mark.skip("Not yet implemented")
+# @pytest.mark.skip("Not yet implemented")
 @pytest.mark.usefixtures("app_ctx")
 def test_agreements_delete_by_id(auth_client, loaded_db, test_contract):
     response = auth_client.delete(f"/api/v1/agreements/{test_contract.id}")

--- a/backend/ops_api/tests/ops/agreement/test_agreement.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement.py
@@ -468,7 +468,7 @@ def test_agreements_patch_by_id_just_notes(auth_client, loaded_db):
 @pytest.mark.usefixtures("app_ctx")
 def test_agreements_delete_by_id(auth_client, loaded_db, test_contract):
     response = auth_client.delete(f"/api/v1/agreements/{test_contract.id}")
-    assert response.status_code == 204
+    assert response.status_code == 200
 
     stmt = select(Agreement).where(Agreement.id == test_contract.id)
     agreement = loaded_db.scalar(stmt)

--- a/backend/ops_api/tests/ops/agreement/test_agreement.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement.py
@@ -464,7 +464,7 @@ def test_agreements_patch_by_id_just_notes(auth_client, loaded_db):
         agreement = loaded_db.execute(stmt)
 
 
-@pytest.mark.skip("Not yet implemented")
+#@pytest.mark.skip("Not yet implemented")
 @pytest.mark.usefixtures("app_ctx")
 def test_agreements_delete_by_id(auth_client, loaded_db, test_contract):
     response = auth_client.delete(f"/api/v1/agreements/{test_contract.id}")


### PR DESCRIPTION
## What changed

It is now possible to delete contracts that only have BLIs in DRAFT status.

## Issue

#1074

## How to test

pytest does the test.

## Screenshots

N/A

## Links

N/A