### PR TITLE
re-adding myself back in as a user

### DIFF
--- a/backend/data_tools/data/user_data.json5
+++ b/backend/data_tools/data/user_data.json5
@@ -118,6 +118,13 @@
       division: 3,
       email: "stekell+sandbox@flexion.us",
       oidc_id: "7716138a-dec6-4976-9f31-e30fade3254d",
+    },
+    { // 18
+      first_name: "Jonathan",
+      last_name: "Nalley",
+      division: 3,
+      email: "jnalley+logingovsandbox@flexion.us",
+      oidc_id: "48f7db91-1861-4d4b-813c-a6221cb61b60",
     }
   ],
   roles: [
@@ -232,6 +239,10 @@
     },
     {
       user_id: 17,
+      role_id: 1,
+    },
+    {
+      user_id: 18,
       role_id: 1,
     },
   ],
@@ -353,6 +364,13 @@
       message: "This is a system notification",
       is_read: false,
       recipient_id: 17,
+      expires: "2031-12-31"
+    },
+    {
+      title: "System Notification",
+      message: "This is a system notification",
+      is_read: false,
+      recipient_id: 18,
       expires: "2031-12-31"
     }
   ],

--- a/backend/ops_api/tests/ops/notification/test_notification.py
+++ b/backend/ops_api/tests/ops/notification/test_notification.py
@@ -107,7 +107,7 @@ def test_notification_creation(loaded_db, notification):
 
 @pytest.mark.usefixtures("app_ctx")
 def test_notifications_get_all(auth_client, loaded_db):
-    assert loaded_db.query(Notification).count() == 17
+    assert loaded_db.query(Notification).count() == 18
 
     response = auth_client.get("/api/v1/notifications/")
     assert response.status_code == 200
@@ -144,7 +144,7 @@ def test_notifications_get_by_oidc_id(auth_client, loaded_db, notification):
 def test_notifications_get_by_is_read(auth_client, loaded_db, notification_is_read_is_true):
     response = auth_client.get("/api/v1/notifications/?is_read=False")
     assert response.status_code == 200
-    assert len(response.json) == 17
+    assert len(response.json) == 18
     assert response.json[0]["title"] == "System Notification"
     assert response.json[0]["message"] == "This is a system notification"
     assert response.json[0]["is_read"] is False

--- a/backend/ops_api/tests/ops/notification/test_notification.py
+++ b/backend/ops_api/tests/ops/notification/test_notification.py
@@ -111,7 +111,7 @@ def test_notifications_get_all(auth_client, loaded_db):
 
     response = auth_client.get("/api/v1/notifications/")
     assert response.status_code == 200
-    assert len(response.json) == 17
+    assert len(response.json) == 18
 
 
 @pytest.mark.usefixtures("app_ctx")


### PR DESCRIPTION
## What changed

Adding a defined user entry for myself back into `user_data.json5` in the `data_tools container`. Another sign the authz is working! Huzzah!

## Issue

N/A

## How to test

I'll try to log in once again without the error messages (kudos for error messages!)

## Screenshots

<img width="391" alt="Screenshot 2023-07-15 at 2 15 35 AM" src="https://github.com/HHS/OPRE-OPS/assets/928984/4c2614b4-2ffd-4436-b3e3-49477b0108c0">


<img width="458" alt="Screenshot 2023-07-15 at 2 15 41 AM" src="https://github.com/HHS/OPRE-OPS/assets/928984/3c1f273a-32db-4847-953d-b03df8a36e6a">

