### PR TITLE
Ops 1394 add team members to bli

### DIFF
--- a/backend/models/cans.py
+++ b/backend/models/cans.py
@@ -466,6 +466,10 @@ class BudgetLineItem(BaseModel):
             )
         )
 
+    @property
+    def team_members(self):
+        return self.agreement.team_members if self.agreement else []
+
     @override
     def to_dict(self):
         d = super().to_dict()

--- a/backend/ops_api/ops/resources/budget_line_item_schemas.py
+++ b/backend/ops_api/ops/resources/budget_line_item_schemas.py
@@ -228,6 +228,13 @@ class QueryParameters:
 
 
 @dataclass
+class TeamMembers:
+    id: int
+    full_name: Optional[str] = None
+    email: Optional[str] = None
+
+
+@dataclass
 class BudgetLineItemResponse:
     id: int
     agreement_id: int
@@ -243,3 +250,4 @@ class BudgetLineItemResponse:
     date_needed: date = field(default=None, metadata={"format": "%Y-%m-%d"})
     portfolio_id: Optional[int] = None
     fiscal_year: Optional[int] = None
+    team_members: Optional[list[TeamMembers]] = field(default_factory=lambda: [])

--- a/backend/ops_api/tests/ops/can/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/can/test_budget_line_item.py
@@ -727,3 +727,10 @@ def test_budget_line_item_fiscal_year_null(auth_client, loaded_db, test_bli_no_n
     response = auth_client.get(f"/api/v1/budget-line-items/{test_bli_no_need_by_date.id}")
     assert response.status_code == 200
     assert response.json["fiscal_year"] is None
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_budget_line_item_team_members(loaded_db, test_bli):
+    team_members = test_bli.agreement.team_members
+    assert len(team_members) > 0
+    assert test_bli.team_members == team_members

--- a/backend/ops_api/tests/ops/can/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/can/test_budget_line_item.py
@@ -734,3 +734,10 @@ def test_budget_line_item_team_members(loaded_db, test_bli):
     team_members = test_bli.agreement.team_members
     assert len(team_members) > 0
     assert test_bli.team_members == team_members
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_budget_line_item_team_members_response(auth_client, loaded_db, test_bli):
+    response = auth_client.get(f"/api/v1/budget-line-items/{test_bli.id}")
+    assert response.status_code == 200
+    assert len(response.json["team_members"]) > 0

--- a/openapi.yml
+++ b/openapi.yml
@@ -1287,6 +1287,15 @@ components:
         fiscal_year:
           type: integer
           example: 1
+        team_members:
+          type: array
+          items:
+            type: array
+            example: [
+              { 'id': 1, 'full_name': 'Chris Fortunato', 'email': 'chris.fortunato@example.com' },
+              { 'id': 2, 'full_name': 'Amy Madigan', 'email': 'Amy.Madigan@example.com' },
+              { 'id': 3, 'full_name': 'Ivelisse Martinez-Beck', 'email': 'Ivelisse.Martinez-Beck@example.com' },
+            ]
 
     BudgetLineItemRequest:
       type: object


### PR DESCRIPTION
## What changed

Add `team_members` property to BLI.

## Issue

https://github.com/HHS/OPRE-OPS/issues/1394

## How to test

HTTP GET `/budget-line-items` and you should get back a `team_members` array in each BLI object.
