### PR TITLE
fix: current project officer not being selected in edit form

### DIFF
--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -1,8 +1,7 @@
-import React, { useEffect } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import classnames from "vest/classnames";
-import _ from "lodash";
 
 import ProcurementShopSelectWithFee from "../../UI/Form/ProcurementShopSelectWithFee";
 import AgreementReasonSelect from "../../UI/Form/AgreementReasonSelect";
@@ -23,7 +22,6 @@ import {
     useUpdateAgreementMutation
 } from "../../../api/opsAPI";
 import ProjectOfficerComboBox from "../../UI/Form/ProjectOfficerComboBox";
-import { getUser } from "../../../api/getUser";
 import useAlert from "../../../hooks/use-alert.hooks";
 
 /**

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -82,24 +82,6 @@ export const AgreementEditForm = ({ goBack, goToNext, isReviewMode, isEditMode, 
         team_members: selectedTeamMembers
     } = agreement;
 
-    // This is needed due to a caching issue with the React Context - for some reason selected_project_officer
-    // is not updated in the parent context/props.
-    useEffect(() => {
-        const getProjectOfficerSetState = async (id) => {
-            const results = await getUser(id);
-            setSelectedProjectOfficer(results);
-        };
-
-        if (_.isEmpty(selectedProjectOfficer) && agreement?.project_officer) {
-            getProjectOfficerSetState(agreement?.project_officer).catch(console.error);
-        }
-
-        return () => {
-            setSelectedProjectOfficer({});
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
     const {
         data: productServiceCodes,
         error: errorProductServiceCodes,


### PR DESCRIPTION
## What changed

fix for the the project officer combo box being empty when edit an agreement with a project 

NOTE: this removes code which says that it's a workaround for a caching problem, but I can't replicate that now

## Issue

#1537 

## How to test

* edit an agreement which already has a project officer, the project officer combobox should be populated with that

## Screenshots

_If relevant, e.g. for a front-end feature_

## Definition of Done Checklist
- ~[ ] OESA: Code refactored for clarity~
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- ~[ ] Form validations updated~


## Links

_If relevant, e.g. for a link to a piece of markdown documentation_
