### PR TITLE
adds api call and wires up trash icon

### DIFF
--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -54,6 +54,13 @@ export const opsApi = createApi({
             },
             invalidatesTags: ["Agreements", "BudgetLineItems"],
         }),
+        deleteAgreement: builder.mutation({
+            query: (id) => ({
+                url: `/agreements/${id}`,
+                method: "DELETE",
+            }),
+            invalidatesTags: ["Agreements", "BudgetLineItems"],
+        }),
         addBudgetLineItem: builder.mutation({
             query: ({ data }) => {
                 const cleanData = { ...data }; // make a copy
@@ -173,6 +180,7 @@ export const {
     useGetAgreementByIdQuery,
     useAddAgreementMutation,
     useUpdateAgreementMutation,
+    useDeleteAgreementMutation,
     useAddBudgetLineItemMutation,
     useUpdateBudgetLineItemMutation,
     useGetAgreementsByResearchProjectFilterQuery,

--- a/frontend/src/pages/agreements/list/AgreementTableRow.jsx
+++ b/frontend/src/pages/agreements/list/AgreementTableRow.jsx
@@ -9,12 +9,14 @@ import { getUser } from "../../../api/getUser";
 import icons from "../../../uswds/img/sprite.svg";
 import { convertCodeForDisplay, formatDate } from "../../../helpers/utils";
 import TableTag from "../../../components/UI/PreviewTable/TableTag";
+import { useDeleteAgreementMutation } from "../../../api/opsAPI";
 
 export const AgreementTableRow = ({ agreement }) => {
     const [user, setUser] = useState({});
     const navigate = useNavigate();
     const [isExpanded, setIsExpanded] = useState(false);
     const [isRowActive, setIsRowActive] = useState(false);
+    const [deleteAgreement] = useDeleteAgreementMutation();
 
     const agreementName = agreement?.name;
     const researchProjectName = agreement?.research_project?.title;
@@ -72,9 +74,8 @@ export const AgreementTableRow = ({ agreement }) => {
     const handleEditAgreement = (event) => {
         navigate(`/agreements/${event}?mode=edit`);
     };
-    const handleDeleteAgreement = () => {
-        // TODO: implement delete agreement
-        alert("not implemented yet");
+    const handleDeleteAgreement = (id) => {
+        deleteAgreement(id);
     };
     const handleSubmitAgreementForApproval = (event) => {
         navigate(`/agreements/approve/${event}`);

--- a/frontend/src/pages/agreements/list/AgreementTableRow.test.js
+++ b/frontend/src/pages/agreements/list/AgreementTableRow.test.js
@@ -3,6 +3,8 @@ import "@testing-library/jest-dom";
 import { AgreementTableRow } from "./AgreementTableRow";
 import { Router } from "react-router-dom";
 import { createMemoryHistory } from "history";
+import { Provider } from "react-redux";
+import store from "../../../store";
 
 const history = createMemoryHistory();
 
@@ -40,13 +42,15 @@ describe("AgreementTableRow", () => {
 
     test("renders correctly", () => {
         render(
-            <Router location={history.location} navigator={history}>
-                <table>
-                    <tbody>
-                        <AgreementTableRow agreement={agreement} />
-                    </tbody>
-                </table>
-            </Router>
+            <Provider store={store}>
+                <Router location={history.location} navigator={history}>
+                    <table>
+                        <tbody>
+                            <AgreementTableRow agreement={agreement} />
+                        </tbody>
+                    </table>
+                </Router>
+            </Provider>
         );
         expect(screen.getByText("Test Agreement")).toBeInTheDocument();
         expect(screen.getByText("Test Project")).toBeInTheDocument();

--- a/frontend/src/pages/agreements/list/AgreementsList.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.jsx
@@ -36,11 +36,12 @@ export const AgreementsList = () => {
         data: agreements,
         error: errorAgreement,
         isLoading: isLoadingAgreement,
-        refetch,
+        refetch, // is this needed?
     } = useGetAgreementsQuery({ refetchOnMountOrArgChange: true });
 
     const activeUser = useSelector((state) => state.auth.activeUser);
 
+    // FSP@Flexion: Not sure if this is needed since we have the refetchOnMountOrArgChange: true
     useEffect(() => {
         refetch();
         // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## What changed

- adds api call and wires up trash icon for deleting Agreements
- does not include:
  -  Create a notification, which reflects the status of the deletion (success or fail)
  - Enforce a subset of the rules on the frontend as well
  - Optional - give Tooltip feedback on why DELETE is disabled (?)

## Issue

#1294 

## How to test

1. create an agreement or add yourself to an agreement that only has DRAFT budget lines.
2. In the Agreement list, click on the trash can icon
3. 💰 profit

