### PR TITLE
fix: Add NODE_ENV

### DIFF
--- a/frontend/Dockerfile.azure
+++ b/frontend/Dockerfile.azure
@@ -38,4 +38,4 @@ RUN bun install -g runtime-env-cra
 EXPOSE 3000/tcp
 
 # Entry point to run the application.
-ENTRYPOINT ["/bin/sh", "-c", "bun run ~/.bun/bin/runtime-env-cra && bun run index.js"]
+ENTRYPOINT ["/bin/sh", "-c", "NODE_ENV=production bun run ~/.bun/bin/runtime-env-cra && bun run index.js"]


### PR DESCRIPTION
Should work without, but tested to require some NODE_ENV

## What changed

Added NODE_ENV to the entrypoint where the runtime env is set. 

## Issue

Runtime env injection stopped working. Documentation indicates the NODE_ENV is not required for this to work, but testing proves it must be set to something... anything but development. 

