### PR TITLE
adds checks to disable editing

### DIFF
--- a/frontend/src/pages/agreements/EditAgreement.js
+++ b/frontend/src/pages/agreements/EditAgreement.js
@@ -1,9 +1,9 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
 import App from "../../App";
 import { EditAgreementProvider } from "../../components/Agreements/AgreementEditor/AgreementEditorContext";
 import CreateEditAgreement from "./CreateEditAgreement";
-import { useParams } from "react-router-dom";
 import { useGetAgreementByIdQuery } from "../../api/opsAPI";
-import { useEffect, useState } from "react";
 import { getUser } from "../../api/getUser";
 import SimpleAlert from "../../components/UI/Alert/SimpleAlert";
 
@@ -17,15 +17,9 @@ const EditAgreement = () => {
         data: agreement,
         error: errorAgreement,
         isLoading: isLoadingAgreement,
-        refetch,
     } = useGetAgreementByIdQuery(agreementId, {
         refetchOnMountOrArgChange: true,
     });
-
-    useEffect(() => {
-        refetch();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     useEffect(() => {
         const getProjectOfficerSetState = async (id) => {
@@ -49,18 +43,17 @@ const EditAgreement = () => {
         return <div>Oops, an error occurred</div>;
     }
 
-    const agreementStatus = agreement?.budget_line_items?.find((bli) => bli.status === "UNDER_REVIEW")
-        ? "In Review"
-        : "Draft";
+    const areAnyBudgetLinesInExecuting = agreement?.budget_line_items.some((bli) => bli.status === "IN_EXECUTION");
+    const areAnyBudgetLinesObligated = agreement?.budget_line_items.some((bli) => bli.status === "OBLIGATED");
+    const isAgreementEditable = !areAnyBudgetLinesInExecuting && !areAnyBudgetLinesObligated;
 
-    if (agreementStatus !== "Draft" && agreementStatus !== "In Review") {
+    if (!isAgreementEditable) {
         return (
             <App>
-                <SimpleAlert
-                    type="error"
-                    heading="Error"
-                    message={`This Agreement cannot be edited because its status is ${agreement.status}.`}
-                ></SimpleAlert>
+                <SimpleAlert type="error" heading="Error" message={`This Agreement cannot be edited.`}></SimpleAlert>
+                <Link to="/" className="usa-button margin-top-4">
+                    Go back home
+                </Link>
             </App>
         );
     }

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.js
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.js
@@ -23,6 +23,8 @@ export const AgreementBudgetLines = ({ agreement, isEditMode, setIsEditMode }) =
                 details="This is a list of all budget lines within this agreement."
                 isEditMode={isEditMode}
                 setIsEditMode={setIsEditMode}
+                // TODO: this is not correct, but could be a good starting point for 1001
+                isAgreementEditable={true}
             />
             {isEditMode ? (
                 <StepCreateBudgetLines

--- a/frontend/src/pages/agreements/details/AgreementDetailHeader.js
+++ b/frontend/src/pages/agreements/details/AgreementDetailHeader.js
@@ -9,14 +9,15 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
  * @param {string} props.details - The details to display.
  * @param {boolean} props.isEditMode - Whether the edit mode is on.
  * @param {function} props.setIsEditMode - The function to set the edit mode.
+ * @param {boolean} props.isAgreementEditable - Whether the agreement is editable.
  * @returns {React.JSX.Element} - The rendered component.
  */
-export const AgreementDetailHeader = ({ heading, details, isEditMode, setIsEditMode }) => {
+export const AgreementDetailHeader = ({ heading, details, isEditMode, setIsEditMode, isAgreementEditable }) => {
     return (
         <>
             <div className="display-flex flex-justify flex-align-center">
                 <h2 className="font-sans-lg">{heading}</h2>
-                {!isEditMode && (
+                {!isEditMode && isAgreementEditable && (
                     <button
                         id="edit"
                         className="hover:text-underline cursor-pointer"
@@ -42,6 +43,7 @@ AgreementDetailHeader.propTypes = {
     details: PropTypes.string.isRequired,
     isEditMode: PropTypes.bool.isRequired,
     setIsEditMode: PropTypes.func.isRequired,
+    isAgreementEditable: PropTypes.bool.isRequired,
 };
 
 export default AgreementDetailHeader;

--- a/frontend/src/pages/agreements/details/AgreementDetails.js
+++ b/frontend/src/pages/agreements/details/AgreementDetails.js
@@ -28,6 +28,9 @@ const AgreementDetails = ({ agreement, projectOfficer, isEditMode, setIsEditMode
         p[status]++;
         return p;
     }, {});
+    const areAnyBudgetLinesInExecuting = blis.some((bli) => bli.status === "IN_EXECUTION");
+    const areAnyBudgetLinesObligated = blis.some((bli) => bli.status === "OBLIGATED");
+    const isAgreementEditable = !areAnyBudgetLinesInExecuting && !areAnyBudgetLinesObligated;
 
     return (
         <div>
@@ -36,6 +39,7 @@ const AgreementDetails = ({ agreement, projectOfficer, isEditMode, setIsEditMode
                 details="The summary below shows the budget lines and spending for this agreement."
                 isEditMode={isEditMode}
                 setIsEditMode={setIsEditMode}
+                isAgreementEditable={isAgreementEditable}
             />
             <div className="display-flex flex-justify">
                 <AgreementTotalBudgetLinesCard

--- a/frontend/src/pages/agreements/review/ReviewAgreement.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.jsx
@@ -103,6 +103,10 @@ export const ReviewAgreement = ({ agreement_id }) => {
     const areThereBudgetLineErrors = budgetLinePageErrorsExist || budgetLineErrorsExist;
 
     const anyBudgetLinesAreDraft = agreement.budget_line_items.some((item) => item.status === "DRAFT");
+    const anyBudgetLinesInExecuting = agreement.budget_line_items.some((item) => item.status === "IN_EXECUTING");
+    const anyBudgetLinesObligated = agreement.budget_line_items.some((item) => item.status === "OBLIGATED");
+    const isAgreementEditable = !anyBudgetLinesInExecuting && !anyBudgetLinesObligated;
+
     const handleSendToApproval = () => {
         if (anyBudgetLinesAreDraft) {
             agreement?.budget_line_items.forEach((bli) => {
@@ -301,17 +305,22 @@ export const ReviewAgreement = ({ agreement_id }) => {
             <PreviewTable readOnly={true} budgetLinesAdded={agreement?.budget_line_items} isReviewMode={true} />
             <div className="grid-row flex-justify-end margin-top-1">
                 <button
-                    className="usa-button usa-button--outline margin-right-2"
+                    className={`usa-button usa-button--outline margin-right-2 ${
+                        !isAgreementEditable ? "usa-tooltip" : ""
+                    }`}
                     data-cy="edit-agreement-btn"
+                    title={!isAgreementEditable ? "Agreement is not editable" : ""}
                     onClick={() => {
                         navigate(`/agreements/edit/${agreement?.id}?mode=review`);
                     }}
+                    disabled={!isAgreementEditable}
                 >
                     Edit
                 </button>
                 <button
-                    className="usa-button"
+                    className={`usa-button ${!anyBudgetLinesAreDraft ? "usa-tooltip" : ""}`}
                     data-cy="send-to-approval-btn"
+                    title={!anyBudgetLinesAreDraft ? "Agreement is not able to be reviewed" : ""}
                     onClick={handleSendToApproval}
                     disabled={!anyBudgetLinesAreDraft || !res.isValid()}
                 >


### PR DESCRIPTION
## What changed
- checks BLIs to see if any are in IN_EXECUTING or OBLIGATED
- hides edit button if Agreement is not editable
- pertaining to editing an Agreement from Agreement detail page

Does not cover
- wizard workflows 
- e2e tests

## Issue

#1362 

## How to test

1. Goto Agreement list and select first agreement // BLIs in DRAFT
2. should let you edit it
3. Goto Agreement list and select second agreement // BLIs in Obligated and Executing
4. should NOT let you edit it

## Screenshots

https://github.com/HHS/OPRE-OPS/assets/4629398/6c9b0631-ccce-49cf-badb-aa4b16defc40





