### PR TITLE
Exclude USWDS .svg files from eol pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
       - id: detect-private-key
       - id: trailing-whitespace
       - id: end-of-file-fixer
+        exclude: '^frontend/src/uswds/.*\.svg$'
       - id: check-json
       - id: check-yaml
       - id: check-added-large-files


### PR DESCRIPTION
## What changed

Simple change, for those who newly install pre-commit, or run with `--all-files`, this will NOT modify the USWDS .svg files by adding a newline.


## How to test

1. run `pre-commit run --all-files` from the root of the project
2. You should NOT see any .svg files within `frontend/src/uswds` modified
