### PR TITLE
OPS-1301 View an agreement's note

### DIFF
--- a/frontend/cypress/e2e/agreementDetails.cy.js
+++ b/frontend/cypress/e2e/agreementDetails.cy.js
@@ -23,6 +23,8 @@ it("agreement loads with details", () => {
     cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(1)').contains("Agreement Type");
     cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(2) > .font-12px').contains("Contract");
     cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(3)').contains("Product Service Code");
+    cy.get('[data-cy="details-left-col"] > :nth-child(2)').contains("Notes");
+    cy.get("p.font-12px").contains("There are currently no notes for this agreement.");
 });
 
 it("agreement loads with budget lines", () => {

--- a/frontend/cypress/e2e/agreementDetailsEdit.cy.js
+++ b/frontend/cypress/e2e/agreementDetailsEdit.cy.js
@@ -15,13 +15,13 @@ const testAgreement = {
     project_officer: 1,
     team_members: [
         {
-            id: 3,
+            id: 3
         },
         {
-            id: 5,
-        },
+            id: 5
+        }
     ],
-    notes: "Test Notes",
+    notes: "Test Notes"
 };
 
 beforeEach(() => {
@@ -46,8 +46,8 @@ it("edit an agreement", () => {
         headers: {
             Authorization: bearer_token,
             "Content-Type": "application/json",
-            Accept: "application/json",
-        },
+            Accept: "application/json"
+        }
     }).then((response) => {
         expect(response.status).to.eq(201);
         expect(response.body.id).to.exist;
@@ -84,7 +84,7 @@ it("edit an agreement", () => {
         cy.get(".usa-error-message").should("not.exist");
         cy.get("[data-cy='continue-btn']").should("not.be.disabled");
         cy.get("#description").type(" more text");
-        cy.get("#agreementNotes").type("test edit notes");
+        cy.get("#agreementNotes").type(" test edit notes");
 
         cy.get("[data-cy='continue-btn']").click();
 
@@ -99,6 +99,8 @@ it("edit an agreement", () => {
         // eslint-disable-next-line cypress/no-unnecessary-waiting
         cy.wait(6000);
         cy.get("h1").should("have.text", "Test Edit Title");
+        cy.get("[data-cy='details-notes']").should("exist");
+        cy.get("[data-cy='details-notes']").should("have.text", "Test Notes test edit notes");
         cy.get("#edit").should("exist");
 
         cy.get(
@@ -129,8 +131,8 @@ it("edit an agreement", () => {
             url: `http://localhost:8080/api/v1/agreements/${agreementId}`,
             headers: {
                 Authorization: bearer_token,
-                Accept: "application/json",
-            },
+                Accept: "application/json"
+            }
         }).then((response) => {
             expect(response.status).to.eq(200);
         });

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -305,7 +305,7 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
                 messages={res.getErrors("description")}
                 className={cn("description")}
                 value={agreementDescription}
-                maxLength={500}
+                maxLength={1000}
                 onChange={(name, value) => {
                     setAgreementDescription(value);
                     if (isReviewMode) {

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -305,6 +305,7 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
                 messages={res.getErrors("description")}
                 className={cn("description")}
                 value={agreementDescription}
+                maxLength={500}
                 onChange={(name, value) => {
                     setAgreementDescription(value);
                     if (isReviewMode) {
@@ -405,7 +406,7 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
             <TextArea
                 name="agreementNotes"
                 label="Notes (optional)"
-                hintMsg="Maximum 150 characters"
+                maxLength={1000}
                 messages={res.getErrors("agreementNotes")}
                 className={cn("agreementNotes")}
                 value={agreementNotes || ""}

--- a/frontend/src/components/UI/Form/CreateBudgetLinesForm/CreateBudgetLinesForm.jsx
+++ b/frontend/src/components/UI/Form/CreateBudgetLinesForm/CreateBudgetLinesForm.jsx
@@ -155,7 +155,7 @@ export const CreateBudgetLinesForm = ({
                     name="enteredComments"
                     label="Notes (optional)"
                     value={enteredComments || ""}
-                    hintMsg="Maximum 150 characters"
+                    maxLength={150}
                     onChange={(name, value) => {
                         setEnteredComments(value);
                     }}

--- a/frontend/src/components/UI/Form/TextArea/TextArea.jsx
+++ b/frontend/src/components/UI/Form/TextArea/TextArea.jsx
@@ -10,6 +10,7 @@ import cx from "clsx";
  * @param {boolean} [props.pending=false] - Whether the input field is pending.
  * @param {string[]} [props.messages=[]] - The error messages for the input field.
  * @param {string} props.value - The value of the input field.
+ * @param {int} props.maxLength - The maximum number of characters allow.
  * @param {string} [props.className] - The CSS class for the input field.
  * @returns {JSX.Element} - The textarea input component.
  */
@@ -21,8 +22,10 @@ export const TextArea = ({
     pending = false,
     messages = [],
     value,
+    maxLength,
     className
 }) => {
+    if (!hintMsg && maxLength) hintMsg = `Maximum ${maxLength} characters`;
     return (
         <div className="usa-character-count margin-top-3">
             <div className={cx("usa-form-group", pending && "pending", className)}>
@@ -55,6 +58,7 @@ export const TextArea = ({
                     name={name}
                     rows={5}
                     style={{ height: "7rem" }}
+                    maxLength={maxLength}
                     onChange={handleChange}
                     value={value}
                     aria-describedby={`${name}-with-hint-textarea-info ${name}-with-hint-textarea-hint`}
@@ -64,7 +68,7 @@ export const TextArea = ({
                 id={`${name}-with-hint-textarea-info`}
                 className="usa-character-count__message sr-only"
             >
-                You can enter up to 150 characters
+                You can enter up to {maxLength} characters
             </span>
         </div>
     );

--- a/frontend/src/pages/agreements/details/AgreementDetailsView.js
+++ b/frontend/src/pages/agreements/details/AgreementDetailsView.js
@@ -35,11 +35,12 @@ const AgreementDetailsView = ({ agreement, projectOfficer }) => {
                             className="font-12px overflow-y-scroll force-show-scrollbars"
                             style={{ height: "11.375rem" }}
                             tabIndex={0}
+                            data-cy="details-notes"
                         >
                             {agreement.notes}
                         </div>
                     ) : (
-                        <p>There are currently no notes for this agreement.</p>
+                        <p className="font-12px">There are currently no notes for this agreement.</p>
                     )}
                     <h3 className="text-base-dark margin-top-3 text-normal font-12px">History</h3>
                     <AgreementHistoryPanel agreementId={agreement.id} />

--- a/frontend/src/pages/agreements/details/AgreementDetailsView.js
+++ b/frontend/src/pages/agreements/details/AgreementDetailsView.js
@@ -30,24 +30,16 @@ const AgreementDetailsView = ({ agreement, projectOfficer }) => {
                         </dd>
                     </dl>
                     <h3 className="text-base-dark margin-top-3 text-normal font-12px">Notes</h3>
-                    {notesData.length > 0 ? (
-                        <ul
-                            className="usa-list--unstyled overflow-y-scroll force-show-scrollbars"
+                    {agreement.notes ? (
+                        <div
+                            className="font-12px overflow-y-scroll force-show-scrollbars"
                             style={{ height: "11.375rem" }}
                             tabIndex={0}
                         >
-                            {/* // TODO: Replace with real data */}
-                            {notesData.map((note) => (
-                                <LogItem
-                                    key={note.id}
-                                    title={note.created_by}
-                                    createdOn={note.created_on}
-                                    message={note.message}
-                                />
-                            ))}
-                        </ul>
+                            {agreement.notes}
+                        </div>
                     ) : (
-                        <p>Sorry no notes</p>
+                        <p>There are currently no notes for this agreement.</p>
                     )}
                     <h3 className="text-base-dark margin-top-3 text-normal font-12px">History</h3>
                     <AgreementHistoryPanel agreementId={agreement.id} />

--- a/frontend/src/pages/agreements/details/AgreementDetailsView.js
+++ b/frontend/src/pages/agreements/details/AgreementDetailsView.js
@@ -1,6 +1,4 @@
 import PropTypes from "prop-types";
-import { notesData } from "./data";
-import LogItem from "../../../components/UI/LogItem";
 import Tag from "../../../components/UI/Tag/Tag";
 import { convertCodeForDisplay } from "../../../helpers/utils";
 import AgreementHistoryPanel from "../../../components/Agreements/AgreementDetails/AgreementHistoryPanel";


### PR DESCRIPTION
## What changed

* adds display of the Agreement notes field on the details page
* implements character limits on the text area input used for Agreement.notes
    * this same input is used for Agreement.description and CLI.comments (notes), so I added the character limits of 1000 and 150 for those

## Issue

#1301 

## How to test

* edit an agreements description and view the details page

## Screenshots
### Editing the notes
![image](https://github.com/HHS/OPRE-OPS/assets/127965976/cf913c46-f085-4177-822b-92724cbe8707)

### Viewing the notes
![image](https://github.com/HHS/OPRE-OPS/assets/127965976/7cd35aee-d270-4e5c-b3e9-d2f0df53511b)

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated



