### PR TITLE
Using a pinned version of the newly-upgraded semgrep container

### DIFF
--- a/.github/workflows/security_semgrep.yml
+++ b/.github/workflows/security_semgrep.yml
@@ -9,7 +9,7 @@ jobs:
     name: Semgrep Analyze
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@sha256:4ddf4c7908f6cd56bd703ddcac2dcf4ad6e000dba7835a75fe0b9a2181f4a325 # 1.47.0
+      image: returntocorp/semgrep@sha256:e7216f0ec1eaa032f470733e33d4a49d556f04b82fdce5e066599c38c1334c32 # 1.47.0
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/security_semgrep.yml
+++ b/.github/workflows/security_semgrep.yml
@@ -9,7 +9,7 @@ jobs:
     name: Semgrep Analyze
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep@2b41173d4b3029f5dd821375dcaf224c41cc9ac8 # 1.47.0
+      image: returntocorp/semgrep@sha256:4ddf4c7908f6cd56bd703ddcac2dcf4ad6e000dba7835a75fe0b9a2181f4a325 # 1.47.0
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/security_semgrep.yml
+++ b/.github/workflows/security_semgrep.yml
@@ -9,7 +9,7 @@ jobs:
     name: Semgrep Analyze
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep@2b41173d4b3029f5dd821375dcaf224c41cc9ac8 # 1.47.0
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4


### PR DESCRIPTION
## What changed

Using a pinned version (based on sha) of the `semgrep` container rather than relying on `latest`. Among other benefits, it helps us avoid bugs they inadvertently introduce...

## Issue

https://github.com/returntocorp/semgrep/issues/9091

## How to test

See if CI passes 😉 

## Screenshots


## Definition of Done Checklist
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed


## Links

https://hub.docker.com/layers/returntocorp/semgrep/1.47.0/images/sha256-e7216f0ec1eaa032f470733e33d4a49d556f04b82fdce5e066599c38c1334c32
