### PR TITLE
adds check for agreement type

### DIFF
--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -101,7 +101,7 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
     let res = suite.get();
 
     const incumbentDisabled = agreementReason === "NEW_REQ" || agreementReason === null || agreementReason === "0";
-    const shouldDisableBtn = !agreementTitle || res.hasErrors();
+    const shouldDisableBtn = !agreementTitle || !agreementType || res.hasErrors();
 
     const cn = classnames(suite.get(), {
         invalid: "usa-form-group--error",


### PR DESCRIPTION
## What changed

adds check for agreement type

## Issue

#1324 

## How to test

- create agreement w/out agreement type
- try to go next //should not work

## Screenshots

_If relevant, e.g. for a front-end feature_
