### PR TITLE
OPS-1525: Adds REJECT of workflow step

### DIFF
--- a/backend/ops_api/ops/resources/workflow_approve.py
+++ b/backend/ops_api/ops/resources/workflow_approve.py
@@ -94,7 +94,7 @@ class WorkflowApprovalListApi(BaseItemAPI):
             current_app.db_session.add(workflow_step_instance)
             current_app.db_session.commit()
 
-            create_approval_notification_for_submitter(workflow_step_instance)
+            create_rejection_notification_for_submitter(workflow_step_instance)
             return make_response_with_headers(
                 {
                     "message": "Workflow Status Rejected",
@@ -143,6 +143,31 @@ def create_approval_notification_for_submitter(workflow_step_instance):
             title="Budget Lines Approved from Planned to Executing Status",
             message="The budget lines you sent to your Division Director were approved from planned to executing "
             "status.",
+            is_read=False,
+            recipient_id=workflow_step_instance.created_by,
+            expires=date(2031, 12, 31),
+        )
+        current_app.db_session.add(notification)
+        current_app.db_session.commit()
+
+
+def create_rejection_notification_for_submitter(workflow_step_instance):
+    if workflow_step_instance.workflow_instance.workflow_action == WorkflowAction.DRAFT_TO_PLANNED:
+        notification = Notification(
+            title="Budget Lines Rejected from changing from Draft to Planned Status",
+            message="The budget lines you sent to your Division Director were rejected from changing from draft to "
+            "planned status.",
+            is_read=False,
+            recipient_id=workflow_step_instance.created_by,
+            expires=date(2031, 12, 31),
+        )
+        current_app.db_session.add(notification)
+        current_app.db_session.commit()
+    elif workflow_step_instance.workflow_instance.workflow_action == WorkflowAction.PLANNED_TO_EXECUTING:
+        notification = Notification(
+            title="Budget Lines rejected from changing from Planned to Executing Status",
+            message="The budget lines you sent to your Division Director were rejected from changing from planned "
+            "to executing status.",
             is_read=False,
             recipient_id=workflow_step_instance.created_by,
             expires=date(2031, 12, 31),

--- a/backend/ops_api/ops/resources/workflow_approve.py
+++ b/backend/ops_api/ops/resources/workflow_approve.py
@@ -68,30 +68,48 @@ class WorkflowApprovalListApi(BaseItemAPI):
 
             create_approval_notification_for_submitter(workflow_step_instance)
 
+            update_blis(workflow_step_instance)
+
+            return make_response_with_headers(
+                {
+                    "message": "Workflow Status Accepted",
+                    "id": workflow_step_instance.id,
+                },
+                200,
+            )
+
         elif workflow_step_action == "REJECT":
-            # TODO: Update WorkflowStepInstance
-            pass
+            # Update WorkflowStepInstance
+            workflow_step_instance.status = WorkflowStatus.REJECTED
+            workflow_step_instance.time_completed = datetime.now()
+            workflow_step_instance.notes = workflow_notes
+            workflow_step_instance.updated_by = user.id
+
+            # If there are successor dependencies, update the workflow instance to the next step
+            workflow_step_instance.workflow_instance.current_workflow_step_instance_id = (
+                workflow_step_instance.successor_dependencies[0]
+                if workflow_step_instance.successor_dependencies
+                else None
+            )
+            current_app.db_session.add(workflow_step_instance)
+            current_app.db_session.commit()
+
+            create_approval_notification_for_submitter(workflow_step_instance)
+            return make_response_with_headers(
+                {
+                    "message": "Workflow Status Rejected",
+                    "id": workflow_step_instance.id,
+                },
+                200,
+            )
         elif workflow_step_action == "CHANGES":
             # TODO: Update WorkflowStepInstance
             pass
         else:
             raise ValueError(f"Invalid WorkflowAction: {workflow_step_action}")
 
-        ####################################################
-        # Do we do this here...? Or in a listener?
-        ####################################################
-        UpdateBlis(workflow_step_instance)
 
-        return make_response_with_headers(
-            {
-                "message": "Workflow Status Accepted",
-                "id": workflow_step_instance.id,
-            },
-            201,
-        )
-
-
-def UpdateBlis(workflow_step_instance: WorkflowStepInstance):
+def update_blis(workflow_step_instance: WorkflowStepInstance):
     if workflow_step_instance.workflow_instance.workflow_status == WorkflowStatus.APPROVED:
         # BLI
         package_blis = workflow_step_instance.package_entities["budget_line_item_ids"]

--- a/backend/ops_api/tests/ops/workflows/test_workflow_approve.py
+++ b/backend/ops_api/tests/ops/workflows/test_workflow_approve.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 from models import BudgetLineItem, BudgetLineItemStatus, WorkflowAction, WorkflowStatus, WorkflowStepInstance
-from ops_api.ops.resources.workflow_approve import UpdateBlis
+from ops_api.ops.resources.workflow_approve import update_blis
 
 
 @pytest.mark.usefixtures("app_ctx", "loaded_db")
@@ -20,7 +20,7 @@ def test_update_blis_draft_to_planned(loaded_db):
     blis = [bli1, bli2, bli3]
 
     # Call the function
-    UpdateBlis(workflow_step_instance)
+    update_blis(workflow_step_instance)
 
     # Assert that the status of each BudgetLineItem is set to BudgetLineItemStatus.PLANNED
     for bli in blis:

--- a/frontend/cypress/e2e/agreementWorkflow.cy.js
+++ b/frontend/cypress/e2e/agreementWorkflow.cy.js
@@ -1,0 +1,150 @@
+/// <reference types="cypress" />
+
+import { terminalLog, testLogin } from "./utils";
+
+const testAgreement = {
+    agreement_type: "CONTRACT",
+    agreement_reason: "NEW_REQ",
+    name: "E2E Test agreementWorkflow 1",
+    description: "Test Description",
+    project_id: 1,
+    product_service_code_id: 1,
+    procurement_shop_id: 1,
+    project_officer_id: 1,
+    team_members: [
+        {
+            id: 21
+        },
+        {
+            id: 5
+        }
+    ],
+    notes: "Test Notes"
+};
+const testBli = {
+    line_description: "SC1",
+    comments: "",
+    can_id: 1,
+    agreement_id: 11,
+    amount: 1000000,
+    status: "DRAFT",
+    date_needed: "2025-1-01",
+    proc_shop_fee_percentage: 0.005
+};
+
+beforeEach(() => {
+    testLogin("admin");
+    cy.visit(`/`);
+});
+
+// afterEach(() => {
+//     cy.injectAxe();
+//     cy.checkA11y(null, null, terminalLog);
+// });
+
+it("agreement for approval", () => {
+    expect(localStorage.getItem("access_token")).to.exist;
+
+    // create test agreement
+    const bearer_token = `Bearer ${window.localStorage.getItem("access_token")}`;
+    cy.request({
+        method: "POST",
+        url: "http://localhost:8080/api/v1/agreements/",
+        body: testAgreement,
+        headers: {
+            Authorization: bearer_token,
+            "Content-Type": "application/json",
+            Accept: "application/json"
+        }
+    })
+        .then((response) => {
+            expect(response.status).to.eq(201);
+            expect(response.body.id).to.exist;
+            const agreementId = response.body.id;
+            return agreementId;
+        })
+        // create BLI
+        .then((agreementId) => {
+            const bliData = { ...testBli, agreement_id: agreementId };
+            cy.request({
+                method: "POST",
+                url: "http://localhost:8080/api/v1/budget-line-items/",
+                body: bliData,
+                headers: {
+                    Authorization: bearer_token,
+                    Accept: "application/json"
+                }
+            }).then((response) => {
+                expect(response.status).to.eq(201);
+                expect(response.body.id).to.exist;
+                const bliId = response.body.id;
+                return { agreementId, bliId };
+            });
+        })
+        // submit for approval (via REST for now, maybe change to UI click through)
+        .then(({ agreementId, bliId }) => {
+            const workflowSubmitData = {
+                budget_line_item_ids: [bliId],
+                workflow_action: "DRAFT_TO_PLANNED",
+                notes: "E2E Test Notes"
+            };
+            cy.request({
+                method: "POST",
+                url: "http://localhost:8080/api/v1/workflow-submit/",
+                body: workflowSubmitData,
+                headers: {
+                    Authorization: bearer_token,
+                    Accept: "application/json"
+                }
+            }).then((response) => {
+                expect(response.status).to.eq(201);
+                return { agreementId, bliId };
+            });
+        })
+        .then(({ agreementId, bliId }) => {
+            cy.visit("/agreements?filter=for-approval");
+            cy.get(":nth-child(1) > .margin-0").should("have.text", "For Approval");
+            cy.get("tbody").children().should("have.length.at.least", 1);
+            cy.get("tbody tr").first().trigger("mouseover");
+            cy.get("[data-cy='go-to-approve-row']").first().should("exist");
+            cy.get("[data-cy='go-to-approve-row']").first().should("not.be.disabled");
+            cy.get("[data-cy='go-to-approve-row']")
+                .first()
+                .click()
+                .then(() => {
+                    return { agreementId, bliId };
+                });
+        });
+    // .then(({ agreementId, bliId }) => {
+    //     cy.request({
+    //         method: "PATCH",
+    //         url: `http://localhost:8080/api/v1/budget-line-items/${bliId}`,
+    //         body: { status: "DRAFT" },
+    //         headers: {
+    //             Authorization: bearer_token,
+    //             Accept: "application/json"
+    //         }
+    //     }).then((response) => {
+    //         expect(response.status).to.eq(200);
+    //         return agreementId;
+    //     });
+    // })
+    //
+    // .then((agreementId) => {
+    //     cy.request({
+    //         method: "DELETE",
+    //         url: `http://localhost:8080/api/v1/agreements/${agreementId}`,
+    //         headers: {
+    //             Authorization: bearer_token,
+    //             Accept: "application/json"
+    //         }
+    //     }).then((response) => {
+    //         expect(response.status).to.eq(200);
+    //     });
+    // });
+
+    // .then(({ agreementId, bliId }) => {
+    //     cy.visit("/agreements?filter=for-approval");
+    //     cy.get(":nth-child(1) > .margin-0").should("have.text", "For Approval");
+    // });
+});

--- a/frontend/src/pages/agreements/approve/ApproveAgreement.js
+++ b/frontend/src/pages/agreements/approve/ApproveAgreement.js
@@ -103,19 +103,46 @@ const ApproveAgreement = () => {
         });
     };
 
-    const handleDecline = () => {
+    const rejectStep = async () => {
+        const data = {
+            workflow_step_action: "REJECT",
+            workflow_step_id: stepId,
+            notes: notes
+        };
+
+        await workflowApprove(data)
+            .unwrap()
+            .then((fulfilled) => {
+                console.log(`SUCCESS of workflow-approve: ${JSON.stringify(fulfilled, null, 2)}`);
+                setAlert({
+                    type: "success",
+                    heading: "Rejection Saved",
+                    message: `The rejection to change Budget Lines has been saved.`
+                });
+            })
+            .catch((rejected) => {
+                console.error(`ERROR with workflow-approve: ${JSON.stringify(rejected, null, 2)}`);
+                setAlert({
+                    type: "error",
+                    heading: "Error",
+                    message: "An error occurred while saving the approval.",
+                    redirectUrl: "/error"
+                });
+            });
+    };
+
+    const handleDecline = async () => {
         setShowModal(true);
         setModalProps({
             heading: `Are you sure you want to decline these budget lines for ${goToText} Status?`,
             actionButtonText: "Decline",
             secondaryButtonText: "Cancel",
-            handleConfirm: () => {
-                alert("Not implemented yet");
+            handleConfirm: async () => {
+                await rejectStep();
                 navigate("/agreements");
             }
         });
     };
-
     const approveStep = async () => {
         const data = {
             workflow_step_action: "APPROVE",

--- a/frontend/src/pages/agreements/approve/ApproveAgreement.js
+++ b/frontend/src/pages/agreements/approve/ApproveAgreement.js
@@ -272,7 +272,7 @@ const ApproveAgreement = () => {
                 <button
                     name="cancel"
                     className={`usa-button usa-button--unstyled margin-right-2`}
-                    data-cy="edit-agreement-btn"
+                    data-cy="cancel-approval-btn"
                     onClick={handleCancel}
                 >
                     Cancel
@@ -280,7 +280,7 @@ const ApproveAgreement = () => {
 
                 <button
                     className={`usa-button usa-button--outline margin-right-2`}
-                    data-cy="edit-agreement-btn"
+                    data-cy="decline-approval-btn"
                     onClick={handleDecline}
                 >
                     Decline


### PR DESCRIPTION
## What changed

* Implements REJECT for a workflow step in the back end (/workflow-submit)
* Implements Decline button action in the front end to perform the reject

## Issue

#1525 

## How to test

On the Approve Agreement page, click the Decline button.
Also run the e2e tests, which has a new test in `agreementWorkflow.cy.js` to test the reject function


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated


## Links

_If relevant, e.g. for a link to a piece of markdown documentation_
