### PR TITLE
testing 1.1.4

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun@sha256:2705b32a23594adae93d88cd81d3356ae95f8daf8e64387c3e13811c7d0255d0
+FROM oven/bun@sha256:ea572eace71acadb17ea5c408550eafd5ab82f2f6f48c04b906a3091e017cf35
 RUN useradd -ms /bin/bash app
 USER app
 WORKDIR /home/app


### PR DESCRIPTION
## What changed

Testing out bun 1.1 and its ability to install well in GHA with up-to-date versions of `cypress` but without `node`

## Issue


## How to test

what the GHA tests

## Screenshots
