### PR TITLE
Moves Alert to Agreement Details parent

### DIFF
--- a/frontend/cypress/e2e/agreementDetailsEdit.cy.js
+++ b/frontend/cypress/e2e/agreementDetailsEdit.cy.js
@@ -83,7 +83,9 @@ it("edit an agreement", () => {
                 expect(body.message).to.equal("Agreement updated");
             })
             .then(cy.log);
-
+        cy.get(".usa-alert__body").should("contain", "Agreement Draft Saved");
+        // eslint-disable-next-line cypress/no-unnecessary-waiting
+        cy.wait(6000);
         cy.get("h1").should("have.text", "Test Edit Title");
         cy.get("#edit").should("exist");
 

--- a/frontend/src/components/UI/WizardSteps/StepCreateBudgetLines/StepCreateBudgetLines.jsx
+++ b/frontend/src/components/UI/WizardSteps/StepCreateBudgetLines/StepCreateBudgetLines.jsx
@@ -440,16 +440,7 @@ export const StepCreateBudgetLines = ({
                 <button
                     className="usa-button"
                     data-cy="continue-btn"
-                    onClick={() => {
-                        saveBudgetLineItems;
-                        globalDispatch(
-                            setAlert({
-                                type: "success",
-                                heading: "Success",
-                                message: "Budget Lines have been saved.",
-                            })
-                        );
-                    }}
+                    onClick={saveBudgetLineItems}
                     disabled={isReviewMode && !res.isValid()}
                 >
                     {isReviewMode ? "Review" : continueBtnText}

--- a/frontend/src/components/UI/WizardSteps/StepCreateBudgetLines/StepCreateBudgetLines.jsx
+++ b/frontend/src/components/UI/WizardSteps/StepCreateBudgetLines/StepCreateBudgetLines.jsx
@@ -440,7 +440,16 @@ export const StepCreateBudgetLines = ({
                 <button
                     className="usa-button"
                     data-cy="continue-btn"
-                    onClick={saveBudgetLineItems}
+                    onClick={() => {
+                        saveBudgetLineItems;
+                        globalDispatch(
+                            setAlert({
+                                type: "success",
+                                heading: "Success",
+                                message: "Budget Lines have been saved.",
+                            })
+                        );
+                    }}
                     disabled={isReviewMode && !res.isValid()}
                 >
                     {isReviewMode ? "Review" : continueBtnText}

--- a/frontend/src/pages/agreements/details/Agreement.js
+++ b/frontend/src/pages/agreements/details/Agreement.js
@@ -1,17 +1,20 @@
-import App from "../../../App";
 import { useParams, Route, Routes } from "react-router-dom";
-import { useGetAgreementByIdQuery } from "../../../api/opsAPI";
-import React, { useEffect, useState } from "react";
-import { getUser } from "../../../api/getUser";
+import { useSelector } from "react-redux";
+import { useEffect, useState } from "react";
+import App from "../../../App";
 import Breadcrumb from "../../../components/UI/Header/Breadcrumb";
 import DetailsTabs from "../../../components/Agreements/DetailsTabs/DetailsTabs";
 import AgreementDetails from "./AgreementDetails";
 import AgreementBudgetLines from "./AgreementBudgetLines";
+import Alert from "../../../components/UI/Alert";
+import { getUser } from "../../../api/getUser";
+import { useGetAgreementByIdQuery } from "../../../api/opsAPI";
 
 const Agreement = () => {
+    const isGlobalAlertActive = useSelector((state) => state.alert.isActive);
     const urlPathParams = useParams();
     const agreementId = parseInt(urlPathParams.id);
-    const [isEditMode, setIsEditMode] = React.useState(false);
+    const [isEditMode, setIsEditMode] = useState(false);
     const [projectOfficer, setProjectOfficer] = useState({});
 
     const searchParams = new URLSearchParams(location.search);
@@ -53,6 +56,7 @@ const Agreement = () => {
     return (
         <App>
             <Breadcrumb currentName={`${agreement.name}`} />
+            {!isEditMode && isGlobalAlertActive && <Alert />}
             <h1 className={`font-sans-2xl margin-0 text-brand-primary`}>{agreement.name}</h1>
             <h2 className={`font-sans-3xs text-normal margin-top-1 margin-bottom-2`}>
                 {agreement.research_project?.title}

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.js
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.js
@@ -6,7 +6,6 @@ import AgreementDetailHeader from "./AgreementDetailHeader";
 import { CreateBudgetLinesProvider } from "../../../components/UI/WizardSteps/StepCreateBudgetLines/context";
 import BudgetLinesTable from "../../../components/UI/BudgetLinesTable";
 import StepCreateBudgetLines from "../../../components/UI/WizardSteps/StepCreateBudgetLines/StepCreateBudgetLines";
-import Alert from "../../../components/UI/Alert";
 
 /**
  * Renders Agreement budget lines view
@@ -18,8 +17,6 @@ import Alert from "../../../components/UI/Alert";
  */
 export const AgreementBudgetLines = ({ agreement, isEditMode, setIsEditMode }) => {
     const navigate = useNavigate();
-    const isGlobalAlertActive = useSelector((state) => state.alert.isActive);
-
     // Checks for who can edit budget lines
     const loggedInUserId = useSelector((state) => state?.auth?.activeUser?.id);
     const isUserAgreementCreator = agreement?.created_by === loggedInUserId;
@@ -39,7 +36,6 @@ export const AgreementBudgetLines = ({ agreement, isEditMode, setIsEditMode }) =
 
     return (
         <CreateBudgetLinesProvider>
-            {!isEditMode && isGlobalAlertActive && <Alert />}
             <AgreementDetailHeader
                 heading="Budget Lines"
                 details="This is a list of all budget lines within this agreement."


### PR DESCRIPTION
## What changed

Moves Alert to Agreement Details parent
- originally on the Agreement BLI tab
- will need to figure out to show BLI group updates

## Issue

#1432 

## How to test

1. Edit an Agreement from the Agreement Detail page
2. See Success alert

## Screenshots

<img width="1163" alt="image" src="https://github.com/HHS/OPRE-OPS/assets/4629398/2aa97ddb-ed23-4ebd-a926-812c874bf8c5">

