### PR TITLE
COMPARE remove original and diff columns from OpsDbHistory

### DIFF
--- a/backend/models/history.py
+++ b/backend/models/history.py
@@ -23,8 +23,6 @@ class OpsDBHistory(BaseModel):
     event_details = sa.Column(JSONB)
     class_name = sa.Column(sa.String)
     row_key = sa.Column(sa.String)
-    original = sa.Column(JSONB)
-    diff = sa.Column(JSONB)
     changes = sa.Column(JSONB)
 
     @override

--- a/backend/ops_api/tests/ops/history/test_history.py
+++ b/backend/ops_api/tests/ops/history/test_history.py
@@ -59,7 +59,7 @@ def test_bli_history_force_an_error(loaded_db):
 @pytest.mark.usefixtures("app_ctx")
 def test_history_expanded(loaded_db: Session):
     """test the new columns for class_name, row_key to query for history of specific record
-    and verify the new original and diff columns contain the values before and the changes
+    and verify the new changes column contains the changes
     """
     bli = BudgetLineItem(
         line_description="Grant Expenditure GA999",
@@ -83,8 +83,6 @@ def test_history_expanded(loaded_db: Session):
     )
     result = loaded_db.scalars(stmt).all()
     assert result[0].event_details["line_description"] == "Grant Expenditure GA999"
-    assert "line_description" not in result[0].original
-    assert result[0].diff["line_description"] == "Grant Expenditure GA999"
 
     bli.line_description = "(UPDATED) Grant Expenditure GA999"
     loaded_db.add(bli)
@@ -99,10 +97,6 @@ def test_history_expanded(loaded_db: Session):
     )
     result = loaded_db.scalars(stmt).all()
     assert result[0].event_details["line_description"] == "(UPDATED) Grant Expenditure GA999"
-    assert result[0].original["line_description"] == "Grant Expenditure GA999"
-    assert result[0].diff["line_description"] == "(UPDATED) Grant Expenditure GA999"
-    assert "status" in result[0].original
-    assert "status" not in result[0].diff
 
     loaded_db.delete(bli)
     loaded_db.commit()
@@ -116,8 +110,6 @@ def test_history_expanded(loaded_db: Session):
     )
     result = loaded_db.scalars(stmt).all()
     assert result[0].event_details["line_description"] == "(UPDATED) Grant Expenditure GA999"
-    assert result[0].original["line_description"] == "(UPDATED) Grant Expenditure GA999"
-    assert len(result[0].diff) == 0
 
 
 @pytest.mark.usefixtures("app_ctx")
@@ -172,10 +164,6 @@ def test_history_expanded_with_web_client(auth_client, loaded_db):
     assert "support_contacts" not in result.changes
     assert "incumbent" not in result.changes
 
-    assert "description" not in result.original
-    assert result.diff["description"] == post_data["description"]
-    assert "notes" not in result.original
-
     # PATCH: edit agreement
     patch_data = {
         "description": "Updated Test Description",
@@ -222,12 +210,6 @@ def test_history_expanded_with_web_client(auth_client, loaded_db):
     assert "support_contacts" not in result.changes
     assert "incumbent" not in result.changes
 
-    assert result.original["description"] == post_data["description"]
-    assert "notes" not in result.original
-    assert result.diff["description"] == patch_data["description"]
-    assert "notes" in result.diff
-    assert result.diff["notes"] == patch_data["notes"]
-
     # DELETE: delete agreement
     resp = auth_client.delete(f"/api/v1/agreements/{agreement_id}")
     assert resp.status_code == 200
@@ -243,12 +225,6 @@ def test_history_expanded_with_web_client(auth_client, loaded_db):
     assert result.created_by == user_id
 
     assert not result.changes
-
-    assert result.original["id"] == agreement_id
-    assert result.original["name"] == post_data["name"]
-    assert result.original["description"] == patch_data["description"]
-    assert result.original["notes"] == patch_data["notes"]
-    assert len(result.diff) == 0
 
 
 @pytest.mark.parametrize(

--- a/openapi.yml
+++ b/openapi.yml
@@ -1341,12 +1341,6 @@ components:
         changes:
           description: JSON for the changeset
           type: object
-        diff:
-          description: properties which changed
-          type: object
-        original:
-          description: properties with their values before changes
-          type: object
 
     BudgetLineItems:
       description: OPS List of Budget Line Items


### PR DESCRIPTION
this is just to simplify the compare for #1527 