### PR TITLE
OPS-2053: Fix error on patch BLI with null data_needed

### DIFF
--- a/backend/ops_api/ops/resources/budget_line_items.py
+++ b/backend/ops_api/ops/resources/budget_line_items.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from datetime import date
 from functools import partial
 from typing import Optional
 
@@ -238,6 +237,7 @@ def validate_and_normalize_request_data(schema: Schema) -> dict[str, Any]:
     bli_stmt = select(BudgetLineItem).where(BudgetLineItem.id == id)
     existing_bli = current_app.db_session.scalar(bli_stmt)
     data = get_change_data(request.json, existing_bli, schema, ["id", "status", "agreement_id"], partial=False)
+    data = convert_date_strings_to_dates(data)
 
     with suppress(AttributeError):
         try:
@@ -248,8 +248,5 @@ def validate_and_normalize_request_data(schema: Schema) -> dict[str, Any]:
         if len(data) > 0 and status == BudgetLineItemStatus.PLANNED:
             status = BudgetLineItemStatus.DRAFT
         data["status"] = status
-
-    with suppress(KeyError):
-        data["date_needed"] = date.fromisoformat(data["date_needed"])
 
     return data

--- a/backend/ops_api/tests/ops/can/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/can/test_budget_line_item.py
@@ -792,35 +792,10 @@ def test_patch_budget_line_items_using_e2e_test(auth_client, test_bli):
 
 @pytest.mark.usefixtures("app_ctx")
 @pytest.mark.usefixtures("loaded_db")
-def test_budget_line_items_with_null_date_needed(auth_client):
-    data = POSTRequestBody(
-        line_description="LI 1",
-        comments="blah blah",
-        agreement_id=1,
-        can_id=1,
-        amount=100.12,
-        status="DRAFT",
-        date_needed=None,
-        proc_shop_fee_percentage=1.23,
-        services_component_id=1,
-    )
-    response = auth_client.post("/api/v1/budget-line-items/", json=data.__dict__)
-    assert response.status_code == 201
-    assert response.json["id"] is not None
-    new_bli_id = response.json["id"]
-    assert response.json["line_description"] == "LI 1"
-    assert response.json["amount"] == 100.12
-    assert response.json["status"] == "DRAFT"
-    assert response.json["date_needed"] is None
-    assert response.json["services_component_id"] == 1
-
-    response = auth_client.patch(f"/api/v1/budget-line-items/{new_bli_id}", json={"date_needed": None})
+def test_patch_budget_line_items_with_null_date_needed(auth_client, test_bli):
+    response = auth_client.patch(f"/api/v1/budget-line-items/{test_bli.id}", json={"date_needed": None})
     assert response.status_code == 200
-    assert response.json["line_description"] == "LI 1"
-    assert response.json["amount"] == 100.12
-    assert response.json["status"] == "DRAFT"
     assert response.json["date_needed"] is None
-    assert response.json["services_component_id"] == 1
 
 
 @pytest.mark.usefixtures("app_ctx")

--- a/backend/ops_api/tests/ops/can/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/can/test_budget_line_item.py
@@ -791,6 +791,39 @@ def test_patch_budget_line_items_using_e2e_test(auth_client, test_bli):
 
 
 @pytest.mark.usefixtures("app_ctx")
+@pytest.mark.usefixtures("loaded_db")
+def test_budget_line_items_with_null_date_needed(auth_client):
+    data = POSTRequestBody(
+        line_description="LI 1",
+        comments="blah blah",
+        agreement_id=1,
+        can_id=1,
+        amount=100.12,
+        status="DRAFT",
+        date_needed=None,
+        proc_shop_fee_percentage=1.23,
+        services_component_id=1,
+    )
+    response = auth_client.post("/api/v1/budget-line-items/", json=data.__dict__)
+    assert response.status_code == 201
+    assert response.json["id"] is not None
+    new_bli_id = response.json["id"]
+    assert response.json["line_description"] == "LI 1"
+    assert response.json["amount"] == 100.12
+    assert response.json["status"] == "DRAFT"
+    assert response.json["date_needed"] is None
+    assert response.json["services_component_id"] == 1
+
+    response = auth_client.patch(f"/api/v1/budget-line-items/{new_bli_id}", json={"date_needed": None})
+    assert response.status_code == 200
+    assert response.json["line_description"] == "LI 1"
+    assert response.json["amount"] == 100.12
+    assert response.json["status"] == "DRAFT"
+    assert response.json["date_needed"] is None
+    assert response.json["services_component_id"] == 1
+
+
+@pytest.mark.usefixtures("app_ctx")
 def test_valid_services_component(auth_client, app, test_bli):
     session = app.db_session
     sc = ServicesComponent(contract_agreement_id=6, number=1, optional=False)


### PR DESCRIPTION
## What changed

This fixes an error that occurred with Patch (update) of a BLI with a null date

## Issue
#2053 

## How to test

run the test
`ops_api.tests.ops.can.test_budget_line_item.test_patch_budget_line_items_with_null_date_needed`

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated



