### PR TITLE
Ops 1198 bell icon

### DIFF
--- a/frontend/cypress/e2e/notificationCenter.cy.js
+++ b/frontend/cypress/e2e/notificationCenter.cy.js
@@ -9,6 +9,8 @@ it("Notification Center appears when you click the bell icon and has 1 item in l
     cy.visit("/");
     testLogin("admin");
     cy.visit("/");
+
+    cy.get("use").should("have.attr", "xlink:href").and("contain", "notifications_active");
     cy.get("#notification-center-bell").click();
     cy.contains("Notifications");
     cy.get("#notification-center-list").its("length").should("eq", 1);
@@ -16,4 +18,5 @@ it("Notification Center appears when you click the bell icon and has 1 item in l
     // notifications not visible after clicking clear button
     cy.get("#clear-all-button").click();
     cy.get("#notification-center-list").its("length").should("eq", 0);
+    cy.get("use").should("have.attr", "xlink:href").and("contain", "notifications_none");
 });

--- a/frontend/src/components/Auth/AuthSection.jsx
+++ b/frontend/src/components/Auth/AuthSection.jsx
@@ -106,8 +106,12 @@ const AuthSection = () => {
             {isLoggedIn && (
                 <div>
                     <div className="display-flex flex-align-center">
-                        <User />
-                        <NotificationCenter />
+                        <div style={{ paddingRight: "20px" }}>
+                            <User />
+                        </div>
+                        <div style={{ paddingRight: "20px" }}>
+                            <NotificationCenter />
+                        </div>
                         <button
                             className="usa-button fa-solid fa-arrow-right-to-bracket margin-1"
                             onClick={logoutHandler}

--- a/frontend/src/components/Auth/AuthSection.jsx
+++ b/frontend/src/components/Auth/AuthSection.jsx
@@ -106,10 +106,10 @@ const AuthSection = () => {
             {isLoggedIn && (
                 <div>
                     <div className="display-flex flex-align-center">
-                        <div style={{ paddingRight: "20px" }}>
+                        <div className="padding-right-205">
                             <User />
                         </div>
-                        <div style={{ paddingRight: "20px" }}>
+                        <div className="padding-right-205">
                             <NotificationCenter />
                         </div>
                         <button

--- a/frontend/src/components/UI/NotificationCenter/NotificationCenter.jsx
+++ b/frontend/src/components/UI/NotificationCenter/NotificationCenter.jsx
@@ -44,7 +44,8 @@ const NotificationCenter = () => {
                 onClick={() => setShowModal(true)}
                 id="notification-center-bell"
             >
-                <use xlinkHref={`${icons}#notifications`}></use>
+                {unreadNotifications.length !== 0 && <use xlinkHref={`${icons}#notifications_active`}></use>}
+                {unreadNotifications.length === 0 && <use xlinkHref={`${icons}#notifications_none`}></use>}
             </svg>
 
             <Modal


### PR DESCRIPTION
## What changed

Use different icon depending on if there are notifications.

## Issue

https://github.com/HHS/OPRE-OPS/issues/1198

## How to test

1. Log into the app and click the bell to see your notifications.
2. Clear the notifications.
3. The bell icon should change.

## Screenshots

![image](https://github.com/HHS/OPRE-OPS/assets/1972158/59869fde-19e2-4f9f-97c6-22c4ab8bda33)

![image](https://github.com/HHS/OPRE-OPS/assets/1972158/7675d367-7e88-49bb-a00d-83b58d584233)
