### PR TITLE
Ops 1379 bug squashing

### DIFF
--- a/backend/data_tools/src/import_static_data/load_db.py
+++ b/backend/data_tools/src/import_static_data/load_db.py
@@ -1,5 +1,5 @@
 import os
-from typing import Tuple
+from typing import Optional
 
 import sqlalchemy.engine
 from data_tools.environment.cloudgov import CloudGovConfig
@@ -8,7 +8,7 @@ from data_tools.environment.dev import DevConfig
 from data_tools.environment.local import LocalConfig
 from data_tools.environment.pytest import PytestConfig
 from data_tools.environment.test import TestConfig
-from models import *
+from models import BaseModel
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import configure_mappers
@@ -18,11 +18,9 @@ configure_mappers()
 
 def init_db(
     config: DataToolsConfig, db: Optional[Engine] = None
-) -> Tuple[sqlalchemy.engine.Engine, sqlalchemy.MetaData]:
+) -> tuple[sqlalchemy.engine.Engine, sqlalchemy.MetaData]:
     if not db:
-        engine = create_engine(
-            config.db_connection_string, echo=config.verbosity, future=True
-        )
+        engine = create_engine(config.db_connection_string, echo=config.verbosity, future=True)
     else:
         engine = db
     return engine, BaseModel.metadata

--- a/backend/models/base.py
+++ b/backend/models/base.py
@@ -5,7 +5,7 @@ from typing import Annotated, ClassVar, Final, TypeAlias, TypedDict, TypeVar, ca
 from marshmallow import Schema as MMSchema
 from models.mixins.repr import ReprMixin
 from models.mixins.serialize import SerializeMixin
-from sqlalchemy import Column, Integer, DateTime, ForeignKey, Numeric, func
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, Numeric, func
 from sqlalchemy.orm import declarative_base, declared_attr, mapped_column, registry, relationship
 from typing_extensions import Any, override
 

--- a/backend/models/history.py
+++ b/backend/models/history.py
@@ -42,7 +42,7 @@ class OpsDBHistory(BaseModel):
 
 # index for typical change history queries to find all changes for a record (class+row_key), with recent first
 index = Index(
-    'idx_ops_db_history_class_name_row_key_created_on',
+    "idx_ops_db_history_class_name_row_key_created_on",
     OpsDBHistory.class_name,
     OpsDBHistory.row_key,
     sa.desc(OpsDBHistory.created_on),

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -47,38 +47,37 @@ class User(BaseModel):
         "Portfolio",
         back_populates="team_leaders",
         secondary="portfolio_team_leaders",
-        viewonly=True
+        viewonly=True,
     )
 
     research_projects = relationship(
         "ResearchProject",
         back_populates="team_leaders",
         secondary="research_project_team_leaders",
-        viewonly=True
+        viewonly=True,
     )
 
     agreements = relationship(
         "Agreement",
         back_populates="team_members",
         secondary="agreement_team_members",
-        viewonly=True
+        viewonly=True,
     )
 
     contracts = relationship(
         "ContractAgreement",
         back_populates="support_contacts",
         secondary="contract_support_contacts",
-        viewonly=True
+        viewonly=True,
     )
 
     notifications = relationship(
-        "Notification", foreign_keys="Notification.recipient_id",
+        "Notification",
+        foreign_keys="Notification.recipient_id",
     )
-
 
     def get_user_id(self):
         return self.id
-
 
     @override
     def to_dict(self) -> dict[str, Any]:  # type: ignore [override]

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -429,26 +429,22 @@ def update_data(agreement: Agreement, data: dict[str, Any]) -> None:
         # subclass attributes won't have the old (deleted) value in get_history
         # unless they were loaded before setting
         _hack_to_fix_get_history = getattr(agreement, item)  # noqa: F841
-        if item in {"agreement_type"}:
-            pass
-        elif item not in {"team_members", "support_contacts"}:
-            if getattr(agreement, item) != data[item]:
-                setattr(agreement, item, data[item])
-                changed = True
+        match (item):
+            case "agreement_type":
+                pass
 
-        elif item == "team_members":
-            tmp_team_members = _get_user_list(data[item])
-            if tmp_team_members:
-                agreement.team_members = tmp_team_members
-            else:
-                agreement.team_members = []
+            case "team_members":
+                tmp_team_members = _get_user_list(data[item])
+                agreement.team_members = tmp_team_members if tmp_team_members else []
 
-        elif item == "support_contacts":
-            tmp_support_contacts = _get_user_list(data[item])
-            if tmp_support_contacts:
-                agreement.support_contacts = tmp_support_contacts
-            else:
-                agreement.support_contacts = []
+            case "support_contacts":
+                tmp_support_contacts = _get_user_list(data[item])
+                agreement.support_contacts = tmp_support_contacts if tmp_support_contacts else []
+
+            case _:
+                if getattr(agreement, item) != data[item]:
+                    setattr(agreement, item, data[item])
+                    changed = True
 
     if changed:
         for bli in agreement.budget_line_items:

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -424,6 +424,7 @@ def _get_user_list(data: Any):
 
 
 def update_data(agreement: Agreement, data: dict[str, Any]) -> None:
+    changed = False
     for item in data:
         # subclass attributes won't have the old (deleted) value in get_history
         # unless they were loaded before setting
@@ -431,7 +432,9 @@ def update_data(agreement: Agreement, data: dict[str, Any]) -> None:
         if item in {"agreement_type"}:
             pass
         elif item not in {"team_members", "support_contacts"}:
-            setattr(agreement, item, data[item])
+            if getattr(agreement, item) != data[item]:
+                setattr(agreement, item, data[item])
+                changed = True
 
         elif item == "team_members":
             tmp_team_members = _get_user_list(data[item])
@@ -447,8 +450,9 @@ def update_data(agreement: Agreement, data: dict[str, Any]) -> None:
             else:
                 agreement.support_contacts = []
 
-    for bli in agreement.budget_line_items:
-        bli.status = BudgetLineItemStatus.DRAFT
+    if changed:
+        for bli in agreement.budget_line_items:
+            bli.status = BudgetLineItemStatus.DRAFT
 
 
 def update_agreement(data: dict[str, Any], agreement: Agreement):

--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -424,7 +424,6 @@ def _get_user_list(data: Any):
 
 
 def update_data(agreement: Agreement, data: dict[str, Any]) -> None:
-    changed = False
     for item in data:
         # subclass attributes won't have the old (deleted) value in get_history
         # unless they were loaded before setting
@@ -442,13 +441,10 @@ def update_data(agreement: Agreement, data: dict[str, Any]) -> None:
                 agreement.support_contacts = tmp_support_contacts if tmp_support_contacts else []
 
             case _:
-                if getattr(agreement, item) != data[item]:
-                    setattr(agreement, item, data[item])
-                    changed = True
+                setattr(agreement, item, data[item])
 
-    if changed:
-        for bli in agreement.budget_line_items:
-            bli.status = BudgetLineItemStatus.DRAFT
+    for bli in agreement.budget_line_items:
+        bli.status = BudgetLineItemStatus.DRAFT
 
 
 def update_agreement(data: dict[str, Any], agreement: Agreement):

--- a/backend/ops_api/ops/resources/budget_line_items.py
+++ b/backend/ops_api/ops/resources/budget_line_items.py
@@ -334,6 +334,15 @@ def validate_and_normalize_request_data(schema: Schema) -> dict[str, Any]:
         and value != data.get(key, None)
     }  # only keep the attributes from the request body
 
+    from pprint import pprint
+    print("*"*80)
+    print(f">>> Updating BLI with {schema.context['method']} <<<")
+    print("*"*80)
+    pprint(data)
+    print("-"*80)
+    pprint(change_data)
+    print("^"*80)
+
     data |= change_data
 
     with suppress(AttributeError):

--- a/backend/ops_api/ops/resources/budget_line_items.py
+++ b/backend/ops_api/ops/resources/budget_line_items.py
@@ -334,15 +334,6 @@ def validate_and_normalize_request_data(schema: Schema) -> dict[str, Any]:
         and value != data.get(key, None)
     }  # only keep the attributes from the request body
 
-    from pprint import pprint
-    print("*"*80)
-    print(f">>> Updating BLI with {schema.context['method']} <<<")
-    print("*"*80)
-    pprint(data)
-    print("-"*80)
-    pprint(change_data)
-    print("^"*80)
-
     data |= change_data
 
     with suppress(AttributeError):

--- a/backend/ops_api/ops/resources/budget_line_items.py
+++ b/backend/ops_api/ops/resources/budget_line_items.py
@@ -319,9 +319,7 @@ def validate_and_normalize_request_data(schema: Schema) -> dict[str, Any]:
     existing_bli = current_app.db_session.scalar(bli_stmt)
     try:
         data = {
-            key: value
-            for key, value in existing_bli.to_dict().items()
-            if key in request.json
+            key: value for key, value in existing_bli.to_dict().items() if key in request.json
         }  # only keep the attributes from the request body
     except AttributeError:
         data = {}
@@ -329,9 +327,7 @@ def validate_and_normalize_request_data(schema: Schema) -> dict[str, Any]:
     change_data = {
         key: value
         for key, value in change_data.items()
-        if key not in {"status", "id"}
-        and key in request.json
-        and value != data.get(key, None)
+        if key not in {"status", "id"} and key in request.json and value != data.get(key, None)
     }  # only keep the attributes from the request body
 
     data |= change_data

--- a/backend/ops_api/ops/resources/budget_line_items.py
+++ b/backend/ops_api/ops/resources/budget_line_items.py
@@ -121,7 +121,7 @@ class BudgetLineItemsItemAPI(BaseItemAPI):
 
                 if request.json.get("status") == BudgetLineItemStatus.UNDER_REVIEW.name:
                     with OpsEventHandler(OpsEventType.SEND_BLI_FOR_APPROVAL) as approval_meta:
-                        data = validate_and_normalize_request_data_for_put(self._put_schema)
+                        data = validate_and_normalize_request_data(self._put_schema)
                         budget_line_item = self.update_and_commit_budget_line_item(data, id)
 
                         approval_meta.metadata.update({"bli": budget_line_item.to_dict()})
@@ -130,7 +130,7 @@ class BudgetLineItemsItemAPI(BaseItemAPI):
                             f"{message_prefix}: BLI Sent For Approval: {budget_line_item.to_dict()}"
                         )
                 else:
-                    data = validate_and_normalize_request_data_for_put(self._put_schema)
+                    data = validate_and_normalize_request_data(self._put_schema)
                     budget_line_item = self.update_and_commit_budget_line_item(data, id)
 
                 bli_dict = self._response_schema.dump(budget_line_item)
@@ -165,7 +165,7 @@ class BudgetLineItemsItemAPI(BaseItemAPI):
 
                 if request.json.get("status") == BudgetLineItemStatus.UNDER_REVIEW.name:
                     with OpsEventHandler(OpsEventType.SEND_BLI_FOR_APPROVAL) as approval_meta:
-                        data = validate_and_normalize_request_data_for_patch(self._patch_schema)
+                        data = validate_and_normalize_request_data(self._patch_schema)
                         budget_line_item = self.update_and_commit_budget_line_item(data, id)
 
                         approval_meta.metadata.update({"bli": budget_line_item.to_dict()})
@@ -174,7 +174,7 @@ class BudgetLineItemsItemAPI(BaseItemAPI):
                             f"{message_prefix}: BLI Sent For Approval: {budget_line_item.to_dict()}"
                         )
                 else:
-                    data = validate_and_normalize_request_data_for_patch(self._patch_schema)
+                    data = validate_and_normalize_request_data(self._patch_schema)
                     budget_line_item = self.update_and_commit_budget_line_item(data, id)
 
                 bli_dict = self._response_schema.dump(budget_line_item)
@@ -313,68 +313,40 @@ def update_budget_line_item(data: dict[str, Any], id: int):
     return budget_line_item
 
 
-def validate_and_normalize_request_data_for_patch(schema: Schema) -> dict[str, Any]:
-    data = schema.dump(schema.load(request.json, unknown=EXCLUDE))
-    data = {k: v for (k, v) in data.items() if k in request.json}  # only keep the attributes from the request body
-
-    with suppress(KeyError):
-        if data["status"]:
-            new_status = BudgetLineItemStatus[data["status"]]
-            if new_status == BudgetLineItemStatus.PLANNED:
-                new_status = BudgetLineItemStatus.DRAFT
-            data["status"] = new_status
-        else:
-            data["status"] = None
-
-    with suppress(KeyError):
-        if data["date_needed"]:
-            data["date_needed"] = date.fromisoformat(data["date_needed"])
-        else:
-            data["date_needed"] = None
-
-    return data
-
-
-def validate_and_normalize_request_data_for_put(schema: Schema) -> dict[str, Any]:
+def validate_and_normalize_request_data(schema: Schema) -> dict[str, Any]:
     id = schema.context["id"]
-    budget_line_item_stmt = select(BudgetLineItem).where(BudgetLineItem.id == id)
-    budget_line_item = current_app.db_session.scalar(budget_line_item_stmt)
-    change_obj = schema.load(request.json, partial=True, unknown=EXCLUDE)
-    change_data = schema.dump(change_obj)
+    bli_stmt = select(BudgetLineItem).where(BudgetLineItem.id == id)
+    existing_bli = current_app.db_session.scalar(bli_stmt)
+    try:
+        data = {
+            key: value
+            for key, value in existing_bli.to_dict().items()
+            if key in request.json
+        }  # only keep the attributes from the request body
+    except AttributeError:
+        data = {}
+    change_data = schema.dump(schema.load(request.json, unknown=EXCLUDE))
     change_data = {
-        key: getattr(change_obj, key)
-        for key in change_data
+        key: value
+        for key, value in change_data.items()
         if key not in {"status", "id"}
         and key in request.json
-        and getattr(budget_line_item, key) != getattr(change_obj, key)
-    }
+        and value != data.get(key, None)
+    }  # only keep the attributes from the request body
 
-    if change_data and budget_line_item.status == BudgetLineItemStatus.PLANNED:
-        status = BudgetLineItemStatus.DRAFT
-    else:
-        status = getattr(change_obj, "status", budget_line_item.status)
-        if not isinstance(status, BudgetLineItemStatus):
-            status = budget_line_item.status
-    print(f">>>>>> ID: {id}; orig_status: {budget_line_item.status}; change_status: {change_obj.status}; status: {status}")
+    data |= change_data
 
-    if status != budget_line_item.status:
-        change_data["status"] = status
+    with suppress(AttributeError):
+        try:
+            status = BudgetLineItemStatus[request.json["status"]]
+        except KeyError:
+            status = existing_bli.status
 
-    change_data["id"] = id
+        if len(change_data) > 0 and status == BudgetLineItemStatus.PLANNED:
+            status = BudgetLineItemStatus.DRAFT
+        data["status"] = status
 
-    data = {
-        key: (
-            BudgetLineItemStatus[value] if key == "status"
-            else date.fromisoformat(value) if key == "date_needed"
-            else value
-        )
-        for key, value in budget_line_item.to_dict().items()
-    }
-    data.update(change_data)
-
-    from pprint import pprint
-    print("*"*80)
-    pprint(data)
-    print("^"*80)
+    with suppress(KeyError):
+        data["date_needed"] = date.fromisoformat(data["date_needed"])
 
     return data

--- a/backend/ops_api/tests/ops/can/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/can/test_budget_line_item.py
@@ -372,13 +372,13 @@ def test_put_budget_line_items_minimum(auth_client, loaded_db):
         assert response.status_code == 200
         assert response.json["line_description"] == "Updated LI 1"
         assert response.json["id"] == 1000
-        assert response.json["comments"] is None
+        assert response.json["comments"] == "blah blah"
         assert response.json["agreement_id"] == 1
-        assert response.json["can_id"] is None
-        assert response.json["amount"] is None
-        assert response.json["status"] is None
-        assert response.json["date_needed"] is None
-        assert response.json["psc_fee_amount"] is None
+        assert response.json["can_id"] == 1
+        assert response.json["amount"] == 100.12
+        assert response.json["status"] == "DRAFT"
+        assert response.json["date_needed"] == "2043-01-01"
+        assert response.json["psc_fee_amount"] == 1.23
         assert response.json["created_on"] != response.json["updated_on"]
 
     finally:


### PR DESCRIPTION
## What changed

This fixes the bug found that when an Agreement's BLIs were edited and then saved, ALL of the BLIs, whether they were edited or not, that were in `PLANNED` would be set to `DRAFT` status.

The corrective was to validate if a BLI actually was changed or not. If not, then the status will not be changed.

## Issue

#1379 

## How to test

Start up OPS locally
Log in as an admin
Navigate to Agreements
Edit "DIRECT ALLOCATION #2: African American Child and Family Research Center"
Go to Budget Lines tab
Choose to edit the BLIs.
Select 1 of the BLIs in `PLANNED`, change something, save the BLI.
Go to bottom of page, save all changes.
Notice that only that 1 `PLANNED` BLI is now set to `DRAFT`, while all other `PLANNED` BLIs remain in their current status.

## Screenshots

<img width="1086" alt="Screenshot 2023-09-01 at 15 26 31" src="https://github.com/HHS/OPRE-OPS/assets/881707/b3f7ee9a-639b-488a-9df5-79c88caad4e0">

## Links

N/A
