### PR TITLE
linting along with black 24 upgrade

### DIFF
--- a/backend/data_tools/Pipfile
+++ b/backend/data_tools/Pipfile
@@ -29,7 +29,7 @@ pytest-cov = "==4.1.0"
 pytest-mock = "==3.12.0"
 ipython = "==8.22.1"
 pytest-docker = {extras = ["docker-compose-v2"], version = "==2.2.0"}
-black = {extras = ["d"], version = "==23.12.1"}
+black = {extras = ["d"], version = "==24.3.0"}
 types-all = "==1.0.0"
 
 [requires]

--- a/backend/data_tools/Pipfile.lock
+++ b/backend/data_tools/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5efaedd3477db3cd9775e9f59305a0398e2346bc55d2d0a683c0edf872f00adf"
+            "sha256": "b4056d7bee3f2453d288a84b814dc25ce40ca8f4fc84e43b12c88f60b5f4e1c4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -423,7 +423,7 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.0.post0"
         },
         "pytz": {
@@ -438,7 +438,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "sqlalchemy": {
@@ -507,11 +507,11 @@
         },
         "sqlalchemy-utils": {
             "hashes": [
-                "sha256:6c96b0768ea3f15c0dc56b363d386138c562752b84f647fb8d31a2223aaab801",
-                "sha256:a2181bff01eeb84479e38571d2c0718eb52042f9afd8c194d0d02877e84b7d74"
+                "sha256:85cf3842da2bf060760f955f8467b87983fb2e30f1764fd0e24a48307dc8ec6e",
+                "sha256:bc599c8c3b3319e53ce6c5c3c471120bd325d0071fb6f38a10e924e3d07b9990"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.41.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.41.2"
         },
         "typing-extensions": {
             "hashes": [
@@ -672,31 +672,31 @@
                 "d"
             ],
             "hashes": [
-                "sha256:0808494f2b2df923ffc5723ed3c7b096bd76341f6213989759287611e9837d50",
-                "sha256:1fa88a0f74e50e4487477bc0bb900c6781dbddfdfa32691e780bf854c3b4a47f",
-                "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e",
-                "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec",
-                "sha256:3e1b38b3135fd4c025c28c55ddfc236b05af657828a8a6abe5deec419a0b7055",
-                "sha256:3fa4be75ef2a6b96ea8d92b1587dd8cb3a35c7e3d51f0738ced0781c3aa3a5a3",
-                "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5",
-                "sha256:4f0031eaa7b921db76decd73636ef3a12c942ed367d8c3841a0739412b260a54",
-                "sha256:602cfb1196dc692424c70b6507593a2b29aac0547c1be9a1d1365f0d964c353b",
-                "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e",
-                "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e",
-                "sha256:8d4df77958a622f9b5a4c96edb4b8c0034f8434032ab11077ec6c56ae9f384ba",
-                "sha256:97e56155c6b737854e60a9ab1c598ff2533d57e7506d97af5481141671abf3ea",
-                "sha256:9c4352800f14be5b4864016882cdba10755bd50805c95f728011bcb47a4afd59",
-                "sha256:a4d6a9668e45ad99d2f8ec70d5c8c04ef4f32f648ef39048d010b0689832ec6d",
-                "sha256:a920b569dc6b3472513ba6ddea21f440d4b4c699494d2e972a1753cdc25df7b0",
-                "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9",
-                "sha256:b18fb2ae6c4bb63eebe5be6bd869ba2f14fd0259bda7d18a46b764d8fb86298a",
-                "sha256:c04b6d9d20e9c13f43eee8ea87d44156b8505ca8a3c878773f68b4e4812a421e",
-                "sha256:c88b3711d12905b74206227109272673edce0cb29f27e1385f33b0163c414bba",
-                "sha256:dd15245c8b68fe2b6bd0f32c1556509d11bb33aec9b5d0866dd8e2ed3dba09c2",
-                "sha256:e0aaf6041986767a5e0ce663c7a2f0e9eaf21e6ff87a5f95cbf3675bfd4c41d2"
+                "sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f",
+                "sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93",
+                "sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11",
+                "sha256:4be5bb28e090456adfc1255e03967fb67ca846a03be7aadf6249096100ee32d0",
+                "sha256:4f1373a7808a8f135b774039f61d59e4be7eb56b2513d3d2f02a8b9365b8a8a9",
+                "sha256:56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5",
+                "sha256:65b76c275e4c1c5ce6e9870911384bff5ca31ab63d19c76811cb1fb162678213",
+                "sha256:65c02e4ea2ae09d16314d30912a58ada9a5c4fdfedf9512d23326128ac08ac3d",
+                "sha256:6905238a754ceb7788a73f02b45637d820b2f5478b20fec82ea865e4f5d4d9f7",
+                "sha256:79dcf34b33e38ed1b17434693763301d7ccbd1c5860674a8f871bd15139e7837",
+                "sha256:7bb041dca0d784697af4646d3b62ba4a6b028276ae878e53f6b4f74ddd6db99f",
+                "sha256:7d5e026f8da0322b5662fa7a8e752b3fa2dac1c1cbc213c3d7ff9bdd0ab12395",
+                "sha256:9f50ea1132e2189d8dff0115ab75b65590a3e97de1e143795adb4ce317934995",
+                "sha256:a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f",
+                "sha256:aadf7a02d947936ee418777e0247ea114f78aff0d0959461057cae8a04f20597",
+                "sha256:b5991d523eee14756f3c8d5df5231550ae8993e2286b8014e2fdea7156ed0959",
+                "sha256:bf21b7b230718a5f08bd32d5e4f1db7fc8788345c8aea1d155fc17852b3410f5",
+                "sha256:c45f8dff244b3c431b36e3224b6be4a127c6aca780853574c00faf99258041eb",
+                "sha256:c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4",
+                "sha256:d7de8d330763c66663661a1ffd432274a2f92f07feeddd89ffd085b5744f85e7",
+                "sha256:e19cb1c6365fd6dc38a6eae2dcb691d7d83935c10215aef8e6c38edee3f77abd",
+                "sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==23.12.1"
+            "version": "==24.3.0"
         },
         "cffi": {
             "hashes": [
@@ -904,11 +904,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e",
-                "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"
+                "sha256:5ffa845303983e7a0b7ae17636509bc97997d58afeafa72fb141a17b152284cb",
+                "sha256:a79895a25bbefdf55d1a2a0a80968f7dbb28edcd6d4234a0afb3f37ecde4b546"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.13.1"
+            "version": "==3.13.3"
         },
         "flake8": {
             "hashes": [
@@ -1482,7 +1482,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "stack-data": {
@@ -1646,11 +1646,11 @@
         },
         "types-croniter": {
             "hashes": [
-                "sha256:29fc0aa0294815f07a3e2bbf2b8027902f6e5eeeafce800af0381df12da6fe42",
-                "sha256:2b3b903b40276160b2cb1a135226f3d1c90643eaedec492324ef68ed1c144c5b"
+                "sha256:5d9560e0fd3cf0299860e886f3cb19c38ec22135cee7b2e69daa8b2312c4f24c",
+                "sha256:8dc34f7e7bdc6ca9b581a7f7f28ad1dc757cd1ada618d425b00cd66149ec9374"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.0.0.20240318"
+            "version": "==2.0.0.20240321"
         },
         "types-cryptography": {
             "hashes": [
@@ -1901,11 +1901,11 @@
         },
         "types-pillow": {
             "hashes": [
-                "sha256:34ca2fe768c6b1d05f288374c1a5ef9437f75faa1f91437b43c50970bbb54a94",
-                "sha256:f611f6baf7c3784fe550ee92b108060f5544a47c37c73acb81a785f1c6312772"
+                "sha256:e0108f0b30ea926a3a5d00f201cde627cde1574181b586eb36dd6be1e4ba09cf",
+                "sha256:e0ac3b50ade911b2a238b6633cc6be9559a6f8bc54141db6ad13b70989fd3d99"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.2.0.20240311"
+            "version": "==10.2.0.20240324"
         },
         "types-pkg-resources": {
             "hashes": [
@@ -1916,11 +1916,11 @@
         },
         "types-polib": {
             "hashes": [
-                "sha256:5b4be206688c62f34cdd328b92e6001ac1b02f9ff50820f284a7ca47164b7440",
-                "sha256:ca7d39f461d106e5f10e6d9e14ac0ecefb8210641b4d3d9ee36e47d19d4b8b5a"
+                "sha256:8cf6746e87f652599f06ac755fdd61e4582c756e7714f393fc6a89a8e8a5b152",
+                "sha256:d86add535343c293d3f94a16caca6ec3110ccc194a144743769f146cef6fa30d"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.2.0.20240115"
+            "version": "==1.2.0.20240327"
         },
         "types-protobuf": {
             "hashes": [

--- a/backend/ops_api/.flake8
+++ b/backend/ops_api/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 select = B,B9,BLK,C,E,F,S,W
-ignore = E203,E501,W503
+ignore = E203,E501,W503,E704
 per-file-ignores = tests/*:S101
 
 max-complexity = 10

--- a/backend/ops_api/Pipfile
+++ b/backend/ops_api/Pipfile
@@ -33,7 +33,7 @@ nox = "==2024.3.2"
 ipython = "==8.22.1"
 types-all = "==1.0.0"
 pytest-flask = "==1.3.0"
-black = {extras = ["d"], version = "==23.12.1"}
+black = {extras = ["d"], version = "==24.3.0"}
 flake8-black = "==0.3.6"
 pytest-cov = "==4.1.0"
 pytest-docker = {extras = ["docker-compose-v2"], version = "==2.2.0"}

--- a/backend/ops_api/Pipfile.lock
+++ b/backend/ops_api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b28ef08fdadf252848946399be79094cf310606d474694c585c0fdba1a456173"
+            "sha256": "2b861480bcf8ddd6135a62c0443eb407458e84aa220cc7dd9c8d5bb1b83ee9f1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,6 +22,7 @@
                 "sha256:4932c8558bf68f2ee92b9bbcb8218671c627064d5b08939437af6d77dc05e595"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==1.13.1"
         },
         "alembic-postgresql-enum": {
@@ -30,6 +31,7 @@
                 "sha256:7c23303b4383d23bbb8aafbd9541cd744e37b476e93fa8dc6d27a157c7c8e597"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
             "version": "==1.1.2"
         },
         "attrs": {
@@ -37,7 +39,7 @@
                 "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30",
                 "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==23.2.0"
         },
         "authlib": {
@@ -46,6 +48,7 @@
                 "sha256:9637e4de1fb498310a56900b3e2043a206b03cb11c05422014b0302cbc814be3"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==1.3.0"
         },
         "azure-core": {
@@ -53,7 +56,7 @@
                 "sha256:26273a254131f84269e8ea4464f3560c731f29c0c1f69ac99010845f239c1a8f",
                 "sha256:7c5ee397e48f281ec4dd773d67a0a47a0962ed6fa833036057f9ea067f688e74"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==1.30.1"
         },
         "azure-identity": {
@@ -62,6 +65,7 @@
                 "sha256:a14b1f01c7036f11f148f22cd8c16e05035293d714458d6b44ddf534d93eb912"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==1.15.0"
         },
         "azure-storage-blob": {
@@ -70,6 +74,7 @@
                 "sha256:7bbc2c9c16678f7a420367fef6b172ba8730a7e66df7f4d7a55d5b3c8216615b"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==12.19.0"
         },
         "blinker": {
@@ -247,7 +252,7 @@
                 "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
                 "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
         },
         "cryptography": {
@@ -285,7 +290,7 @@
                 "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac",
                 "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==42.0.5"
         },
         "desert": {
@@ -294,6 +299,7 @@
                 "sha256:cad7b6f1936448d26bde403882ec6855786b4d24d38d0ed4400e505ac8c5591f"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==2022.9.22"
         },
         "flask": {
@@ -302,6 +308,7 @@
                 "sha256:f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==2.3.3"
         },
         "flask-cors": {
@@ -320,8 +327,72 @@
                 "sha256:63a28fc9731bcc6c4b8815b6f954b5904caa534fc2ae9b93b1d3ef12930dca95",
                 "sha256:9215d05a9413d3855764bcd67035e75819d23af2fafb6b55197eb5a3313fdfb2"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==4.6.0"
+        },
+        "greenlet": {
+            "hashes": [
+                "sha256:01bc7ea167cf943b4c802068e178bbf70ae2e8c080467070d01bfa02f337ee67",
+                "sha256:0448abc479fab28b00cb472d278828b3ccca164531daab4e970a0458786055d6",
+                "sha256:086152f8fbc5955df88382e8a75984e2bb1c892ad2e3c80a2508954e52295257",
+                "sha256:098d86f528c855ead3479afe84b49242e174ed262456c342d70fc7f972bc13c4",
+                "sha256:149e94a2dd82d19838fe4b2259f1b6b9957d5ba1b25640d2380bea9c5df37676",
+                "sha256:1551a8195c0d4a68fac7a4325efac0d541b48def35feb49d803674ac32582f61",
+                "sha256:15d79dd26056573940fcb8c7413d84118086f2ec1a8acdfa854631084393efcc",
+                "sha256:1996cb9306c8595335bb157d133daf5cf9f693ef413e7673cb07e3e5871379ca",
+                "sha256:1a7191e42732df52cb5f39d3527217e7ab73cae2cb3694d241e18f53d84ea9a7",
+                "sha256:1ea188d4f49089fc6fb283845ab18a2518d279c7cd9da1065d7a84e991748728",
+                "sha256:1f672519db1796ca0d8753f9e78ec02355e862d0998193038c7073045899f305",
+                "sha256:2516a9957eed41dd8f1ec0c604f1cdc86758b587d964668b5b196a9db5bfcde6",
+                "sha256:2797aa5aedac23af156bbb5a6aa2cd3427ada2972c828244eb7d1b9255846379",
+                "sha256:2dd6e660effd852586b6a8478a1d244b8dc90ab5b1321751d2ea15deb49ed414",
+                "sha256:3ddc0f794e6ad661e321caa8d2f0a55ce01213c74722587256fb6566049a8b04",
+                "sha256:3ed7fb269f15dc662787f4119ec300ad0702fa1b19d2135a37c2c4de6fadfd4a",
+                "sha256:419b386f84949bf0e7c73e6032e3457b82a787c1ab4a0e43732898a761cc9dbf",
+                "sha256:43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491",
+                "sha256:52f59dd9c96ad2fc0d5724107444f76eb20aaccb675bf825df6435acb7703559",
+                "sha256:57e8974f23e47dac22b83436bdcf23080ade568ce77df33159e019d161ce1d1e",
+                "sha256:5b51e85cb5ceda94e79d019ed36b35386e8c37d22f07d6a751cb659b180d5274",
+                "sha256:649dde7de1a5eceb258f9cb00bdf50e978c9db1b996964cd80703614c86495eb",
+                "sha256:64d7675ad83578e3fc149b617a444fab8efdafc9385471f868eb5ff83e446b8b",
+                "sha256:68834da854554926fbedd38c76e60c4a2e3198c6fbed520b106a8986445caaf9",
+                "sha256:6b66c9c1e7ccabad3a7d037b2bcb740122a7b17a53734b7d72a344ce39882a1b",
+                "sha256:70fb482fdf2c707765ab5f0b6655e9cfcf3780d8d87355a063547b41177599be",
+                "sha256:7170375bcc99f1a2fbd9c306f5be8764eaf3ac6b5cb968862cad4c7057756506",
+                "sha256:73a411ef564e0e097dbe7e866bb2dda0f027e072b04da387282b02c308807405",
+                "sha256:77457465d89b8263bca14759d7c1684df840b6811b2499838cc5b040a8b5b113",
+                "sha256:7f362975f2d179f9e26928c5b517524e89dd48530a0202570d55ad6ca5d8a56f",
+                "sha256:81bb9c6d52e8321f09c3d165b2a78c680506d9af285bfccbad9fb7ad5a5da3e5",
+                "sha256:881b7db1ebff4ba09aaaeae6aa491daeb226c8150fc20e836ad00041bcb11230",
+                "sha256:894393ce10ceac937e56ec00bb71c4c2f8209ad516e96033e4b3b1de270e200d",
+                "sha256:99bf650dc5d69546e076f413a87481ee1d2d09aaaaaca058c9251b6d8c14783f",
+                "sha256:9da2bd29ed9e4f15955dd1595ad7bc9320308a3b766ef7f837e23ad4b4aac31a",
+                "sha256:afaff6cf5200befd5cec055b07d1c0a5a06c040fe5ad148abcd11ba6ab9b114e",
+                "sha256:b1b5667cced97081bf57b8fa1d6bfca67814b0afd38208d52538316e9422fc61",
+                "sha256:b37eef18ea55f2ffd8f00ff8fe7c8d3818abd3e25fb73fae2ca3b672e333a7a6",
+                "sha256:b542be2440edc2d48547b5923c408cbe0fc94afb9f18741faa6ae970dbcb9b6d",
+                "sha256:b7dcbe92cc99f08c8dd11f930de4d99ef756c3591a5377d1d9cd7dd5e896da71",
+                "sha256:b7f009caad047246ed379e1c4dbcb8b020f0a390667ea74d2387be2998f58a22",
+                "sha256:bba5387a6975598857d86de9eac14210a49d554a77eb8261cc68b7d082f78ce2",
+                "sha256:c5e1536de2aad7bf62e27baf79225d0d64360d4168cf2e6becb91baf1ed074f3",
+                "sha256:c5ee858cfe08f34712f548c3c363e807e7186f03ad7a5039ebadb29e8c6be067",
+                "sha256:c9db1c18f0eaad2f804728c67d6c610778456e3e1cc4ab4bbd5eeb8e6053c6fc",
+                "sha256:d353cadd6083fdb056bb46ed07e4340b0869c305c8ca54ef9da3421acbdf6881",
+                "sha256:d46677c85c5ba00a9cb6f7a00b2bfa6f812192d2c9f7d9c4f6a55b60216712f3",
+                "sha256:d4d1ac74f5c0c0524e4a24335350edad7e5f03b9532da7ea4d3c54d527784f2e",
+                "sha256:d73a9fe764d77f87f8ec26a0c85144d6a951a6c438dfe50487df5595c6373eac",
+                "sha256:da70d4d51c8b306bb7a031d5cff6cc25ad253affe89b70352af5f1cb68e74b53",
+                "sha256:daf3cb43b7cf2ba96d614252ce1684c1bccee6b2183a01328c98d36fcd7d5cb0",
+                "sha256:dca1e2f3ca00b84a396bc1bce13dd21f680f035314d2379c4160c98153b2059b",
+                "sha256:dd4f49ae60e10adbc94b45c0b5e6a179acc1736cf7a90160b404076ee283cf83",
+                "sha256:e1f145462f1fa6e4a4ae3c0f782e580ce44d57c8f2c7aae1b6fa88c0b2efdb41",
+                "sha256:e3391d1e16e2a5a1507d83e4a8b100f4ee626e8eca43cf2cadb543de69827c4c",
+                "sha256:fcd2469d6a2cf298f198f0487e0a5b1a47a42ca0fa4dfd1b6862c999f018ebbf",
+                "sha256:fd096eb7ffef17c456cfa587523c5f92321ae02427ff955bebe9e3c63bc9f0da",
+                "sha256:fe754d231288e1e64323cfad462fcee8f0288654c10bdf4f603a39ed923bef33"
+            ],
+            "markers": "platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "version": "==3.0.3"
         },
         "gunicorn": {
             "hashes": [
@@ -329,6 +400,7 @@
                 "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.5'",
             "version": "==21.2.0"
         },
         "idna": {
@@ -351,7 +423,7 @@
                 "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44",
                 "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==2.1.2"
         },
         "jinja2": {
@@ -359,7 +431,7 @@
                 "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa",
                 "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==3.1.3"
         },
         "mako": {
@@ -434,6 +506,7 @@
                 "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.1.5"
         },
         "marshmallow": {
@@ -450,6 +523,7 @@
                 "sha256:a21f4d050a1d24249fd43aa56c7e4aea4b6454e049dc2c5f1496f479e30bf5d7"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==8.6.0"
         },
         "marshmallow-enum": {
@@ -466,6 +540,7 @@
                 "sha256:808c1e95bf72f4491ad2f3498e73116b33074d7dcef79f0e6997d0d37d648ac7"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==0.30.0"
         },
         "msal": {
@@ -473,7 +548,7 @@
                 "sha256:3064f80221a21cd535ad8c3fafbb3a3582cd9c7e9af0bb789ae14f726a0ca99b",
                 "sha256:80bbabe34567cb734efd2ec1869b2d98195c927455369d8077b3c542088c5c9d"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==1.28.0"
         },
         "msal-extensions": {
@@ -481,7 +556,7 @@
                 "sha256:01be9711b4c0b1a151450068eeb2c4f0997df3bba085ac299de3a66f585e382f",
                 "sha256:6ab357867062db7b253d0bd2df6d411c7891a0ee7308d54d1e4317c1d1c54252"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==1.1.0"
         },
         "mypy": {
@@ -515,6 +590,7 @@
                 "sha256:f5ac9a4eeb1ec0f1ccdc6f326bcdb464de5f80eb07fb38b5ddd7b0de6bc61e55"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==1.8.0"
         },
         "mypy-extensions": {
@@ -530,7 +606,7 @@
                 "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
                 "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==24.0"
         },
         "portalocker": {
@@ -617,6 +693,7 @@
                 "sha256:f9b5571d33660d5009a8b3c25dc1db560206e2d2f89d3df1cb32d72c0d117d52"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.9.9"
         },
         "pycparser": {
@@ -627,11 +704,14 @@
             "version": "==2.21"
         },
         "pyjwt": {
+            "extras": [
+                "crypto"
+            ],
             "hashes": [
                 "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de",
                 "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==2.8.0"
         },
         "requests": {
@@ -640,6 +720,7 @@
                 "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
         },
         "six": {
@@ -703,6 +784,7 @@
                 "sha256:ff2f1b7c963961d41403b650842dc2039175b906ab2093635d8319bef0b7d620"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.0.27"
         },
         "sqlalchemy-continuum": {
@@ -715,11 +797,11 @@
         },
         "sqlalchemy-utils": {
             "hashes": [
-                "sha256:6c96b0768ea3f15c0dc56b363d386138c562752b84f647fb8d31a2223aaab801",
-                "sha256:a2181bff01eeb84479e38571d2c0718eb52042f9afd8c194d0d02877e84b7d74"
+                "sha256:85cf3842da2bf060760f955f8467b87983fb2e30f1764fd0e24a48307dc8ec6e",
+                "sha256:bc599c8c3b3319e53ce6c5c3c471120bd325d0071fb6f38a10e924e3d07b9990"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==0.41.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.41.2"
         },
         "tomli": {
             "hashes": [
@@ -734,7 +816,7 @@
                 "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
                 "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_version < '3.11' and python_version >= '3.7'",
             "version": "==4.10.0"
         },
         "typing-inspect": {
@@ -879,7 +961,7 @@
                 "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30",
                 "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==23.2.0"
         },
         "black": {
@@ -887,31 +969,31 @@
                 "d"
             ],
             "hashes": [
-                "sha256:0808494f2b2df923ffc5723ed3c7b096bd76341f6213989759287611e9837d50",
-                "sha256:1fa88a0f74e50e4487477bc0bb900c6781dbddfdfa32691e780bf854c3b4a47f",
-                "sha256:25e57fd232a6d6ff3f4478a6fd0580838e47c93c83eaf1ccc92d4faf27112c4e",
-                "sha256:2d9e13db441c509a3763a7a3d9a49ccc1b4e974a47be4e08ade2a228876500ec",
-                "sha256:3e1b38b3135fd4c025c28c55ddfc236b05af657828a8a6abe5deec419a0b7055",
-                "sha256:3fa4be75ef2a6b96ea8d92b1587dd8cb3a35c7e3d51f0738ced0781c3aa3a5a3",
-                "sha256:4ce3ef14ebe8d9509188014d96af1c456a910d5b5cbf434a09fef7e024b3d0d5",
-                "sha256:4f0031eaa7b921db76decd73636ef3a12c942ed367d8c3841a0739412b260a54",
-                "sha256:602cfb1196dc692424c70b6507593a2b29aac0547c1be9a1d1365f0d964c353b",
-                "sha256:6d1bd9c210f8b109b1762ec9fd36592fdd528485aadb3f5849b2740ef17e674e",
-                "sha256:78baad24af0f033958cad29731e27363183e140962595def56423e626f4bee3e",
-                "sha256:8d4df77958a622f9b5a4c96edb4b8c0034f8434032ab11077ec6c56ae9f384ba",
-                "sha256:97e56155c6b737854e60a9ab1c598ff2533d57e7506d97af5481141671abf3ea",
-                "sha256:9c4352800f14be5b4864016882cdba10755bd50805c95f728011bcb47a4afd59",
-                "sha256:a4d6a9668e45ad99d2f8ec70d5c8c04ef4f32f648ef39048d010b0689832ec6d",
-                "sha256:a920b569dc6b3472513ba6ddea21f440d4b4c699494d2e972a1753cdc25df7b0",
-                "sha256:ae76c22bde5cbb6bfd211ec343ded2163bba7883c7bc77f6b756a1049436fbb9",
-                "sha256:b18fb2ae6c4bb63eebe5be6bd869ba2f14fd0259bda7d18a46b764d8fb86298a",
-                "sha256:c04b6d9d20e9c13f43eee8ea87d44156b8505ca8a3c878773f68b4e4812a421e",
-                "sha256:c88b3711d12905b74206227109272673edce0cb29f27e1385f33b0163c414bba",
-                "sha256:dd15245c8b68fe2b6bd0f32c1556509d11bb33aec9b5d0866dd8e2ed3dba09c2",
-                "sha256:e0aaf6041986767a5e0ce663c7a2f0e9eaf21e6ff87a5f95cbf3675bfd4c41d2"
+                "sha256:2818cf72dfd5d289e48f37ccfa08b460bf469e67fb7c4abb07edc2e9f16fb63f",
+                "sha256:41622020d7120e01d377f74249e677039d20e6344ff5851de8a10f11f513bf93",
+                "sha256:4acf672def7eb1725f41f38bf6bf425c8237248bb0804faa3965c036f7672d11",
+                "sha256:4be5bb28e090456adfc1255e03967fb67ca846a03be7aadf6249096100ee32d0",
+                "sha256:4f1373a7808a8f135b774039f61d59e4be7eb56b2513d3d2f02a8b9365b8a8a9",
+                "sha256:56f52cfbd3dabe2798d76dbdd299faa046a901041faf2cf33288bc4e6dae57b5",
+                "sha256:65b76c275e4c1c5ce6e9870911384bff5ca31ab63d19c76811cb1fb162678213",
+                "sha256:65c02e4ea2ae09d16314d30912a58ada9a5c4fdfedf9512d23326128ac08ac3d",
+                "sha256:6905238a754ceb7788a73f02b45637d820b2f5478b20fec82ea865e4f5d4d9f7",
+                "sha256:79dcf34b33e38ed1b17434693763301d7ccbd1c5860674a8f871bd15139e7837",
+                "sha256:7bb041dca0d784697af4646d3b62ba4a6b028276ae878e53f6b4f74ddd6db99f",
+                "sha256:7d5e026f8da0322b5662fa7a8e752b3fa2dac1c1cbc213c3d7ff9bdd0ab12395",
+                "sha256:9f50ea1132e2189d8dff0115ab75b65590a3e97de1e143795adb4ce317934995",
+                "sha256:a0c9c4a0771afc6919578cec71ce82a3e31e054904e7197deacbc9382671c41f",
+                "sha256:aadf7a02d947936ee418777e0247ea114f78aff0d0959461057cae8a04f20597",
+                "sha256:b5991d523eee14756f3c8d5df5231550ae8993e2286b8014e2fdea7156ed0959",
+                "sha256:bf21b7b230718a5f08bd32d5e4f1db7fc8788345c8aea1d155fc17852b3410f5",
+                "sha256:c45f8dff244b3c431b36e3224b6be4a127c6aca780853574c00faf99258041eb",
+                "sha256:c7ed6668cbbfcd231fa0dc1b137d3e40c04c7f786e626b405c62bcd5db5857e4",
+                "sha256:d7de8d330763c66663661a1ffd432274a2f92f07feeddd89ffd085b5744f85e7",
+                "sha256:e19cb1c6365fd6dc38a6eae2dcb691d7d83935c10215aef8e6c38edee3f77abd",
+                "sha256:e2af80566f43c85f5797365077fb64a393861a3730bd110971ab7a0c94e873e7"
             ],
-            "index": "pypi",
-            "version": "==23.12.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==24.3.0"
         },
         "blinker": {
             "hashes": [
@@ -984,7 +1066,7 @@
                 "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
                 "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==8.1.7"
         },
         "colorlog": {
@@ -1091,7 +1173,7 @@
                 "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac",
                 "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==42.0.5"
         },
         "decorator": {
@@ -1127,11 +1209,11 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e",
-                "sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c"
+                "sha256:5ffa845303983e7a0b7ae17636509bc97997d58afeafa72fb141a17b152284cb",
+                "sha256:a79895a25bbefdf55d1a2a0a80968f7dbb28edcd6d4234a0afb3f37ecde4b546"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.13.1"
+            "version": "==3.13.3"
         },
         "flake8": {
             "hashes": [
@@ -1139,6 +1221,7 @@
                 "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.8.1'",
             "version": "==7.0.0"
         },
         "flake8-black": {
@@ -1147,6 +1230,7 @@
                 "sha256:fe8ea2eca98d8a504f22040d9117347f6b367458366952862ac3586e7d4eeaca"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==0.3.6"
         },
         "flask": {
@@ -1155,6 +1239,7 @@
                 "sha256:f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==2.3.3"
         },
         "frozenlist": {
@@ -1262,6 +1347,7 @@
                 "sha256:869335e8cded62ffb6fac8928e5287a05433d6462e3ebaac25f4216474dd6bc4"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.10'",
             "version": "==8.22.1"
         },
         "isort": {
@@ -1270,6 +1356,7 @@
                 "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.8.0'",
             "version": "==5.13.2"
         },
         "itsdangerous": {
@@ -1277,7 +1364,7 @@
                 "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44",
                 "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==2.1.2"
         },
         "jedi": {
@@ -1293,7 +1380,7 @@
                 "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa",
                 "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==3.1.3"
         },
         "mako": {
@@ -1368,6 +1455,7 @@
                 "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.1.5"
         },
         "matplotlib-inline": {
@@ -1496,6 +1584,7 @@
                 "sha256:f521ae08a15adbf5e11f16cb34e8d0e6ea521e0b92868f684e91677deb974553"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2024.3.2"
         },
         "numpy": {
@@ -1545,7 +1634,7 @@
                 "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
                 "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7'",
             "version": "==24.0"
         },
         "parse": {
@@ -1608,7 +1697,7 @@
                 "sha256:3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d",
                 "sha256:a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_full_version >= '3.7.0'",
             "version": "==3.0.43"
         },
         "ptyprocess": {
@@ -1662,6 +1751,7 @@
                 "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==7.4.4"
         },
         "pytest-bdd": {
@@ -1670,6 +1760,7 @@
                 "sha256:faf115b9de793dc2341e898347f936c3766179a54a018c132796302b120918e5"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==7.0.1"
         },
         "pytest-cov": {
@@ -1678,6 +1769,7 @@
                 "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==4.1.0"
         },
         "pytest-docker": {
@@ -1688,7 +1780,7 @@
                 "sha256:8ee9c9742d58ac079c81c03635bb830881f7f4d529f0f53f4ba2c89ffc9c7137",
                 "sha256:b083fd2ae69212369390033c22228d3263555a5f3b4bef87b74160e07218f377"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==2.2.0"
         },
         "pytest-flask": {
@@ -1697,6 +1789,7 @@
                 "sha256:c0e36e6b0fddc3b91c4362661db83fa694d1feb91fa505475be6732b5bc8c253"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==1.3.0"
         },
         "pytest-mock": {
@@ -1705,6 +1798,7 @@
                 "sha256:31a40f038c22cad32287bb43932054451ff5583ff094bca6f675df2f8bc1a6e9"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==3.12.0"
         },
         "six": {
@@ -1752,6 +1846,7 @@
                 "sha256:b61d204c31b733e4296e666399c0ecf829844ab7080d77e5404fa55ef1d7d972"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.6.1'",
             "version": "==1.0.0"
         },
         "types-annoy": {
@@ -2122,11 +2217,11 @@
         },
         "types-pillow": {
             "hashes": [
-                "sha256:34ca2fe768c6b1d05f288374c1a5ef9437f75faa1f91437b43c50970bbb54a94",
-                "sha256:f611f6baf7c3784fe550ee92b108060f5544a47c37c73acb81a785f1c6312772"
+                "sha256:e0108f0b30ea926a3a5d00f201cde627cde1574181b586eb36dd6be1e4ba09cf",
+                "sha256:e0ac3b50ade911b2a238b6633cc6be9559a6f8bc54141db6ad13b70989fd3d99"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==10.2.0.20240311"
+            "version": "==10.2.0.20240324"
         },
         "types-pkg-resources": {
             "hashes": [
@@ -2137,11 +2232,11 @@
         },
         "types-polib": {
             "hashes": [
-                "sha256:5b4be206688c62f34cdd328b92e6001ac1b02f9ff50820f284a7ca47164b7440",
-                "sha256:ca7d39f461d106e5f10e6d9e14ac0ecefb8210641b4d3d9ee36e47d19d4b8b5a"
+                "sha256:8cf6746e87f652599f06ac755fdd61e4582c756e7714f393fc6a89a8e8a5b152",
+                "sha256:d86add535343c293d3f94a16caca6ec3110ccc194a144743769f146cef6fa30d"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.2.0.20240115"
+            "version": "==1.2.0.20240327"
         },
         "types-protobuf": {
             "hashes": [
@@ -2413,7 +2508,7 @@
                 "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475",
                 "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
             ],
-            "markers": "python_version >= '3.8'",
+            "markers": "python_version < '3.11' and python_version >= '3.7'",
             "version": "==4.10.0"
         },
         "urllib3": {

--- a/backend/ops_api/ops/resources/procurement_shops.py
+++ b/backend/ops_api/ops/resources/procurement_shops.py
@@ -1,4 +1,5 @@
 """Module containing views for Procurement Shops."""
+
 from flask import Response
 from typing_extensions import override
 

--- a/backend/ops_api/ops/resources/product_service_code.py
+++ b/backend/ops_api/ops/resources/product_service_code.py
@@ -1,4 +1,5 @@
 """Module containing views for Product Service Codes."""
+
 from flask import Response
 from typing_extensions import override
 

--- a/backend/ops_api/ops/resources/workflow_submit.py
+++ b/backend/ops_api/ops/resources/workflow_submit.py
@@ -59,9 +59,7 @@ class WorkflowSubmisionListApi(BaseItemAPI):
         target_bli_status = (
             BudgetLineItemStatus.PLANNED
             if workflow_action == WorkflowAction.DRAFT_TO_PLANNED
-            else BudgetLineItemStatus.IN_EXECUTION
-            if workflow_action == WorkflowAction.PLANNED_TO_EXECUTING
-            else None
+            else BudgetLineItemStatus.IN_EXECUTION if workflow_action == WorkflowAction.PLANNED_TO_EXECUTING else None
         )
         # Create new Package
         new_package = Package()

--- a/backend/ops_api/tests/ops/can/test_can_fiscal_year_carry_over.py
+++ b/backend/ops_api/tests/ops/can/test_can_fiscal_year_carry_over.py
@@ -1,4 +1,5 @@
 """FY carry forward tests."""
+
 import pytest
 
 from models.cans import CANFiscalYearCarryForward

--- a/backend/ops_api/tests/ops/conftest.py
+++ b/backend/ops_api/tests/ops/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for pytest tests."""
+
 import subprocess
 from collections.abc import Generator
 

--- a/backend/ops_api/tests/ops/features/test_edit_planned_budget_line.py
+++ b/backend/ops_api/tests/ops/features/test_edit_planned_budget_line.py
@@ -47,28 +47,23 @@ def no_perms_client(no_perms_auth_client):
 
 
 @scenario("edit_planned_budget_line.feature", "Successful Edit as Owner")
-def test_edit_planned_budget_line_owner():
-    ...
+def test_edit_planned_budget_line_owner(): ...
 
 
 @scenario("edit_planned_budget_line.feature", "Successful Edit as Project Officer")
-def test_edit_planned_budget_line_project_officer():
-    ...
+def test_edit_planned_budget_line_project_officer(): ...
 
 
 @scenario("edit_planned_budget_line.feature", "Successful Edit as a Team Member")
-def test_edit_planned_budget_line_team_member():
-    ...
+def test_edit_planned_budget_line_team_member(): ...
 
 
 @scenario("edit_planned_budget_line.feature", "Successful Edit as a member of the Budget Team")
-def test_edit_planned_budget_line_budget_team():
-    ...
+def test_edit_planned_budget_line_budget_team(): ...
 
 
 @scenario("edit_planned_budget_line.feature", "Unsuccessful Edit")
-def test_edit_planned_budget_line_unauthorized():
-    ...
+def test_edit_planned_budget_line_unauthorized(): ...
 
 
 @given(

--- a/backend/ops_api/tests/ops/features/test_validate_draft_budget_lines.py
+++ b/backend/ops_api/tests/ops/features/test_validate_draft_budget_lines.py
@@ -41,129 +41,111 @@ def cleanup(loaded_db, context):
 
 
 @scenario("validate_draft_budget_lines.feature", "Valid Project")
-def test_valid_project(loaded_db, context):
-    ...
+def test_valid_project(loaded_db, context): ...
 
 
 @scenario("validate_draft_budget_lines.feature", "Valid Agreement")
-def test_valid_agreement(loaded_db, context):
-    ...
+def test_valid_agreement(loaded_db, context): ...
 
 
 @scenario("validate_draft_budget_lines.feature", "Valid Agreement Description")
-def test_valid_agreement_description(loaded_db, context):
-    ...
+def test_valid_agreement_description(loaded_db, context): ...
 
 
 @scenario("validate_draft_budget_lines.feature", "Valid Product Service Code")
-def test_valid_product_service_code(loaded_db, context):
-    ...
+def test_valid_product_service_code(loaded_db, context): ...
 
 
 @scenario("validate_draft_budget_lines.feature", "Valid Procurement Shop")
-def test_valid_procurement_shop(loaded_db, context):
-    ...
+def test_valid_procurement_shop(loaded_db, context): ...
 
 
 @scenario("validate_draft_budget_lines.feature", "Valid Agreement Reason")
-def test_valid_agreement_reason(loaded_db, context):
-    ...
+def test_valid_agreement_reason(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid Agreement Reason - NEW_REQ does not have an Incumbent",
 )
-def test_valid_agreement_reason_no_incumbent(loaded_db, context):
-    ...
+def test_valid_agreement_reason_no_incumbent(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid Agreement Reason - RECOMPETE and LOGICAL_FOLLOW_ON requires an Incumbent",
 )
-def test_valid_agreement_reason_incumbent_required(loaded_db, context):
-    ...
+def test_valid_agreement_reason_incumbent_required(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid Project Officer",
 )
-def test_valid_project_officer(loaded_db, context):
-    ...
+def test_valid_project_officer(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid Need By Date: Both NULL",
 )
-def test_valid_need_by_date_both_null(loaded_db, context):
-    ...
+def test_valid_need_by_date_both_null(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid Need By Date: Request Empty",
 )
-def test_valid_need_by_date_request_empty(loaded_db, context):
-    ...
+def test_valid_need_by_date_request_empty(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid Need By Date: Both Empty",
 )
-def test_valid_need_by_date_both_empty(loaded_db, context):
-    ...
+def test_valid_need_by_date_both_empty(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid Need By Date: Future Date",
 )
-def test_valid_need_by_date_exists_future_date(loaded_db, context):
-    ...
+def test_valid_need_by_date_exists_future_date(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid CAN: Both NULL",
 )
-def test_valid_can_both_null(loaded_db, context):
-    ...
+def test_valid_can_both_null(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid CAN: Request Empty",
 )
-def test_valid_can_request_empty(loaded_db, context):
-    ...
+def test_valid_can_request_empty(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid Amount: Both NULL",
 )
-def test_valid_amount_both_null(loaded_db, context):
-    ...
+def test_valid_amount_both_null(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid Amount: Request Empty",
 )
-def test_valid_amount_request_empty(loaded_db, context):
-    ...
+def test_valid_amount_request_empty(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines.feature",
     "Valid Amount: Greater than 0",
 )
-def test_valid_amount_greater_than_zero(loaded_db, context):
-    ...
+def test_valid_amount_greater_than_zero(loaded_db, context): ...
 
 
 @pytest.fixture()

--- a/backend/ops_api/tests/ops/features/test_validate_draft_budget_lines_in_workflow.py
+++ b/backend/ops_api/tests/ops/features/test_validate_draft_budget_lines_in_workflow.py
@@ -37,97 +37,83 @@ def cleanup(loaded_db, context):
 
 
 @scenario("validate_draft_budget_lines_in_workflow.feature", "Valid Project")
-def test_valid_project(loaded_db, context):
-    ...
+def test_valid_project(loaded_db, context): ...
 
 
 @scenario("validate_draft_budget_lines_in_workflow.feature", "Valid Agreement")
-def test_valid_agreement(loaded_db, context):
-    ...
+def test_valid_agreement(loaded_db, context): ...
 
 
 @scenario("validate_draft_budget_lines_in_workflow.feature", "Valid Agreement Description")
-def test_valid_agreement_description(loaded_db, context):
-    ...
+def test_valid_agreement_description(loaded_db, context): ...
 
 
 @scenario("validate_draft_budget_lines_in_workflow.feature", "Valid Product Service Code")
-def test_valid_product_service_code(loaded_db, context):
-    ...
+def test_valid_product_service_code(loaded_db, context): ...
 
 
 @scenario("validate_draft_budget_lines_in_workflow.feature", "Valid Procurement Shop")
-def test_valid_procurement_shop(loaded_db, context):
-    ...
+def test_valid_procurement_shop(loaded_db, context): ...
 
 
 @scenario("validate_draft_budget_lines_in_workflow.feature", "Valid Agreement Reason")
-def test_valid_agreement_reason(loaded_db, context):
-    ...
+def test_valid_agreement_reason(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines_in_workflow.feature",
     "Valid Agreement Reason - NEW_REQ does not have an Incumbent",
 )
-def test_valid_agreement_reason_no_incumbent(loaded_db, context):
-    ...
+def test_valid_agreement_reason_no_incumbent(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines_in_workflow.feature",
     "Valid Agreement Reason - RECOMPETE and LOGICAL_FOLLOW_ON requires an Incumbent",
 )
-def test_valid_agreement_reason_incumbent_required(loaded_db, context):
-    ...
+def test_valid_agreement_reason_incumbent_required(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines_in_workflow.feature",
     "Valid Project Officer",
 )
-def test_valid_project_officer(loaded_db, context):
-    ...
+def test_valid_project_officer(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines_in_workflow.feature",
     "Valid Need By Date: Not Null",
 )
-def test_valid_need_by_date_not_null(loaded_db, context):
-    ...
+def test_valid_need_by_date_not_null(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines_in_workflow.feature",
     "Valid Need By Date: Future Date",
 )
-def test_valid_need_by_date_exists_future_date(loaded_db, context):
-    ...
+def test_valid_need_by_date_exists_future_date(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines_in_workflow.feature",
     "Valid CAN: Not NULL",
 )
-def test_valid_can_not_null(loaded_db, context):
-    ...
+def test_valid_can_not_null(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines_in_workflow.feature",
     "Valid Amount: Not NULL",
 )
-def test_valid_amount_not_null(loaded_db, context):
-    ...
+def test_valid_amount_not_null(loaded_db, context): ...
 
 
 @scenario(
     "validate_draft_budget_lines_in_workflow.feature",
     "Valid Amount: Greater than 0",
 )
-def test_valid_amount_greater_than_zero(loaded_db, context):
-    ...
+def test_valid_amount_greater_than_zero(loaded_db, context): ...
 
 
 @pytest.fixture()


### PR DESCRIPTION
## What changed

Upgrades `black` to v24 and re-lints the backend

Also disables E704 in `.flake` config due to disagreement between linters/formatters about whether you can have multiple statements on one line. See inline review for more info

## Issue

[CVE-2024-21503](https://nvd.nist.gov/vuln/detail/CVE-2024-21503)

## How to test

## Links
