### PR TITLE
Adds agreement name in Alert when successfully deleting agreement

### DIFF
--- a/frontend/src/pages/agreements/list/AgreementTableRow.jsx
+++ b/frontend/src/pages/agreements/list/AgreementTableRow.jsx
@@ -120,7 +120,7 @@ export const AgreementTableRow = ({ agreement }) => {
                             setAlert({
                                 type: "success",
                                 heading: "Agreement deleted",
-                                message: "The agreement has been successfully deleted.",
+                                message: `${agreementName} has been successfully deleted.`,
                             })
                         );
                     })

--- a/frontend/src/pages/agreements/list/AgreementTableRow.jsx
+++ b/frontend/src/pages/agreements/list/AgreementTableRow.jsx
@@ -120,7 +120,7 @@ export const AgreementTableRow = ({ agreement }) => {
                             setAlert({
                                 type: "success",
                                 heading: "Agreement deleted",
-                                message: `${agreementName} has been successfully deleted.`,
+                                message: `Agreement ${agreementName} has been successfully deleted.`,
                             })
                         );
                     })


### PR DESCRIPTION
## What changed

Adds agreement name in Alert when successfully deleting agreement

## Issue

#1036 

## How to test

1. create agreement and remember Agreement Title
2. delete agreement
3. see Agreement title in the success Alert

## Screenshots
https://github.com/HHS/OPRE-OPS/assets/4629398/66566f2b-21e6-422c-8451-13b8dc216f5c
