### PR TITLE
Agreement History - Infinite Scrolling

### DIFF
--- a/backend/ops_api/ops/history.py
+++ b/backend/ops_api/ops/history.py
@@ -68,7 +68,7 @@ def build_audit(obj, event_type: OpsDBHistoryType) -> DbRecordAudit:  # noqa: C9
             if old_val:
                 original[key] = old_val
             # exclude Enums that didn't really change
-            if old_val == new_val and isinstance(hist.deleted[0], Enum):
+            if hist.deleted and isinstance(hist.deleted[0], Enum) and old_val == new_val:
                 continue
             diff[key] = new_val
             if event_type == OpsDBHistoryType.NEW:

--- a/backend/ops_api/ops/history.py
+++ b/backend/ops_api/ops/history.py
@@ -67,6 +67,9 @@ def build_audit(obj, event_type: OpsDBHistoryType) -> DbRecordAudit:  # noqa: C9
             new_val = convert_for_jsonb(hist.added[0]) if hist.added else None
             if old_val:
                 original[key] = old_val
+            # exclude Enums that didn't really change
+            if old_val == new_val and isinstance(hist.deleted[0], Enum):
+                continue
             diff[key] = new_val
             if event_type == OpsDBHistoryType.NEW:
                 if new_val:

--- a/backend/ops_api/ops/resources/agreement_history.py
+++ b/backend/ops_api/ops/resources/agreement_history.py
@@ -50,16 +50,8 @@ class AgreementHistoryListAPI(BaseListAPI):
             if offset:
                 stmt = stmt.offset(int(offset))
 
-            print(f"\n\n!!!!~~~~~~~~SQL for Agreement History {id=}, {offset=}, {limit=}~~~~~~~~\n")
-            from sqlalchemy.dialects import postgresql
-            print(str(stmt.compile(
-                dialect=postgresql.dialect(),
-                compile_kwargs={"literal_binds": True})))
-
             results = current_app.db_session.execute(stmt).all()
             if results:
-                for row in results:
-                    print(row[0].id)
                 response = make_response_with_headers([build_agreement_history_dict(row[0], row[1]) for row in results])
             else:
                 response = make_response_with_headers({}, 404)

--- a/backend/ops_api/ops/resources/agreement_history.py
+++ b/backend/ops_api/ops/resources/agreement_history.py
@@ -48,10 +48,18 @@ class AgreementHistoryListAPI(BaseListAPI):
             stmt = stmt.order_by(OpsDBHistory.created_on.desc())
             stmt = stmt.limit(limit)
             if offset:
-                stmt = stmt.offset(int(limit))
+                stmt = stmt.offset(int(offset))
+
+            print(f"\n\n!!!!~~~~~~~~SQL for Agreement History {id=}, {offset=}, {limit=}~~~~~~~~\n")
+            from sqlalchemy.dialects import postgresql
+            print(str(stmt.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True})))
 
             results = current_app.db_session.execute(stmt).all()
             if results:
+                for row in results:
+                    print(row[0].id)
                 response = make_response_with_headers([build_agreement_history_dict(row[0], row[1]) for row in results])
             else:
                 response = make_response_with_headers({}, 404)

--- a/frontend/cypress/e2e/agreementDetailsEdit.cy.js
+++ b/frontend/cypress/e2e/agreementDetailsEdit.cy.js
@@ -55,6 +55,12 @@ it("edit an agreement", () => {
 
         cy.intercept("PATCH", "**/agreements/**").as("patchAgreement");
         cy.visit(`/agreements/${agreementId}`);
+        cy.get("h1").should("have.text", "Test Contract");
+        cy.get('[data-cy="details-left-col"] > :nth-child(4)').should("have.text", "History");
+        cy.get('[data-cy="agreement-history-container"]').should("exist");
+        cy.get('[data-cy="agreement-history-container"]').scrollIntoView();
+        cy.get('[data-cy="agreement-history-list"]').should("exist");
+        cy.get('[data-cy="agreement-history-list"] > :nth-child(1) > .margin-0').should("exist");
         cy.get('[data-cy="agreement-history-list"] > :nth-child(1) > .margin-0').should(
             "have.text",
             'New Contract Agreement, "Test Contract", created by Admin Demo.'

--- a/frontend/cypress/e2e/agreementDetailsEdit.cy.js
+++ b/frontend/cypress/e2e/agreementDetailsEdit.cy.js
@@ -99,16 +99,24 @@ it("edit an agreement", () => {
             "have.text",
             'Contract Agreement, "Test Edit Title", updated by Admin Demo.'
         );
-        // there's currently a false change for agreement_reason, these child indexes will need to changed when that is fixed
-        cy.get(":nth-child(1) > dl > :nth-child(3)").should("have.text", "Description");
-        cy.get(":nth-child(1) > dl > :nth-child(4)").should(
+        cy.get('[data-cy="agreement-history-list"] > :nth-child(1) > dl > :nth-child(1)').should(
+            "have.text",
+            "Description"
+        );
+        cy.get('[data-cy="agreement-history-list"] > :nth-child(1) > dl > :nth-child(2)').should(
             "contain.text",
             "changed from “Test Description” to “Test Description more text”"
         );
-        cy.get("dl > :nth-child(5)").should("have.text", "Title");
-        cy.get("dl > :nth-child(6)").should("contain.text", "changed from “Test Contract” to “Test Edit Title”");
-        cy.get("dl > :nth-child(7)").should("have.text", "Notes");
-        cy.get("dl > :nth-child(8)").should("contain.text", "changed from “Test Notes” to “Test Notestest edit notes”");
+        cy.get('[data-cy="agreement-history-list"] > :nth-child(1) > dl > :nth-child(3)').should("have.text", "Title");
+        cy.get('[data-cy="agreement-history-list"] > :nth-child(1) > dl > :nth-child(4)').should(
+            "contain.text",
+            "changed from “Test Contract” to “Test Edit Title”"
+        );
+        cy.get('[data-cy="agreement-history-list"] > :nth-child(1) > dl > :nth-child(5)').should("have.text", "Notes");
+        cy.get('[data-cy="agreement-history-list"] > :nth-child(1) > dl > :nth-child(6)').should(
+            "contain.text",
+            "changed from “Test Notes” to “Test Notestest edit notes”"
+        );
 
         cy.request({
             method: "DELETE",

--- a/frontend/src/api/getAgreementHistory.js
+++ b/frontend/src/api/getAgreementHistory.js
@@ -1,0 +1,11 @@
+import ApplicationContext from "../applicationContext/ApplicationContext";
+
+export const getAgreementHistoryByIdAndPage = async (id, page) => {
+    const pageSize = 3;
+    const limit = pageSize;
+    const offset = pageSize * (page - 1);
+    const api_version = ApplicationContext.get().helpers().backEndConfig.apiVersion;
+    const endpoint = `/api/${api_version}/agreements/${id}/history/?limit=${limit}&offset=${offset}`;
+    const responseData = await ApplicationContext.get().helpers().callBackend(endpoint, "get");
+    return responseData;
+};

--- a/frontend/src/api/getAgreementHistory.js
+++ b/frontend/src/api/getAgreementHistory.js
@@ -1,7 +1,7 @@
 import ApplicationContext from "../applicationContext/ApplicationContext";
 
 export const getAgreementHistoryByIdAndPage = async (id, page) => {
-    const pageSize = 3;
+    const pageSize = 20;
     const limit = pageSize;
     const offset = pageSize * (page - 1);
     const api_version = ApplicationContext.get().helpers().backEndConfig.apiVersion;

--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -35,17 +35,6 @@ export const opsApi = createApi({
             query: (id) => `/agreements/${id}`,
             providesTags: ["Agreements"],
         }),
-        getAgreementHistoryById: builder.query({
-            // https://stackoverflow.com/a/74844699
-            query: ({ id, page }) => {
-                const pageSize = 3;
-                const limit = pageSize;
-                const offset = pageSize * (page - 1);
-                return `/agreements/${id}/history/?limit=${limit}&offset=${offset}`;
-            },
-            // query: ({ id, page }) => `/agreements/${id}/history/?limit=20`,
-            providesTags: ["AgreementHistory"],
-        }),
         addAgreement: builder.mutation({
             query: (data) => {
                 return {
@@ -203,7 +192,6 @@ export const opsApi = createApi({
 export const {
     useGetAgreementsQuery,
     useGetAgreementByIdQuery,
-    useGetAgreementHistoryByIdQuery,
     useAddAgreementMutation,
     useUpdateAgreementMutation,
     useDeleteAgreementMutation,

--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -36,7 +36,14 @@ export const opsApi = createApi({
             providesTags: ["Agreements"],
         }),
         getAgreementHistoryById: builder.query({
-            query: (id) => `/agreements/${id}/history/?limit=20`,
+            // https://stackoverflow.com/a/74844699
+            query: ({ id, page }) => {
+                const pageSize = 3;
+                const limit = pageSize;
+                const offset = pageSize * (page - 1);
+                return `/agreements/${id}/history/?limit=${limit}&offset=${offset}`;
+            },
+            // query: ({ id, page }) => `/agreements/${id}/history/?limit=20`,
             providesTags: ["AgreementHistory"],
         }),
         addAgreement: builder.mutation({

--- a/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryList.js
+++ b/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryList.js
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import { useGetAgreementHistoryByIdQuery } from "../../../api/opsAPI";
 import { historyData } from "../../../pages/agreements/details/data";
 import LogItem from "../../UI/LogItem";
 import { convertCodeForDisplay } from "../../../helpers/utils";
@@ -142,8 +141,8 @@ const AgreementHistoryList = ({ agreementHistory }) => {
     );
 };
 
-// AgreementHistoryList.propTypes = {
-//     agreementId: PropTypes.number.isRequired,
-// };
+AgreementHistoryList.propTypes = {
+    agreementHistory: PropTypes.arrayOf(Object),
+};
 
 export default AgreementHistoryList;

--- a/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryList.js
+++ b/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryList.js
@@ -125,9 +125,8 @@ const AgreementHistoryList = ({ agreementHistory }) => {
                     {agreementHistory.map((item, index) => (
                         <LogItem
                             key={index}
-                            title={item.id + ": " + item.created_by_user_full_name}
+                            title={item.created_by_user_full_name}
                             createdOn={item.created_on}
-                            // message={summaryMessage(item)}
                             message={summaryMessage(item)}
                         >
                             <ChangesDetails historyItem={item} />

--- a/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryList.js
+++ b/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryList.js
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import { historyData } from "../../../pages/agreements/details/data";
 import LogItem from "../../UI/LogItem";
 import { convertCodeForDisplay } from "../../../helpers/utils";
 import { Fragment } from "react";
@@ -120,7 +119,7 @@ const ChangesDetails = ({ historyItem }) => {
 const AgreementHistoryList = ({ agreementHistory }) => {
     return (
         <>
-            {historyData.length > 0 ? (
+            {agreementHistory && agreementHistory.length > 0 ? (
                 <ul className="usa-list--unstyled" data-cy="agreement-history-list">
                     {agreementHistory.map((item, index) => (
                         <LogItem

--- a/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryList.js
+++ b/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryList.js
@@ -1,0 +1,149 @@
+import PropTypes from "prop-types";
+import { useGetAgreementHistoryByIdQuery } from "../../../api/opsAPI";
+import { historyData } from "../../../pages/agreements/details/data";
+import LogItem from "../../UI/LogItem";
+import { convertCodeForDisplay } from "../../../helpers/utils";
+import { Fragment } from "react";
+
+const findObjectTitle = (historyItem) => {
+    if (historyItem.class_name === "BudgetLineItem") {
+        return historyItem.event_details.line_description;
+    } else {
+        return historyItem.event_details.name;
+    }
+};
+
+const summaryMessage = (historyItem) => {
+    const className = convertCodeForDisplay("className", historyItem.class_name);
+    const userFullName = historyItem.created_by_user_full_name;
+    const objectTitle = findObjectTitle(historyItem);
+    const classAndTitle = `${className}, "${objectTitle}",`;
+    if (historyItem.event_type === "NEW") {
+        return `New ${classAndTitle} created by ${userFullName}.`;
+    } else if (historyItem.event_type === "UPDATED") {
+        return `${classAndTitle} updated by ${userFullName}.`;
+    } else if (historyItem.event_type === "DELETED") {
+        return `${classAndTitle} deleted by ${userFullName}.`;
+    }
+    return `${className} ${historyItem.event_type} ${userFullName}`;
+};
+
+const getPropertyLabel = (className, fieldName) => {
+    if (className === "BudgetLineItem") return convertCodeForDisplay("budgetLineItemPropertyLabels", fieldName);
+    return convertCodeForDisplay("agreementPropertyLabels", fieldName);
+};
+
+const usersToNames = (users) => {
+    return users.map((user) => user.full_name);
+};
+
+const ChangesDetails = ({ historyItem }) => {
+    const rawChanges = historyItem.changes;
+    const eventType = historyItem.event_type;
+    if (eventType != "UPDATED") return;
+    const preparedChanges = Object.entries(rawChanges).map(([key, change]) => {
+        if ("collection_of" in change) {
+            const added = change.collection_of == "User" ? usersToNames(change.added) : change.added;
+            const deleted = change.collection_of == "User" ? usersToNames(change.deleted) : change.deleted;
+            return {
+                key: key,
+                propertyLabel: getPropertyLabel(historyItem.class_name, key),
+                isCollection: true,
+                added: added,
+                deleted: deleted,
+            };
+        } else if (key === "procurement_shop_id") {
+            const new_val = historyItem.event_details?.procurement_shop?.name;
+            return {
+                key: key,
+                propertyLabel: getPropertyLabel(historyItem.class_name, "procurement_shop"),
+                to: new_val,
+            };
+        } else if (key === "product_service_code_id") {
+            const new_val = historyItem.event_details?.product_service_code?.name;
+            return {
+                key: key,
+                propertyLabel: getPropertyLabel(historyItem.class_name, "product_service_code"),
+                to: new_val,
+            };
+        } else if (key === "project_officer") {
+            return {
+                key: key,
+                propertyLabel: getPropertyLabel(historyItem.class_name, "project_officer"),
+            };
+        } else if (key === "research_project_id") {
+            const new_val = historyItem.event_details?.research_project?.title;
+            return {
+                key: key,
+                propertyLabel: getPropertyLabel(historyItem.class_name, "research_project"),
+                to: new_val,
+            };
+        } else if (key === "can_id") {
+            const new_val = historyItem.event_details?.can?.number;
+            return {
+                key: key,
+                propertyLabel: getPropertyLabel(historyItem.class_name, "can"),
+                to: new_val,
+            };
+        } else
+            return {
+                key: key,
+                propertyLabel: getPropertyLabel(historyItem.class_name, key),
+                from: change.old,
+                to: change.new,
+            };
+    });
+
+    return (
+        <dl>
+            {preparedChanges.map((change, index) => (
+                <Fragment key={index}>
+                    <dt>{change.propertyLabel}</dt>
+                    <dd>
+                        {change.isCollection ? (
+                            <>
+                                {change.added && <> added: {JSON.stringify(change.added)}</>}
+                                {change.removed && <> removed: {JSON.stringify(change.deleted)}</>}
+                            </>
+                        ) : (
+                            <>
+                                changed {"from" in change && <>from &ldquo;{change.from}&rdquo; </>}
+                                {"to" in change && <>to &ldquo;{change.to}&rdquo;</>}
+                            </>
+                        )}
+                    </dd>
+                </Fragment>
+            ))}
+        </dl>
+    );
+};
+
+const AgreementHistoryList = ({ agreementHistory }) => {
+    return (
+        <>
+            {historyData.length > 0 ? (
+                <ul className="usa-list--unstyled" data-cy="agreement-history-list">
+                    {agreementHistory.map((item, index) => (
+                        <LogItem
+                            key={index}
+                            title={item.id + ": " + item.created_by_user_full_name}
+                            createdOn={item.created_on}
+                            // message={summaryMessage(item)}
+                            message={summaryMessage(item)}
+                        >
+                            <ChangesDetails historyItem={item} />
+                        </LogItem>
+                    ))}
+                </ul>
+            ) : (
+                <p>Sorry no history</p>
+            )}
+        </>
+    );
+};
+
+// AgreementHistoryList.propTypes = {
+//     agreementId: PropTypes.number.isRequired,
+// };
+
+export default AgreementHistoryList;

--- a/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryPanel.jsx
+++ b/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryPanel.jsx
@@ -29,7 +29,12 @@ const AgreementHistoryPanel = ({ agreementId }) => {
     const noData = !agreementHistory || agreementHistory.length == 0;
 
     return (
-        <div className="overflow-y-scroll" style={{ height: "15rem" }} tabIndex={0}>
+        <div
+            className="overflow-y-scroll"
+            style={{ height: "15rem" }}
+            tabIndex={0}
+            data-cy="agreement-history-container"
+        >
             {stopped && noData ? (
                 "Sorry, no history."
             ) : (

--- a/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryPanel.jsx
+++ b/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryPanel.jsx
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
-import { useEffect, useState } from "react";
-import { useGetAgreementHistoryByIdQuery } from "../../../api/opsAPI";
+import { useState } from "react";
 import AgreementHistoryList from "./AgreementHistoryList";
 import InfiniteScroll from "./InfiniteScroll";
 import { getAgreementHistoryByIdAndPage } from "../../../api/getAgreementHistory";
@@ -12,10 +11,8 @@ const AgreementHistoryPanel = ({ agreementId }) => {
     const [agreementHistory, setAgreementHistory] = useState([]);
 
     const fetchMoreData = async () => {
-        console.log(`fetchMoreData> stopped: ${stopped}, page: ${page}`);
         if (stopped) return;
         setIsLoading(true);
-        // Replace with your data fetching logic
         await getAgreementHistoryByIdAndPage(agreementId, page)
             .then(function (response) {
                 setAgreementHistory([...agreementHistory, ...response]);
@@ -23,7 +20,7 @@ const AgreementHistoryPanel = ({ agreementId }) => {
                 return response;
             })
             .catch(function (error) {
-                // console.log(error);
+                if (error.response.status !== 404) console.log("Error loading history:", error);
                 setStopped(true);
             });
         setIsLoading(false);

--- a/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryPanel.jsx
+++ b/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryPanel.jsx
@@ -3,50 +3,30 @@ import { useEffect, useState } from "react";
 import { useGetAgreementHistoryByIdQuery } from "../../../api/opsAPI";
 import AgreementHistoryList from "./AgreementHistoryList";
 import InfiniteScroll from "./InfiniteScroll";
+import { getAgreementHistoryByIdAndPage } from "../../../api/getAgreementHistory";
 
 const AgreementHistoryPanel = ({ agreementId }) => {
     const [page, setPage] = useState(1);
-    const [prevFirstId, setPrevFirstId] = useState(0);
+    const [isLoading, setIsLoading] = useState(false);
     const [stopped, setStopped] = useState(false);
     const [agreementHistory, setAgreementHistory] = useState([]);
-    const { isSuccess, isFetching, data, error, isLoading } = useGetAgreementHistoryByIdQuery(
-        { id: agreementId, page: page },
-        {
-            refetchOnMountOrArgChange: true,
-        }
-    );
 
-    useEffect(() => {
-        console.log(`isSuccess: ${isSuccess}`);
-        if (isSuccess) {
-            const firstId = data && data.length > 0 ? data[0].id : 0;
-            console.log(`isFetching: ${isFetching}, isSuccess: ${isSuccess}, page: ${page}, firstId: ${firstId}`);
-            console.log(data);
-            data.forEach((item) => {
-                console.log(`data.ID:${item.id}`);
+    const fetchMoreData = async () => {
+        console.log(`fetchMoreData> stopped: ${stopped}, page: ${page}`);
+        if (stopped) return;
+        setIsLoading(true);
+        // Replace with your data fetching logic
+        await getAgreementHistoryByIdAndPage(agreementId, page)
+            .then(function (response) {
+                setAgreementHistory([...agreementHistory, ...response]);
+                setPage(page + 1);
+                return response;
+            })
+            .catch(function (error) {
+                // console.log(error);
+                setStopped(true);
             });
-            // setAgreementHistory(data);
-            if (firstId !== prevFirstId) {
-                setAgreementHistory((prevHist) => [...prevHist, ...data]);
-                setPrevFirstId(firstId);
-            }
-        }
-    }, [isSuccess]);
-
-    useEffect(() => {
-        // if we run out of data (404) or have some other error then stop trying to get data
-        if (error) {
-            console.log("stopping for error", error);
-            setStopped(true);
-        }
-    }, [error]);
-
-    const fetchMoreData = () => {
-        console.log(`fetchMoreData> isLoading:${isLoading}, page:${page}, stop:${stopped}`);
-        if (isLoading || stopped || page > 5) {
-            return;
-        }
-        setPage(page + 1);
+        setIsLoading(false);
     };
 
     const noData = !agreementHistory || agreementHistory.length == 0;
@@ -58,7 +38,7 @@ const AgreementHistoryPanel = ({ agreementId }) => {
             ) : (
                 <>
                     <AgreementHistoryList agreementHistory={agreementHistory} />
-                    <InfiniteScroll fetchMoreData={fetchMoreData} isLoading={isLoading} />
+                    {!stopped && <InfiniteScroll fetchMoreData={fetchMoreData} isLoading={isLoading} />}
                 </>
             )}
         </div>

--- a/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryPanel.jsx
+++ b/frontend/src/components/Agreements/AgreementDetails/AgreementHistoryPanel.jsx
@@ -1,167 +1,67 @@
 import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
 import { useGetAgreementHistoryByIdQuery } from "../../../api/opsAPI";
-import { historyData } from "../../../pages/agreements/details/data";
-import LogItem from "../../UI/LogItem";
-import { convertCodeForDisplay } from "../../../helpers/utils";
-
-const findObjectTitle = (historyItem) => {
-    if (historyItem.class_name === "BudgetLineItem") {
-        return historyItem.event_details.line_description;
-    } else {
-        return historyItem.event_details.name;
-    }
-};
-
-const summaryMessage = (historyItem) => {
-    const className = convertCodeForDisplay("className", historyItem.class_name);
-    const userFullName = historyItem.created_by_user_full_name;
-    const objectTitle = findObjectTitle(historyItem);
-    const classAndTitle = `${className}, "${objectTitle}",`;
-    if (historyItem.event_type === "NEW") {
-        return `New ${classAndTitle} created by ${userFullName}.`;
-    } else if (historyItem.event_type === "UPDATED") {
-        return `${classAndTitle} updated by ${userFullName}.`;
-    } else if (historyItem.event_type === "DELETED") {
-        return `${classAndTitle} deleted by ${userFullName}.`;
-    }
-    return `${className} ${historyItem.event_type} ${userFullName}`;
-};
-
-const getPropertyLabel = (className, fieldName) => {
-    if (className === "BudgetLineItem") return convertCodeForDisplay("budgetLineItemPropertyLabels", fieldName);
-    return convertCodeForDisplay("agreementPropertyLabels", fieldName);
-};
-
-const usersToNames = (users) => {
-    return users.map((user) => user.full_name);
-};
-
-const ChangesDetails = ({ historyItem }) => {
-    const rawChanges = historyItem.changes;
-    const eventType = historyItem.event_type;
-    if (eventType != "UPDATED") return;
-    const preparedChanges = Object.entries(rawChanges).map(([key, change]) => {
-        if ("collection_of" in change) {
-            const added = change.collection_of == "User" ? usersToNames(change.added) : change.added;
-            const deleted = change.collection_of == "User" ? usersToNames(change.deleted) : change.deleted;
-            return {
-                propertyLabel: getPropertyLabel(historyItem.class_name, key),
-                isCollection: true,
-                added: added,
-                deleted: deleted,
-            };
-        } else if (key === "procurement_shop_id") {
-            const new_val = historyItem.event_details?.procurement_shop?.name;
-            return {
-                propertyLabel: getPropertyLabel(historyItem.class_name, "procurement_shop"),
-                to: new_val,
-            };
-        } else if (key === "product_service_code_id") {
-            const new_val = historyItem.event_details?.product_service_code?.name;
-            return {
-                propertyLabel: getPropertyLabel(historyItem.class_name, "product_service_code"),
-                to: new_val,
-            };
-        } else if (key === "project_officer") {
-            return {
-                propertyLabel: getPropertyLabel(historyItem.class_name, "project_officer"),
-            };
-        } else if (key === "research_project_id") {
-            const new_val = historyItem.event_details?.research_project?.title;
-            return {
-                propertyLabel: getPropertyLabel(historyItem.class_name, "research_project"),
-                to: new_val,
-            };
-        } else if (key === "can_id") {
-            const new_val = historyItem.event_details?.can?.number;
-            return {
-                propertyLabel: getPropertyLabel(historyItem.class_name, "can"),
-                to: new_val,
-            };
-        } else
-            return {
-                propertyLabel: getPropertyLabel(historyItem.class_name, key),
-                from: change.old,
-                to: change.new,
-            };
-    });
-
-    return (
-        <dl>
-            {preparedChanges.map((change) => (
-                <>
-                    <dt>{change.propertyLabel}</dt>
-                    <dd>
-                        {change.isCollection ? (
-                            <>
-                                {change.added && <> added: {JSON.stringify(change.added)}</>}
-                                {change.removed && <> removed: {JSON.stringify(change.deleted)}</>}
-                            </>
-                        ) : (
-                            <>
-                                changed {"from" in change && <>from &ldquo;{change.from}&rdquo; </>}
-                                {"to" in change && <>to &ldquo;{change.to}&rdquo;</>}
-                            </>
-                        )}
-                    </dd>
-                </>
-            ))}
-        </dl>
-    );
-};
+import AgreementHistoryList from "./AgreementHistoryList";
+import InfiniteScroll from "./InfiniteScroll";
 
 const AgreementHistoryPanel = ({ agreementId }) => {
-    const {
-        data: agreementHistory,
-        error: errorAgreementHistory,
-        isLoading: isLoadingAgreementHistory,
-    } = useGetAgreementHistoryByIdQuery(agreementId, {
-        refetchOnMountOrArgChange: true,
-    });
-
-    if (isLoadingAgreementHistory) {
-        return <div>Loading...</div>;
-    }
-    if (errorAgreementHistory) {
-        if (errorAgreementHistory.status === 404) {
-            return <p>Sorry no history</p>;
+    const [page, setPage] = useState(1);
+    const [prevFirstId, setPrevFirstId] = useState(0);
+    const [stopped, setStopped] = useState(false);
+    const [agreementHistory, setAgreementHistory] = useState([]);
+    const { isSuccess, isFetching, data, error, isLoading } = useGetAgreementHistoryByIdQuery(
+        { id: agreementId, page: page },
+        {
+            refetchOnMountOrArgChange: true,
         }
-        return (
-            <div>
-                Oops, an error occurred
-                <pre>{JSON.stringify(errorAgreementHistory, null, 2)}</pre>
-            </div>
-        );
-    }
+    );
 
-    if (!agreementHistory) {
-        return <p>Sorry no history</p>;
-    }
+    useEffect(() => {
+        console.log(`isSuccess: ${isSuccess}`);
+        if (isSuccess) {
+            const firstId = data && data.length > 0 ? data[0].id : 0;
+            console.log(`isFetching: ${isFetching}, isSuccess: ${isSuccess}, page: ${page}, firstId: ${firstId}`);
+            console.log(data);
+            data.forEach((item) => {
+                console.log(`data.ID:${item.id}`);
+            });
+            // setAgreementHistory(data);
+            if (firstId !== prevFirstId) {
+                setAgreementHistory((prevHist) => [...prevHist, ...data]);
+                setPrevFirstId(firstId);
+            }
+        }
+    }, [isSuccess]);
+
+    useEffect(() => {
+        // if we run out of data (404) or have some other error then stop trying to get data
+        if (error) {
+            console.log("stopping for error", error);
+            setStopped(true);
+        }
+    }, [error]);
+
+    const fetchMoreData = () => {
+        console.log(`fetchMoreData> isLoading:${isLoading}, page:${page}, stop:${stopped}`);
+        if (isLoading || stopped || page > 5) {
+            return;
+        }
+        setPage(page + 1);
+    };
+
+    const noData = !agreementHistory || agreementHistory.length == 0;
 
     return (
-        <>
-            {historyData.length > 0 ? (
-                <ul
-                    className="usa-list--unstyled overflow-y-scroll"
-                    style={{ height: "15rem" }}
-                    tabIndex={0}
-                    data-cy="agreement-history-list"
-                >
-                    {agreementHistory.map((item) => (
-                        <LogItem
-                            key={item.id}
-                            title={item.created_by_user_full_name}
-                            createdOn={item.created_on}
-                            message={summaryMessage(item)}
-                        >
-                            <ChangesDetails historyItem={item} />
-                        </LogItem>
-                    ))}
-                </ul>
+        <div className="overflow-y-scroll" style={{ height: "15rem" }} tabIndex={0}>
+            {stopped && noData ? (
+                "Sorry, no history."
             ) : (
-                <p>Sorry no history</p>
+                <>
+                    <AgreementHistoryList agreementHistory={agreementHistory} />
+                    <InfiniteScroll fetchMoreData={fetchMoreData} isLoading={isLoading} />
+                </>
             )}
-        </>
+        </div>
     );
 };
 

--- a/frontend/src/components/Agreements/AgreementDetails/InfiniteScroll.js
+++ b/frontend/src/components/Agreements/AgreementDetails/InfiniteScroll.js
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from "react";
+
+const InfiniteScroll = ({ fetchMoreData, isLoading }) => {
+    const observerRef = useRef();
+
+    const handleIntersection = (entries) => {
+        const entry = entries[0];
+        if (entry.isIntersecting && !isLoading) {
+            fetchMoreData();
+        }
+    };
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(handleIntersection, {
+            threshold: 0.1,
+        });
+
+        if (observerRef.current) {
+            observer.observe(observerRef.current);
+        }
+
+        return () => {
+            if (observerRef.current) {
+                observer.unobserve(observerRef.current);
+            }
+        };
+    }, [observerRef, isLoading, fetchMoreData]);
+
+    return (
+        <div ref={observerRef} style={{ minHeight: "2em" }}>
+            {isLoading && "Loading ..."}
+        </div>
+    );
+};
+
+export default InfiniteScroll;

--- a/frontend/src/components/Agreements/AgreementDetails/InfiniteScroll.js
+++ b/frontend/src/components/Agreements/AgreementDetails/InfiniteScroll.js
@@ -25,10 +25,11 @@ const InfiniteScroll = ({ fetchMoreData, isLoading }) => {
 
         return () => {
             if (observerRef.current) {
+                // eslint-disable-next-line react-hooks/exhaustive-deps
                 observer.unobserve(observerRef.current);
             }
         };
-    }, [observerRef, isLoading, fetchMoreData, isFetching]);
+    }, [observerRef, isLoading, fetchMoreData, isFetching]); // eslint-disable-line react-hooks/exhaustive-deps
 
     return <div ref={observerRef} style={{ minHeight: "2em" }} />;
 };

--- a/frontend/src/components/Agreements/AgreementDetails/InfiniteScroll.js
+++ b/frontend/src/components/Agreements/AgreementDetails/InfiniteScroll.js
@@ -1,12 +1,16 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const InfiniteScroll = ({ fetchMoreData, isLoading }) => {
+    const [isFetching, setIsFetching] = useState(false);
     const observerRef = useRef();
 
     const handleIntersection = (entries) => {
         const entry = entries[0];
-        if (entry.isIntersecting && !isLoading) {
-            fetchMoreData();
+        if (entry.isIntersecting && !isLoading && !isFetching) {
+            setIsFetching(true);
+            fetchMoreData().then(() => {
+                setIsFetching(false);
+            });
         }
     };
 
@@ -24,13 +28,9 @@ const InfiniteScroll = ({ fetchMoreData, isLoading }) => {
                 observer.unobserve(observerRef.current);
             }
         };
-    }, [observerRef, isLoading, fetchMoreData]);
+    }, [observerRef, isLoading, fetchMoreData, isFetching]);
 
-    return (
-        <div ref={observerRef} style={{ minHeight: "2em" }}>
-            {isLoading && "Loading ..."}
-        </div>
-    );
+    return <div ref={observerRef} style={{ minHeight: "2em" }} />;
 };
 
 export default InfiniteScroll;

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -175,7 +175,7 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
         };
         const { id, cleanData } = cleanAgreementForApi(data);
         if (id) {
-            updateAgreement({ id: id, data: cleanData })
+            await updateAgreement({ id: id, data: cleanData })
                 .unwrap()
                 .then((fulfilled) => {
                     console.log(`UPDATE: agreement updated: ${JSON.stringify(fulfilled, null, 2)}`);
@@ -199,7 +199,7 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
                     navigate("/error");
                 });
         } else {
-            addAgreement(cleanData)
+            await addAgreement(cleanData)
                 .unwrap()
                 .then((payload) => {
                     const newAgreementId = payload.id;
@@ -230,13 +230,13 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
     };
 
     const handleContinue = async () => {
-        saveAgreement();
+        await saveAgreement();
         if (isEditMode && setIsEditMode) setIsEditMode(false);
         await goToNext();
     };
 
     const handleDraft = async () => {
-        saveAgreement();
+        await saveAgreement();
         await navigate("/agreements");
     };
 

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -168,8 +168,6 @@ export const timeAgo = (dateParam) => {
     const seconds = Math.round((today - date) / 1000);
     const minutes = Math.round(seconds / 60);
 
-    console.log(`seconds: ${seconds}`);
-
     if (seconds < 5) {
         return "now";
     } else if (seconds < 60) {

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -110,6 +110,11 @@ const codesToDisplayText = {
         project_officer: "Project Officer",
         research_project: "Research Project",
         team_members: "Team Members",
+        contract_number: "Contract Number",
+        vendor: "Vendor",
+        delivered_status: "Delivered Status",
+        contract_type: "Contract Type",
+        support_contacts: "Support Contacts",
     },
     budgetLineItemPropertyLabels: {
         amount: "Amount",

--- a/frontend/src/pages/agreements/details/AgreementDetails.test.js
+++ b/frontend/src/pages/agreements/details/AgreementDetails.test.js
@@ -3,6 +3,7 @@ import "@testing-library/jest-dom";
 import AgreementDetails from "./AgreementDetails";
 import { Router } from "react-router-dom";
 import { createMemoryHistory } from "history";
+import TestApplicationContext from "../../../applicationContext/TestApplicationContext";
 
 const history = createMemoryHistory();
 
@@ -410,6 +411,19 @@ describe("AgreementDetails", () => {
     };
 
     test("renders correctly", () => {
+        TestApplicationContext.helpers().callBackend.mockImplementation(async () => {
+            return agreementHistoryData;
+        });
+
+        // IntersectionObserver isn't available in test environment
+        const mockIntersectionObserver = jest.fn();
+        mockIntersectionObserver.mockReturnValue({
+            observe: () => null,
+            unobserve: () => null,
+            disconnect: () => null,
+        });
+        window.IntersectionObserver = mockIntersectionObserver;
+
         render(
             <Router location={history.location} navigator={history}>
                 <AgreementDetails

--- a/frontend/src/pages/agreements/details/AgreementDetails.test.js
+++ b/frontend/src/pages/agreements/details/AgreementDetails.test.js
@@ -356,11 +356,6 @@ const agreementHistoryData = [
     },
 ];
 
-jest.mock("../../../api/opsAPI", () => ({
-    ...jest.requireActual("../../../api/opsAPI"),
-    useGetAgreementHistoryByIdQuery: () => jest.fn(() => ({ data: agreementHistoryData })),
-}));
-
 // This will reset all mocks after each test
 afterEach(() => {
     jest.resetAllMocks();

--- a/frontend/src/pages/agreements/details/AgreementDetailsView.js
+++ b/frontend/src/pages/agreements/details/AgreementDetailsView.js
@@ -170,7 +170,7 @@ const AgreementDetailsView = ({ agreement, projectOfficer }) => {
 
 AgreementDetailsView.propTypes = {
     agreement: PropTypes.object.isRequired,
-    projectOfficer: PropTypes.object.isRequired,
+    projectOfficer: PropTypes.object,
 };
 
 export default AgreementDetailsView;


### PR DESCRIPTION
## What changed

Implemented infinite scrolling for the Agreement History panel.
This gets pages of 20 records as one scrolls to the bottom of the history panel.
This implementation uses Axios instead of RTK due to issues with this approach to infinite scrolling and RTK.


## Issue

#1385 #1300 

## How to test

Edit an agreement and/or it's BLIs (multiple times) and view the history on the details page.  Scroll in the history panel to load more history records.  You can edit the pageSize in frontend/src/api/getAgreementHistory.js if you want to test with smaller pages and more loads.


## Screenshots

![image](https://github.com/HHS/OPRE-OPS/assets/127965976/16009312-469e-4049-9372-becfa483f6d2)

