### PR TITLE
adding DoD item for new debt documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_work_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_work_template.md
@@ -27,6 +27,7 @@ _As a [type of user], I want to [do something] [to produce this outcome]_
 - [ ] Usability validated (UX team)
 - [ ] PR(s) have been merged to main
 - [ ] Design/tech debt eliminated
+- [ ] New design/tech debt documented
 - [ ] Build process updated
 - [ ] Documentation updated or added
 - [ ] Feature flags/toggles created

--- a/.github/ISSUE_TEMPLATE/feature_work_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_work_template.md
@@ -27,7 +27,7 @@ _As a [type of user], I want to [do something] [to produce this outcome]_
 - [ ] Usability validated (UX team)
 - [ ] PR(s) have been merged to main
 - [ ] Design/tech debt eliminated
-- [ ] New design/tech debt documented
+- [ ] New design/tech debt documented (if applicable)
 - [ ] Build process updated
 - [ ] Documentation updated or added
 - [ ] Feature flags/toggles created


### PR DESCRIPTION
## What changed

In our February retro, we discussed and added an action item for making a new Definition of Done item for us to acknowledge that we have documented any design or technical debt that we couldn't go ahead and tackle in the same story/GH issue.  This change adds that new item to our feature/story GH issue template. 

## Issue

N/A

## How to test

N/A


## Links

https://flexion.teamretro.com/teams/6qdYqREFtyhJ6zCs5LkGb3?actionId=040480e9-43a7-4734-a18f-9b0acc83d4cc
