### PR TITLE
fix: :bug: fixes basic user editing agreements

### DIFF
--- a/frontend/cypress/e2e/editAgreementAsBasicUser.cy.js
+++ b/frontend/cypress/e2e/editAgreementAsBasicUser.cy.js
@@ -1,0 +1,35 @@
+/// <reference types="cypress" />
+
+import { terminalLog, testLogin } from "./utils";
+
+beforeEach(() => {
+    testLogin("basic");
+    cy.visit(`/`);
+});
+
+afterEach(() => {
+    cy.injectAxe();
+    cy.checkA11y(null, null, terminalLog);
+});
+
+it("disables pencil icon from agreements list", () => {
+    cy.visit(`/agreements`);
+    cy.get("tbody").find("tr").first().trigger("mouseover");
+    cy.get("tbody").find("tr").first().find('[data-cy="edit-row"]').should("not.exist");
+});
+
+it("select first agreement and edit icon should not be visible", () => {
+    cy.visit(`/agreements/1`);
+    cy.get("#edit").should("not.exist");
+});
+
+it("review first agreement and edit button is disabled", () => {
+    cy.visit(`/agreements/approve/1`);
+    cy.get('[data-cy="edit-agreement-btn"]').should("be.disabled");
+});
+
+it("hack url and see error alert", () => {
+    cy.visit(`/agreements/edit/1`);
+    cy.get(".usa-alert__body").should("exist");
+    cy.get(".usa-alert__body").contains("This Agreement cannot be edited");
+});

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -31,6 +31,7 @@ const constants = {
 
 export const All_BUDGET_LINES_TABLE_HEADINGS = ["Description", "Agreement", "Need By", "FY", "CAN", "Total", "Status"];
 export const BUDGET_LINE_TABLE_HEADERS = ["Description", "Need By", "FY", "CAN", "Amount", "Fee", "Total", "Status"];
+export const DISABLED_ICON_CLASSES = "opacity-30 cursor-not-allowed";
 
 export const BLIS_PER_PAGE = 10;
 

--- a/frontend/src/pages/agreements/EditAgreement.js
+++ b/frontend/src/pages/agreements/EditAgreement.js
@@ -6,11 +6,11 @@ import CreateEditAgreement from "./CreateEditAgreement";
 import { useGetAgreementByIdQuery } from "../../api/opsAPI";
 import { getUser } from "../../api/getUser";
 import SimpleAlert from "../../components/UI/Alert/SimpleAlert";
+import { useIsUserAllowedToEditAgreement, useIsAgreementEditable } from "../../helpers/useAgreements";
 
 const EditAgreement = () => {
     const urlPathParams = useParams();
     const agreementId = parseInt(urlPathParams.id);
-
     const [projectOfficer, setProjectOfficer] = useState({});
 
     const {
@@ -20,6 +20,10 @@ const EditAgreement = () => {
     } = useGetAgreementByIdQuery(agreementId, {
         refetchOnMountOrArgChange: true,
     });
+
+    const canUserEditAgreement = useIsUserAllowedToEditAgreement(agreement?.id);
+    const isAgreementEditable = useIsAgreementEditable(agreement?.id);
+    const isEditable = isAgreementEditable && canUserEditAgreement;
 
     useEffect(() => {
         const getProjectOfficerSetState = async (id) => {
@@ -43,14 +47,10 @@ const EditAgreement = () => {
         return <div>Oops, an error occurred</div>;
     }
 
-    const areAnyBudgetLinesInExecuting = agreement?.budget_line_items.some((bli) => bli.status === "IN_EXECUTION");
-    const areAnyBudgetLinesObligated = agreement?.budget_line_items.some((bli) => bli.status === "OBLIGATED");
-    const isAgreementEditable = !areAnyBudgetLinesInExecuting && !areAnyBudgetLinesObligated;
-
-    if (!isAgreementEditable) {
+    if (!isEditable) {
         return (
             <App>
-                <SimpleAlert type="error" heading="Error" message={`This Agreement cannot be edited.`}></SimpleAlert>
+                <SimpleAlert type="error" heading="Error" message="This Agreement cannot be edited."></SimpleAlert>
                 <Link to="/" className="usa-button margin-top-4">
                     Go back home
                 </Link>

--- a/frontend/src/pages/agreements/details/AgreementDetails.js
+++ b/frontend/src/pages/agreements/details/AgreementDetails.js
@@ -4,7 +4,7 @@ import AgreementValuesCard from "../../../components/Agreements/AgreementDetails
 import AgreementDetailHeader from "./AgreementDetailHeader";
 import AgreementDetailsView from "./AgreementDetailsView";
 import AgreementDetailsEdit from "./AgreementDetailsEdit";
-import { useIsAgreementEditable } from "../../../helpers/useAgreements";
+import { useIsAgreementEditable, useIsUserAllowedToEditAgreement } from "../../../helpers/useAgreements";
 
 /**
  * Renders the details of an agreement, including budget lines, spending, and other information.
@@ -30,7 +30,9 @@ const AgreementDetails = ({ agreement, projectOfficer, isEditMode, setIsEditMode
         return p;
     }, {});
 
-    const isEditable = useIsAgreementEditable(agreement?.id);
+    const isAgreementEditable = useIsAgreementEditable(agreement?.id);
+    const canUserEditAgreement = useIsUserAllowedToEditAgreement(agreement?.id);
+    const isEditable = isAgreementEditable && canUserEditAgreement;
 
     return (
         <div>

--- a/frontend/src/pages/agreements/list/AgreementTableRow.jsx
+++ b/frontend/src/pages/agreements/list/AgreementTableRow.jsx
@@ -14,6 +14,7 @@ import icons from "../../../uswds/img/sprite.svg";
 import ConfirmationModal from "../../../components/UI/Modals/ConfirmationModal";
 import useGetUserFullNameFromId from "../../../helpers/useGetUserFullNameFromId";
 import { useIsUserAllowedToEditAgreement } from "../../../helpers/useAgreements";
+import { DISABLED_ICON_CLASSES } from "../../../constants";
 
 /**
  * Renders a row in the agreements table.
@@ -137,10 +138,12 @@ export const AgreementTableRow = ({ agreement }) => {
                     <div className="display-flex flex-align-center">
                         <FontAwesomeIcon
                             icon={faPen}
-                            className="text-primary height-2 width-2 margin-right-1 cursor-pointer usa-tooltip"
-                            title="edit"
+                            title={`${canUserEditAgreement ? "edit" : "user does not have permissions to edit"}`}
+                            className={`text-primary height-2 width-2 margin-right-1 cursor-pointer usa-tooltip ${
+                                !canUserEditAgreement ? DISABLED_ICON_CLASSES : null
+                            }`}
                             data-position="top"
-                            onClick={() => handleEditAgreement(agreement.id)}
+                            onClick={() => canUserEditAgreement && handleEditAgreement(agreement.id)}
                         />
 
                         <FontAwesomeIcon
@@ -148,7 +151,7 @@ export const AgreementTableRow = ({ agreement }) => {
                             title={`${canUserDeleteAgreement ? "delete" : "user does not have permissions to delete"}`}
                             data-position="top"
                             className={`text-primary height-2 width-2 margin-right-1 cursor-pointer usa-tooltip ${
-                                !canUserDeleteAgreement ? "opacity-30 cursor-not-allowed" : null
+                                !canUserDeleteAgreement ? DISABLED_ICON_CLASSES : null
                             }`}
                             onClick={() => canUserDeleteAgreement && handleDeleteAgreement(agreement.id)}
                             data-cy="delete-agreement"
@@ -214,7 +217,7 @@ export const AgreementTableRow = ({ agreement }) => {
                 <td className={removeBorderBottomIfExpanded} style={changeBgColorIfExpanded}>
                     <FontAwesomeIcon
                         icon={isExpanded ? faChevronUp : faChevronDown}
-                        className="height-2 width-2 padding-right-1 hover: cursor-pointer"
+                        className="height-2 width-2 padding-right-1 cursor-pointer"
                         onClick={() => handleExpandRow()}
                         data-cy="expand-row"
                     />

--- a/frontend/src/pages/agreements/review/ReviewAgreement.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.jsx
@@ -12,7 +12,7 @@ import Terms from "./Terms";
 import suite from "./suite";
 import { setAlert } from "../../../components/UI/Alert/alertSlice";
 import useGetUserFullNameFromId from "../../../helpers/useGetUserFullNameFromId";
-import { useIsAgreementEditable } from "../../../helpers/useAgreements";
+import { useIsAgreementEditable, useIsUserAllowedToEditAgreement } from "../../../helpers/useAgreements";
 
 /**
  * Renders a page for reviewing and sending an agreement to approval.
@@ -36,7 +36,9 @@ export const ReviewAgreement = ({ agreement_id }) => {
     const [pageErrors, setPageErrors] = useState({});
     const [isAlertActive, setIsAlertActive] = useState(false);
     const isGlobalAlertActive = useSelector((state) => state.alert.isActive);
-    const isAgreementEditable = useIsAgreementEditable(agreement?.id);
+    const isAgreementStateEditable = useIsAgreementEditable(agreement?.id);
+    const canUserEditAgreement = useIsUserAllowedToEditAgreement(agreement?.id);
+    const isAgreementEditable = isAgreementStateEditable && canUserEditAgreement;
     const projectOfficerName = useGetUserFullNameFromId(agreement?.project_officer);
 
     let res = suite.get();


### PR DESCRIPTION
## What changed

fixes bug allowing basic user to attempt to modify agreements

## Issue

#1416

## How to test

1. Login as basic user
1. Goto agreements list
1. Try to select edit icon // should NOT allow
1. Go to Agreements detail // no edit icon
1. Go to review an agreement // edit button is disabled
1. Hack url `/agreement/edit/{id}` // error Alert shown

## Screenshots

<img width="842" alt="image" src="https://github.com/HHS/OPRE-OPS/assets/4629398/2b020acd-ae9c-4d1a-861d-d5828461a791">

## Definition of Done Checklist
- [X] OESA: Code refactored for clarity
- ~~OESA: Dependency rules followed~~
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- ~~Form validations updated~~
