### PR TITLE
feat: :sparkles: Adds GoBackButton and Cancel button to Step 3

### DIFF
--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -23,6 +23,7 @@ import {
     useUpdateAgreementMutation
 } from "../../../api/opsAPI";
 import ProjectOfficerComboBox from "../../UI/Form/ProjectOfficerComboBox";
+import GoBackButton from "../../UI/Button/GoBackButton";
 import useAlert from "../../../hooks/use-alert.hooks";
 import ServiceReqTypeSelect from "../../../pages/servicesComponents/ServiceReqTypeSelect";
 import useHasStateChanged from "../../../hooks/useHasStateChanged.hooks";
@@ -430,16 +431,7 @@ export const AgreementEditForm = ({
                 onChange={(name, value) => setAgreementNotes(value)}
             />
             <div className="grid-row flex-justify margin-top-8">
-                {isWizardMode ? (
-                    <button
-                        className="usa-button usa-button--unstyled margin-right-2"
-                        onClick={() => goBack()}
-                    >
-                        Go Back
-                    </button>
-                ) : (
-                    <div />
-                )}
+                {isWizardMode ? <GoBackButton handleGoBack={goBack} /> : <div />}
                 <div>
                     <button
                         className="usa-button usa-button--unstyled margin-right-2"

--- a/frontend/src/components/UI/Button/GoBackButton/GoBackButton.jsx
+++ b/frontend/src/components/UI/Button/GoBackButton/GoBackButton.jsx
@@ -1,0 +1,36 @@
+import PropTypes from "prop-types";
+import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+/**
+ * GoBackButton is a component that displays a button with an arrow icon and text.
+ * When clicked, it triggers the handleGoBack function.
+ *
+ * @component
+ * @param {Object} props - The properties passed to this component.
+ * @param {function} [props.handleGoBack=() => {}] - The function to execute when the button is clicked.
+ * @param {string} [props.buttonText="Back"] - The text to display on the button.
+ * @param {Object} [props.rest] - Any additional props to pass to the button. optional
+ * @returns {JSX.Element} The rendered GoBackButton component.
+ */
+function GoBackButton({ handleGoBack = () => {}, buttonText = "Back", ...rest }) {
+    return (
+        <button
+            className="usa-button usa-button--unstyled margin-right-2"
+            data-cy="back-button"
+            onClick={handleGoBack}
+            {...rest}
+        >
+            <FontAwesomeIcon
+                icon={faArrowLeft}
+                className="margin-right-1 cursor-pointer"
+            />
+            {buttonText}
+        </button>
+    );
+}
+GoBackButton.propTypes = {
+    handleGoBack: PropTypes.func,
+    buttonText: PropTypes.string
+};
+export default GoBackButton;

--- a/frontend/src/components/UI/Button/GoBackButton/index.js
+++ b/frontend/src/components/UI/Button/GoBackButton/index.js
@@ -1,0 +1,2 @@
+export * from "./GoBackButton";
+export { default } from "./GoBackButton";

--- a/frontend/src/components/UI/Form/CreateBudgetLinesForm/CreateBudgetLinesForm.jsx
+++ b/frontend/src/components/UI/Form/CreateBudgetLinesForm/CreateBudgetLinesForm.jsx
@@ -190,19 +190,6 @@ export const CreateBudgetLinesForm = ({
                     </button>
                 )}
             </div>
-            <DebugCode
-                title="Form Data"
-                data={{
-                    servicesComponentId,
-                    selectedCan,
-                    enteredAmount,
-                    enteredMonth,
-                    enteredDay,
-                    enteredYear,
-                    enteredComments,
-                    isEditing
-                }}
-            />
         </form>
     );
 };

--- a/frontend/src/components/UI/Form/CreateBudgetLinesForm/CreateBudgetLinesForm.jsx
+++ b/frontend/src/components/UI/Form/CreateBudgetLinesForm/CreateBudgetLinesForm.jsx
@@ -6,7 +6,6 @@ import suite from "./suite";
 import TextArea from "../TextArea/TextArea";
 import CurrencyInput from "./CurrencyInput";
 import AllServicesComponentSelect from "../../../../pages/servicesComponents/AllServicesComponentSelect";
-import DebugCode from "../../../../pages/servicesComponents/DebugCode";
 
 /**
  * A form for creating or editing a budget line.

--- a/frontend/src/components/UI/Modals/ConfirmationModal.jsx
+++ b/frontend/src/components/UI/Modals/ConfirmationModal.jsx
@@ -4,7 +4,7 @@ import LogItem from "../LogItem";
 
 /**
  * A modal component that can be used to display a message or prompt the user for confirmation.
- *
+ * @component
  * @param {Object} props - The component props.
  * @param {string} props.heading - The heading text to display in the modal.
  * @param {string|Array<any>} [props.description=""] - The description text to display in the modal.
@@ -12,7 +12,7 @@ import LogItem from "../LogItem";
  * @param {string} props.actionButtonText - The text to display on the primary action button.
  * @param {string} [props.secondaryButtonText="Cancel"] - The text to display on the secondary action button.
  * @param {function} [props.handleConfirm=() => {}] - A function to handle the primary action button click.
- * @returns {React.JSX.Element} - The modal component JSX.
+ * @returns {JSX.Element} - The modal component JSX.
  */
 export const ConfirmationModal = ({
     heading,

--- a/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/StepCreateBLIsAndSCs.jsx
+++ b/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/StepCreateBLIsAndSCs.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { useNavigate } from "react-router-dom";
 import StepIndicator from "../../StepIndicator/StepIndicator";
 import ProjectAgreementSummaryCard from "../../Form/ProjectAgreementSummaryCard";
 import BudgetLinesTable from "../../../BudgetLineItems/BudgetLinesTable";
@@ -9,12 +8,12 @@ import EditModeTitle from "../../../../pages/agreements/EditModeTitle";
 import ConfirmationModal from "../../Modals/ConfirmationModal";
 import ServicesComponents from "../../../../pages/servicesComponents";
 import DebugCode from "../../../../pages/servicesComponents/DebugCode";
-import { useBudgetLinesDispatch } from "./context";
 import useCreateBLIsAndSCs from "./useCreateBLIsAndSCs.hooks";
 import { convertCodeForDisplay } from "../../../../helpers/utils";
 import ServicesComponentAccordion from "../../../../pages/servicesComponents/ServicesComponentAccordion";
 import BLIsByFYSummaryCard from "../../../Agreements/AgreementDetailsCards/BLIsByFYSummaryCard";
 import AgreementTotalCard from "../../../Agreements/AgreementDetailsCards/AgreementTotalCard";
+import GoBackButton from "../../Button/GoBackButton";
 
 /**
  * Renders the Create Budget Lines and Services Components with React context.
@@ -54,8 +53,6 @@ export const StepCreateBLIsAndSCs = ({
     isReviewMode,
     workflow
 }) => {
-    const navigate = useNavigate();
-    const dispatch = useBudgetLinesDispatch();
     const {
         budgetLinePageErrorsExist,
         handleDeleteBudgetLine,
@@ -73,7 +70,6 @@ export const StepCreateBLIsAndSCs = ({
         setEnteredDay,
         setEnteredMonth,
         setEnteredYear,
-        setModalProps,
         setSelectedCan,
         setServicesComponentId,
         setShowModal,
@@ -90,15 +86,19 @@ export const StepCreateBLIsAndSCs = ({
         res,
         feesForCards,
         subTotalForCards,
-        totalsForCards
+        totalsForCards,
+        handleCancel,
+        handleGoBack
     } = useCreateBLIsAndSCs(
         isReviewMode,
         existingBudgetLines,
         goToNext,
+        goBack,
         continueOverRide,
         selectedAgreement,
         selectedProcurementShop,
-        setIsEditMode
+        setIsEditMode,
+        workflow
     );
 
     return (
@@ -108,6 +108,7 @@ export const StepCreateBLIsAndSCs = ({
                     heading={modalProps.heading}
                     setShowModal={setShowModal}
                     actionButtonText={modalProps.actionButtonText}
+                    secondaryButtonText={modalProps.secondaryButtonText}
                     handleConfirm={modalProps.handleConfirm}
                 />
             )}
@@ -234,44 +235,25 @@ export const StepCreateBLIsAndSCs = ({
                 title="Budget Lines BY Services Component"
                 data={groupedBudgetLinesByServicesComponent}
             />
-            <div className="grid-row flex-justify-end margin-top-1">
-                <button
-                    className="usa-button usa-button--unstyled margin-right-2"
-                    data-cy="back-button"
-                    onClick={() => {
-                        // if no budget lines have been added, go back
-                        if (newBudgetLines?.length === 0) {
-                            if (workflow === "none") {
-                                setIsEditMode(false);
-                                navigate(`/agreements/${selectedAgreement?.id}`);
-                            } else {
-                                goBack();
-                                return;
-                            }
-                        }
-                        // if budget lines have been added, show modal
-                        setShowModal(true);
-                        setModalProps({
-                            heading: "Are you sure you want to go back? Your budget lines will not be saved.",
-                            actionButtonText: "Go Back",
-                            handleConfirm: () => {
-                                dispatch({ type: "RESET_FORM_AND_BUDGET_LINES" });
-                                setModalProps({});
-                                goBack();
-                            }
-                        });
-                    }}
-                >
-                    Back
-                </button>
-                <button
-                    className="usa-button"
-                    data-cy="continue-btn"
-                    onClick={saveBudgetLineItems}
-                    disabled={isReviewMode && !res.isValid()}
-                >
-                    {isReviewMode ? "Review" : continueBtnText}
-                </button>
+            <div className="display-flex flex-justify margin-top-1">
+                <GoBackButton handleGoBack={handleGoBack} />
+                <div>
+                    <button
+                        className="usa-button usa-button--unstyled margin-right-2"
+                        data-cy="cancel-button"
+                        onClick={handleCancel}
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        className="usa-button"
+                        data-cy="continue-btn"
+                        onClick={saveBudgetLineItems}
+                        disabled={isReviewMode && !res.isValid()}
+                    >
+                        {isReviewMode ? "Review" : continueBtnText}
+                    </button>
+                </div>
             </div>
         </>
     );

--- a/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/StepCreateBLIsAndSCs.jsx
+++ b/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/StepCreateBLIsAndSCs.jsx
@@ -232,8 +232,8 @@ export const StepCreateBLIsAndSCs = ({
                     </ServicesComponentAccordion>
                 ))}
             <DebugCode
-                title="Budget Lines BY Services Component"
-                data={groupedBudgetLinesByServicesComponent}
+                title="Agreement"
+                data={selectedAgreement}
             />
             <div className="display-flex flex-justify margin-top-1">
                 <GoBackButton handleGoBack={handleGoBack} />

--- a/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/StepCreateBLIsAndSCs.jsx
+++ b/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/StepCreateBLIsAndSCs.jsx
@@ -7,7 +7,6 @@ import CreateBudgetLinesForm from "../../Form/CreateBudgetLinesForm";
 import EditModeTitle from "../../../../pages/agreements/EditModeTitle";
 import ConfirmationModal from "../../Modals/ConfirmationModal";
 import ServicesComponents from "../../../../pages/servicesComponents";
-import DebugCode from "../../../../pages/servicesComponents/DebugCode";
 import useCreateBLIsAndSCs from "./useCreateBLIsAndSCs.hooks";
 import { convertCodeForDisplay } from "../../../../helpers/utils";
 import ServicesComponentAccordion from "../../../../pages/servicesComponents/ServicesComponentAccordion";
@@ -231,10 +230,6 @@ export const StepCreateBLIsAndSCs = ({
                         />
                     </ServicesComponentAccordion>
                 ))}
-            <DebugCode
-                title="Agreement"
-                data={selectedAgreement}
-            />
             <div className="display-flex flex-justify margin-top-1">
                 <GoBackButton handleGoBack={handleGoBack} />
                 <div>

--- a/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/useCreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/useCreateBLIsAndSCs.hooks.js
@@ -8,6 +8,7 @@ import { useGetLoggedInUserFullName } from "../../../../hooks/user.hooks";
 import suite from "./suite";
 import { budgetLinesTotal } from "../../../../helpers/budgetLines.helpers";
 import { getProcurementShopSubTotal } from "../../../../helpers/agreement.helpers";
+import { useDeleteAgreementMutation } from "../../../../api/opsAPI";
 
 /**
  * Custom hook to manage the creation and manipulation of Budget Line Items and Service Components.
@@ -40,6 +41,7 @@ const useCreateBLIsAndSCs = (
     const [budgetLineIdFromUrl, setBudgetLineIdFromUrl] = React.useState(
         () => searchParams.get("budget-line-id") || null
     );
+    const [deleteAgreement] = useDeleteAgreementMutation();
 
     const {
         selected_can: selectedCan,
@@ -281,11 +283,30 @@ const useCreateBLIsAndSCs = (
     const handleCancel = () => {
         setShowModal(true);
         setModalProps({
-            heading: "Are you sure you want to cancel? Your budget lines will not be saved.",
+            heading: "Are you sure you want to cancel? Your agreement will not be saved.",
             actionButtonText: "Cancel",
             secondaryButtonText: "Continue Editing",
             handleConfirm: () => {
-                navigate("/agreements");
+                deleteAgreement(selectedAgreement?.id)
+                    .unwrap()
+                    .then((fulfilled) => {
+                        console.log(`DELETE agreement success: ${JSON.stringify(fulfilled, null, 2)}`);
+                        setAlert({
+                            type: "success",
+                            heading: "Agreement cancelled",
+                            message: `Agreement ${selectedAgreement?.name} has been successfully cancelled.`,
+                            redirectUrl: "/agreements"
+                        });
+                    })
+                    .catch((rejected) => {
+                        console.error(`DELETE agreement rejected: ${JSON.stringify(rejected, null, 2)}`);
+                        setAlert({
+                            type: "error",
+                            heading: "Error",
+                            message: "An error occurred while deleting the agreement.",
+                            redirectUrl: "/error"
+                        });
+                    });
             }
         });
     };

--- a/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/useCreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/useCreateBLIsAndSCs.hooks.js
@@ -15,21 +15,24 @@ import { getProcurementShopSubTotal } from "../../../../helpers/agreement.helper
  * @param {boolean} isReviewMode - Flag to indicate if the component is in review mode.
  * @param {Array<Object>} existingBudgetLines - Array of existing budget lines.
  * @param {Function} goToNext - Function to navigate to the next step.
+ * @param {Function} goBack - Function to navigate to the previous step.
  * @param {Function} continueOverRide - Function to override the continue action.
  * @param {Object} selectedAgreement - Selected agreement object.
  * @param {Object} selectedProcurementShop - Selected procurement shop object.
  * @param {Function} setIsEditMode - Function to set the edit mode.
+ * @param {string} workflow - The workflow type ("agreement" or "budgetLines").
  *
- * @returns {Object} Contains various state variables and functions to manage budget line items and service components.
  */
 const useCreateBLIsAndSCs = (
     isReviewMode,
     existingBudgetLines,
     goToNext,
+    goBack,
     continueOverRide,
     selectedAgreement,
     selectedProcurementShop,
-    setIsEditMode
+    setIsEditMode,
+    workflow
 ) => {
     const [showModal, setShowModal] = React.useState(false);
     const [modalProps, setModalProps] = React.useState({});
@@ -236,6 +239,7 @@ const useCreateBLIsAndSCs = (
                 );
             }
         };
+
         const newBudgetLineItems = newBudgetLines.filter((budgetLineItem) => !("created_on" in budgetLineItem));
         const existingBudgetLineItems = newBudgetLines.filter((budgetLineItem) => "created_on" in budgetLineItem);
 
@@ -273,7 +277,44 @@ const useCreateBLIsAndSCs = (
             payload: { ...budgetLine, created_by: loggedInUserFullName }
         });
     };
-    // TODO: consider moving this to a separate helper function
+
+    const handleCancel = () => {
+        setShowModal(true);
+        setModalProps({
+            heading: "Are you sure you want to cancel? Your budget lines will not be saved.",
+            actionButtonText: "Cancel",
+            secondaryButtonText: "Continue Editing",
+            handleConfirm: () => {
+                navigate("/agreements");
+            }
+        });
+    };
+
+    const handleGoBack = () => {
+        // if no budget lines have been added, go back
+        if (newBudgetLines?.length === 0) {
+            if (workflow === "none") {
+                setIsEditMode(false);
+                navigate(`/agreements/${selectedAgreement?.id}`);
+            } else {
+                goBack();
+                return;
+            }
+        }
+        // if budget lines have been added, show modal
+        setShowModal(true);
+        setModalProps({
+            heading: "Are you sure you want to go back? Your budget lines will not be saved.",
+            actionButtonText: "Go Back",
+            secondaryButtonText: "Continue Editing",
+            handleConfirm: () => {
+                dispatch({ type: "RESET_FORM_AND_BUDGET_LINES" });
+                setModalProps({});
+                goBack();
+            }
+        });
+    };
+
     const resetQueryParams = () => {
         setBudgetLineIdFromUrl(null);
         const url = new URL(window.location);
@@ -355,7 +396,9 @@ const useCreateBLIsAndSCs = (
         res,
         feesForCards,
         subTotalForCards,
-        totalsForCards
+        totalsForCards,
+        handleCancel,
+        handleGoBack
     };
 };
 
@@ -363,10 +406,12 @@ useCreateBLIsAndSCs.propTypes = {
     isReviewMode: PropTypes.bool,
     existingBudgetLines: PropTypes.array,
     goToNext: PropTypes.func,
+    goBack: PropTypes.func,
     continueOverRide: PropTypes.func,
     selectedAgreement: PropTypes.object,
     selectedProcurementShop: PropTypes.object,
-    setIsEditMode: PropTypes.func
+    setIsEditMode: PropTypes.func,
+    workflow: PropTypes.string
 };
 
 export default useCreateBLIsAndSCs;

--- a/frontend/src/pages/agreements/StepCreateAgreement.jsx
+++ b/frontend/src/pages/agreements/StepCreateAgreement.jsx
@@ -5,7 +5,19 @@ import StepIndicator from "../../components/UI/StepIndicator";
 import ProjectSummaryCard from "../../components/ResearchProjects/ProjectSummaryCard/ProjectSummaryCard";
 import { useEditAgreement } from "../../components/Agreements/AgreementEditor/AgreementEditorContext";
 
-export const StepCreateAgreement = ({ goBack, goToNext, isEditMode, isReviewMode, wizardSteps }) => {
+/**
+ * StepCreateAgreement is a component that represents a step in a wizard for creating or editing an agreement.
+ * It displays the title of the mode (edit or review), a step indicator, a summary of the selected research project, and an agreement edit form.
+ * @component
+ * @param {Object} props - The properties passed to this component.
+ * @param {function} props.goBack - The function to go back to the previous step.
+ * @param {function} props.goToNext - The function to go to the next step.
+ * @param {boolean} props.isEditMode - Indicates if the wizard is in edit mode.
+ * @param {boolean} props.isReviewMode - Indicates if the wizard is in review mode.
+ * @param {Array.<string>} props.wizardSteps - The steps of the wizard.
+ * @returns {JSX.Element} The rendered StepCreateAgreement component.
+ */
+const StepCreateAgreement = ({ goBack, goToNext, isEditMode, isReviewMode, wizardSteps }) => {
     const { selected_project: selectedResearchProject } = useEditAgreement();
 
     return (


### PR DESCRIPTION
## What changed

Adds GoBackButton and Cancel button to Step 3
- Refactor ConfirmationModal and AgreementEditForm components

## Issue

#1967 #2019 

## How to test

1. Goto Agreement Creation wizard
2. Goto Step 3 
3. Click on GoBack button
4. Will take you to Step 2
5. Go to Step 3
6. Click Cancel button
7. Will take you to Agreements list and remove the Agreement

## Screenshots

<img width="1221" alt="image" src="https://github.com/HHS/OPRE-OPS/assets/4629398/00b268cb-f93b-4631-b034-8f428095dacc">

## Definition of Done Checklist
- [X] OESA: Code refactored for clarity
- [X] OESA: Dependency rules followed
- [X] Automated unit tests updated and passed
- [X] Automated integration tests updated and passed
- [X] Automated quality tests updated and passed
- [X] Automated load tests updated and passed
- [X] Automated a11y tests updated and passed
- [X] Automated security tests updated and passed
- [X] 90%+ Code coverage achieved
- [-] Form validations updated