### PR TITLE
Ceasing bun upgrades for now

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,7 +41,7 @@
     },
     "packageRules": [
         {
-            "matchPackageNames": ["python"],
+            "matchPackageNames": ["python", "oven/bun"],
             "enabled": false
         },
         {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -46,7 +46,8 @@
         },
         {
             "matchPackageNames": [
-                "python"
+                "python",
+                "oven/bun"
             ],
             "enabled": false,
             "platformAutomerge": true


### PR DESCRIPTION
## What changed

PR #1754 was attempting to update several packages to newer versions. The particular issue going on with the CI workflows on that PR was that the runner could never fully get the full installer for cypress completely downloaded and fails to get completely downloaded. On occasion when re-attempting, it complains about other similar symptomatic issues related to performance and timeouts. After some research and debugging, bun versions > 1.0.16 seem to have a performance change on `install` that is causing this. Until this is worked out, I'm proposing we pump the brakes on `bun` upgrades. 

I've set myself a reminder to re-assess this periodically

## Issue

see if renovate stops attempting to upgrade bun

## How to test

_Write out steps for how someone could test this PR against the acceptance criteria_