### PR TITLE
fixes React linting issue

### DIFF
--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -6,7 +6,6 @@
         "strict": true,
         "noEmit": true,
         "module": "ES2015",
-        "jsx": "react",
         "typeRoots": ["./node_modules/@types"]
     },
     "$schema": "https://json.schemastore.org/tsconfig",


### PR DESCRIPTION
## What changed

Getting red squiggles on React modules, but this setting was overriding the template in the jsonfig:

<img width="1204" alt="SCR-20230828-jict" src="https://github.com/HHS/OPRE-OPS/assets/4629398/9ddbd970-1e52-48df-9101-50d9d1e843fd">
