### PR TITLE
chore: Just changed the source to relative path for now.

### DIFF
--- a/terraform/eus/dev/backend_asa/context.tf
+++ b/terraform/eus/dev/backend_asa/context.tf
@@ -1,5 +1,5 @@
 module "ctx" {
-  source          = "git::https://github.com/HHS/OPRE-OPS.git//terraform/global/context?ref=v0.1"
+  source          = "../../../global/context" // "git::https://github.com/HHS/OPRE-OPS.git//terraform/global/context?ref=v0.1"
   environment     = var.environment
   custom_workload = "be4s"
 }

--- a/terraform/eus/dev/frontend_asa/context.tf
+++ b/terraform/eus/dev/frontend_asa/context.tf
@@ -1,5 +1,5 @@
 module "ctx" {
-  source          = "git::https://github.com/HHS/OPRE-OPS.git//terraform/global/context?ref=v0.1"
+  source          = "../../../global/context" //"git::https://github.com/HHS/OPRE-OPS.git//terraform/global/context?ref=v0.1"
   environment     = var.environment
   custom_workload = "be4s"
 


### PR DESCRIPTION
## What changed

Changed the source to relative path until we can figure out a better solution. 

## Issue

Renovate changed the tags for the context module to something pre-terraform. 
