### PR TITLE
Ops 1316/task 1318

### DIFF
--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -4,7 +4,15 @@ const BACKEND_DOMAIN = process.env.REACT_APP_BACKEND_DOMAIN;
 
 export const opsApi = createApi({
     reducerPath: "opsApi",
-    tagTypes: ["Agreements", "ResearchProjects", "Users", "AgreementTypes", "AgreementReasons", "ProcurementShops"],
+    tagTypes: [
+        "Agreements",
+        "ResearchProjects",
+        "Users",
+        "AgreementTypes",
+        "AgreementReasons",
+        "ProcurementShops",
+        "BudgetLineItems",
+    ],
     baseQuery: fetchBaseQuery({
         baseUrl: `${BACKEND_DOMAIN}/api/v1/`,
         prepareHeaders: (headers) => {

--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -20,7 +20,7 @@ export const opsApi = createApi({
     endpoints: (builder) => ({
         getAgreements: builder.query({
             query: () => `/agreements/`,
-            providesTags: ["Agreements"],
+            providesTags: ["Agreements", "BudgetLineItems"],
         }),
         getAgreementById: builder.query({
             query: (id) => `/agreements/${id}`,

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -33,6 +33,7 @@ import {
  * @param {boolean} [props.isReviewMode] - Whether the form is in review mode. - optional
  * @param {boolean} props.isEditMode - Whether the edit mode is on (in the Agreement details page) - optional.
  * @param {function} props.setIsEditMode - The function to set the edit mode (in the Agreement details page) - optional.
+ * @returns {React.JSX.Element} - The component JSX.
  */
 export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, setIsEditMode }) => {
     const isWizardMode = location.pathname === "/agreements/create" || location.pathname.startsWith("/agreements/edit");

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -175,6 +175,8 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
                             message: "An error occurred while saving the agreement.",
                         })
                     );
+                    // TODO: replace with a redirect to Error page
+                    navigate("/agreements");
                 });
         } else {
             addAgreement(cleanData)
@@ -202,6 +204,8 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
                             message: "An error occurred while creating the agreement.",
                         })
                     );
+                    // TODO: replace with a redirect to Error page
+                    navigate("/agreements");
                 });
         }
     };

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -153,23 +153,55 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
         };
         const { id, cleanData } = cleanAgreementForApi(data);
         if (id) {
-            // TODO: handle failures
             updateAgreement({ id: id, data: cleanData })
                 .unwrap()
-                .then((payload) => {
-                    console.log("Agreement Updated", payload);
+                .then((fulfilled) => {
+                    console.log(`UPDATE: agreement updated: ${JSON.stringify(fulfilled, null, 2)}`);
+                    globalDispatch(
+                        setAlert({
+                            type: "success",
+                            heading: "Agreement Draft Saved",
+                            message: "The agreement has been successfully saved.",
+                        })
+                    );
                 })
-                .catch((error) => console.error("Agreement Updated Failed", error));
+                .catch((rejected) => {
+                    console.error(`UPDATE: agreement updated failed: ${JSON.stringify(rejected, null, 2)}`);
+                    globalDispatch(
+                        setAlert({
+                            type: "error",
+                            heading: "Error",
+                            message: "An error occurred while saving the agreement.",
+                        })
+                    );
+                });
         } else {
-            // TODO: handle failures
             addAgreement(cleanData)
                 .unwrap()
                 .then((payload) => {
-                    console.log("Agreement Created", payload);
                     const newAgreementId = payload.id;
                     setAgreementId(newAgreementId);
                 })
-                .catch((error) => console.error("Agreement Failed", error));
+                .then((fulfilled) => {
+                    console.log(`CREATE: agreement success: ${JSON.stringify(fulfilled, null, 2)}`);
+                    globalDispatch(
+                        setAlert({
+                            type: "success",
+                            heading: "Agreement Draft Saved",
+                            message: "The agreement has been successfully created.",
+                        })
+                    );
+                })
+                .catch((rejected) => {
+                    console.error(`CREATE: agreement failed: ${JSON.stringify(rejected, null, 2)}`);
+                    globalDispatch(
+                        setAlert({
+                            type: "error",
+                            heading: "Error",
+                            message: "An error occurred while creating the agreement.",
+                        })
+                    );
+                });
         }
     };
 
@@ -181,14 +213,7 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
 
     const handleDraft = async () => {
         saveAgreement();
-        await globalDispatch(
-            setAlert({
-                type: "success",
-                heading: "Agreement Draft Saved",
-                message: "The agreement has been successfully saved.",
-                redirectUrl: "/agreements",
-            })
-        );
+        await navigate("/agreements");
     };
 
     const handleCancel = () => {

--- a/frontend/src/pages/agreements/list/AgreementsList.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.jsx
@@ -14,7 +14,7 @@ import { getCurrentFiscalYear } from "../../../helpers/utils";
 
 /**
  * Page for the Agreements List.
- * @returns {ReactNode} The rendered component.
+ * @returns {React.JSX.Element} - The component JSX.
  */
 export const AgreementsList = () => {
     const [searchParams] = useSearchParams();
@@ -37,16 +37,9 @@ export const AgreementsList = () => {
         data: agreements,
         error: errorAgreement,
         isLoading: isLoadingAgreement,
-        refetch, // is this needed?
     } = useGetAgreementsQuery({ refetchOnMountOrArgChange: true });
 
     const activeUser = useSelector((state) => state.auth.activeUser);
-
-    // FSP@Flexion: Not sure if this is needed since we have the refetchOnMountOrArgChange: true
-    useEffect(() => {
-        refetch();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     if (isLoadingAgreement) {
         return (

--- a/frontend/src/pages/agreements/list/AgreementsList.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.jsx
@@ -3,7 +3,7 @@ import { useGetAgreementsQuery } from "../../../api/opsAPI";
 import App from "../../../App";
 import Breadcrumb from "../../../components/UI/Header/Breadcrumb";
 import sortAgreements from "./utils";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Alert from "../../../components/UI/Alert";
 import "./AgreementsList.scss";
 import AgreementsTable from "./AgreementsTable";


### PR DESCRIPTION
## What changed

- Adds error Alert for api calls that fail on agreement creation

Does not include: 
 - add generic error page for api errors
 - update validation for Agreement type select
- add/update e2e tests

## Issue

#1318 

## How to test

1. create an Agreement without selecting a Project Type
2. watch for error Alert

## Screenshots

https://github.com/HHS/OPRE-OPS/assets/4629398/79adc1e3-b7c2-4df0-9c31-c0c89b789c66



