### PR TITLE
manually updating GHA `download-artifact`

### DIFF
--- a/.github/workflows/dev_fe_build_and_deploy.yml
+++ b/.github/workflows/dev_fe_build_and_deploy.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
 
       - name: Download Frontend Artifacts
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 #v4.1
+        uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 #v4.1.3
         with:
           name: ${{ env.WORKING_DIR }}-${{ env.ENVIRONMENT }}-build-${{ github.sha }}
           path: ${{ env.WORKING_DIR }}/build


### PR DESCRIPTION
## What changed

renovatebot has been complaining for sometime now about its inability to ascertain the digest of the version of the GHA `download-artifact`.  So, this is an attempt to manually update it in hopes that if that is in fact the real root issue, it can be overcome or perhaps cast more light on what the next root issue might be


## Issue

see renovatebot logs/status

## How to test

see if renovatebot logs/status report more success or at least different failures.

## Screenshots

N/A

## Links

