### PR TITLE
OPS-1852/task-2047 Remove requirement for line_description

### DIFF
--- a/backend/ops_api/ops/schemas/budget_line_item.py
+++ b/backend/ops_api/ops/schemas/budget_line_item.py
@@ -136,18 +136,6 @@ class RequestBody:
                 raise ValidationError("BLI's Agreement must have a ProjectOfficer when status is not DRAFT")
 
     @validates_schema(skip_on_field_errors=False)
-    def validate_description(self, data: dict, **kwargs):
-        if is_changing_status(data):
-            bli = current_app.db_session.get(BudgetLineItem, self.context.get("id"))
-            bli_description = bli.line_description if bli else None
-            data_description = data.get("line_description")
-            msg = "BLI must valid a valid Description when status is not DRAFT"
-            if self.context.get("method") in ["POST", "PUT"] and is_invalid_full(bli_description, data_description):
-                raise ValidationError(msg)
-            if self.context.get("method") in ["PATCH"] and is_invalid_partial(bli_description, data_description):
-                raise ValidationError(msg)
-
-    @validates_schema(skip_on_field_errors=False)
     def validate_need_by_date(self, data: dict, **kwargs):
         if is_changing_status(data):
             bli = current_app.db_session.get(BudgetLineItem, self.context.get("id"))

--- a/backend/ops_api/tests/ops/features/test_validate_draft_budget_lines.py
+++ b/backend/ops_api/tests/ops/features/test_validate_draft_budget_lines.py
@@ -95,30 +95,6 @@ def test_valid_project_officer(loaded_db, context):
 
 @scenario(
     "validate_draft_budget_lines.feature",
-    "Valid BLI Description: Both NULL",
-)
-def test_valid_description_both_null(loaded_db, context):
-    ...
-
-
-@scenario(
-    "validate_draft_budget_lines.feature",
-    "Valid BLI Description: Request Empty",
-)
-def test_valid_description_request_empty(loaded_db, context):
-    ...
-
-
-@scenario(
-    "validate_draft_budget_lines.feature",
-    "Valid BLI Description: Both Empty",
-)
-def test_valid_description_both_empty(loaded_db, context):
-    ...
-
-
-@scenario(
-    "validate_draft_budget_lines.feature",
     "Valid Need By Date: Both NULL",
 )
 def test_valid_need_by_date_both_null(loaded_db, context):
@@ -461,36 +437,6 @@ def bli(loaded_db, context):
     context["initial_bli_for_patch"] = initial_bli_for_patch
 
 
-@when("I have a BLI in DRAFT status without a Description")
-def bli_without_description(loaded_db, context):
-    initial_bli_for_put = BudgetLineItem(
-        agreement_id=context["agreement"].id,
-        comments="blah blah",
-        amount=100.12,
-        can_id=1,
-        date_needed=datetime.date(2023, 1, 1),
-        status=BudgetLineItemStatus.DRAFT,
-        proc_shop_fee_percentage=1.23,
-        created_by=1,
-    )
-    initial_bli_for_patch = BudgetLineItem(
-        agreement_id=context["agreement"].id,
-        comments="blah blah",
-        amount=100.12,
-        can_id=1,
-        date_needed=datetime.date(2043, 1, 1),
-        status=BudgetLineItemStatus.DRAFT,
-        proc_shop_fee_percentage=1.23,
-        created_by=1,
-    )
-    loaded_db.add(initial_bli_for_put)
-    loaded_db.add(initial_bli_for_patch)
-    loaded_db.commit()
-
-    context["initial_bli_for_put"] = initial_bli_for_put
-    context["initial_bli_for_patch"] = initial_bli_for_patch
-
-
 @when("I have a BLI in DRAFT status without a Need By Date")
 def bli_without_need_by_date(loaded_db, context):
     initial_bli_for_put = BudgetLineItem(
@@ -680,51 +626,6 @@ def submit(client, context):
     data = {
         "agreement_id": context["agreement"].id,
         "line_description": "Updated LI 1",
-        "comments": "hah hah",
-        "can_id": 2,
-        "amount": 200.24,
-        "status": "PLANNED",
-        "date_needed": "2044-01-01",
-        "proc_shop_fee_percentage": 2.34,
-    }
-
-    context["response_put"] = client.put(f"/api/v1/budget-line-items/{context['initial_bli_for_put'].id}", json=data)
-
-    context["response_patch"] = client.patch(
-        f"/api/v1/budget-line-items/{context['initial_bli_for_patch'].id}",
-        json={
-            "status": "PLANNED",
-        },
-    )
-
-
-@when("I submit a BLI to move to IN_REVIEW status (without Description)")
-def submit_without_description(client, context):
-    data = {
-        "agreement_id": context["agreement"].id,
-        "comments": "hah hah",
-        "can_id": 2,
-        "amount": 200.24,
-        "status": "PLANNED",
-        "date_needed": "2044-01-01",
-        "proc_shop_fee_percentage": 2.34,
-    }
-
-    context["response_put"] = client.put(f"/api/v1/budget-line-items/{context['initial_bli_for_put'].id}", json=data)
-
-    context["response_patch"] = client.patch(
-        f"/api/v1/budget-line-items/{context['initial_bli_for_patch'].id}",
-        json={
-            "status": "PLANNED",
-        },
-    )
-
-
-@when("I submit a BLI to move to IN_REVIEW status with an empty string Description")
-def submit_empty_description(client, context):
-    data = {
-        "agreement_id": context["agreement"].id,
-        "line_description": "  ",
         "comments": "hah hah",
         "can_id": 2,
         "amount": 200.24,
@@ -991,27 +892,6 @@ def error_message_valid_project_officer(context, setup_and_teardown):
     assert context["response_patch"].json == {
         "_schema": ["BLI's Agreement must have a ProjectOfficer when status is not DRAFT"]
     }
-
-
-@then("I should get an error message that the BLI must have a Description")
-def error_message_valid_description(context, setup_and_teardown):
-    assert context["response_put"].status_code == 400
-    assert context["response_put"].json == {
-        "_schema": [
-            "BLI must valid a valid Description when status is not DRAFT",
-        ]
-    }
-    assert context["response_patch"].status_code == 400
-    assert context["response_patch"].json == {
-        "_schema": ["BLI must valid a valid Description when status is not DRAFT"]
-    }
-
-
-@then("I should get an error message that the BLI must have a Description (for PUT only)")
-def error_message_valid_description_put_only(context, setup_and_teardown):
-    assert context["response_put"].status_code == 400
-    assert context["response_put"].json == {"_schema": ["BLI must valid a valid Description when status is not DRAFT"]}
-    assert context["response_patch"].status_code == 200
 
 
 @then("I should get an error message that the BLI must have a Need By Date")

--- a/backend/ops_api/tests/ops/features/test_validate_draft_budget_lines_in_workflow.py
+++ b/backend/ops_api/tests/ops/features/test_validate_draft_budget_lines_in_workflow.py
@@ -91,14 +91,6 @@ def test_valid_project_officer(loaded_db, context):
 
 @scenario(
     "validate_draft_budget_lines_in_workflow.feature",
-    "Valid BLI Description",
-)
-def test_valid_description_not_null(loaded_db, context):
-    ...
-
-
-@scenario(
-    "validate_draft_budget_lines_in_workflow.feature",
     "Valid Need By Date: Not Null",
 )
 def test_valid_need_by_date_not_null(loaded_db, context):
@@ -382,25 +374,6 @@ def bli(loaded_db, context):
     initial_bli = BudgetLineItem(
         agreement_id=context["agreement"].id,
         comments="blah blah",
-        line_description="LI 1",
-        amount=100.12,
-        can_id=1,
-        date_needed=datetime.date(2043, 1, 1),
-        status=BudgetLineItemStatus.DRAFT,
-        proc_shop_fee_percentage=1.23,
-        created_by=1,
-    )
-    loaded_db.add(initial_bli)
-    loaded_db.commit()
-
-    context["initial_bli"] = initial_bli
-
-
-@when("I have a BLI in DRAFT status without a Description")
-def bli_without_description(loaded_db, context):
-    initial_bli = BudgetLineItem(
-        agreement_id=context["agreement"].id,
-        comments="blah blah",
         amount=100.12,
         can_id=1,
         date_needed=datetime.date(2043, 1, 1),
@@ -419,7 +392,6 @@ def bli_without_need_by_date(loaded_db, context):
     initial_bli = BudgetLineItem(
         agreement_id=context["agreement"].id,
         comments="blah blah",
-        line_description="LI 1",
         amount=100.12,
         can_id=1,
         status=BudgetLineItemStatus.DRAFT,
@@ -437,7 +409,6 @@ def bli_past_need_by_date(loaded_db, context):
     initial_bli = BudgetLineItem(
         agreement_id=context["agreement"].id,
         comments="blah blah",
-        line_description="LI 1",
         amount=100.12,
         can_id=1,
         date_needed=datetime.date(2022, 1, 1),
@@ -456,7 +427,6 @@ def bli_without_can(loaded_db, context):
     initial_bli = BudgetLineItem(
         agreement_id=context["agreement"].id,
         comments="blah blah",
-        line_description="LI 1",
         amount=100.12,
         date_needed=datetime.date(2043, 1, 1),
         status=BudgetLineItemStatus.DRAFT,
@@ -474,7 +444,6 @@ def bli_without_amount(loaded_db, context):
     initial_bli = BudgetLineItem(
         agreement_id=context["agreement"].id,
         comments="blah blah",
-        line_description="LI 1",
         can_id=1,
         date_needed=datetime.date(2043, 1, 1),
         status=BudgetLineItemStatus.DRAFT,
@@ -492,7 +461,6 @@ def bli_with_amount_less_than_or_equal_to_zero(loaded_db, context):
     initial_bli = BudgetLineItem(
         agreement_id=context["agreement"].id,
         comments="blah blah",
-        line_description="LI 1",
         amount=0,
         can_id=1,
         date_needed=datetime.date(2043, 1, 1),
@@ -510,7 +478,6 @@ def bli_with_amount_less_than_or_equal_to_zero(loaded_db, context):
 def bli_without_agreement(loaded_db, context):
     initial_bli = BudgetLineItem(
         comments="blah blah",
-        line_description="LI 1",
         amount=100.12,
         can_id=1,
         date_needed=datetime.date(2043, 1, 1),
@@ -613,16 +580,6 @@ def error_message_valid_project_officer(context, setup_and_teardown):
     assert context["response_post"].status_code == 400
     assert context["response_post"].json == {
         "_schema": ["BLI's Agreement must have a ProjectOfficer when status is not DRAFT"]
-    }
-
-
-@then("I should get an error message that the BLI must have a Description")
-def error_message_valid_description(context, setup_and_teardown):
-    assert context["response_post"].status_code == 400
-    assert context["response_post"].json == {
-        "_schema": [
-            "BLI must valid a valid Description when status is not DRAFT",
-        ]
     }
 
 

--- a/backend/ops_api/tests/ops/features/validate_draft_budget_lines.feature
+++ b/backend/ops_api/tests/ops/features/validate_draft_budget_lines.feature
@@ -83,34 +83,6 @@ Feature: Validate "Draft" Budget Lines
     Then I should get an error message that the BLI's Agreement must have a Project Officer
 
 
-  Scenario: Valid BLI Description: Both NULL
-    Given I am logged in as an OPS user
-    And I have a valid Agreement
-
-    When I have a BLI in DRAFT status without a Description
-    And I submit a BLI to move to IN_REVIEW status (without Description)
-
-    Then I should get an error message that the BLI must have a Description
-
-  Scenario: Valid BLI Description: Request Empty
-    Given I am logged in as an OPS user
-    And I have a valid Agreement
-
-    When I have a BLI in DRAFT status
-    And I submit a BLI to move to IN_REVIEW status with an empty string Description
-
-    Then I should get an error message that the BLI must have a Description (for PUT only)
-
-  Scenario: Valid BLI Description: Both Empty
-    Given I am logged in as an OPS user
-    And I have a valid Agreement
-
-    When I have a BLI in DRAFT status without a Description
-    And I submit a BLI to move to IN_REVIEW status with an empty string Description
-
-    Then I should get an error message that the BLI must have a Description
-
-
   Scenario: Valid Need By Date: Both NULL
     Given I am logged in as an OPS user
     And I have a valid Agreement

--- a/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/useCreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/UI/WizardSteps/StepCreateBLIsAndSCs/useCreateBLIsAndSCs.hooks.js
@@ -102,7 +102,6 @@ const useCreateBLIsAndSCs = (
             type: "ADD_BUDGET_LINE",
             payload: {
                 id: crypto.getRandomValues(new Uint32Array(1))[0],
-                line_description: ".",
                 services_component_id: servicesComponentId,
                 comments: enteredComments || "",
                 can_id: selectedCan?.id || null,
@@ -128,7 +127,6 @@ const useCreateBLIsAndSCs = (
             type: "EDIT_BUDGET_LINE",
             payload: {
                 id: newBudgetLines[budgetLineBeingEdited].id,
-                line_description: ".",
                 services_component_id: servicesComponentId,
                 comments: enteredComments,
                 can_id: selectedCan?.id,


### PR DESCRIPTION
## What changed

* removed requirement for line_description
* removed the workaround of line_description="." 

More work related to this will come with #2020
This just removes the requirement for line_description

## Issue

#1852 #2047 

## How to test

run the tests
Or manually create budget lines in UI and verify that they have a null line_description.  This will also make display_name like BudgetLineItem#123 when line_description is null.  Which is displayed in the Agreement history.


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

