### PR TITLE
fix: Changed from global install to local, fix permissions

### DIFF
--- a/frontend/Dockerfile.azure
+++ b/frontend/Dockerfile.azure
@@ -32,10 +32,10 @@ RUN chown -R bun:bun .
 USER bun
 
 # Install the runtime script cli package
-RUN bun install -g runtime-env-cra
+RUN bun install runtime-env-cra
 
 # Expose port
 EXPOSE 3000/tcp
 
 # Entry point to run the application.
-ENTRYPOINT ["/bin/sh", "-c", "NODE_ENV=production bun run ~/.bun/bin/runtime-env-cra && bun run index.js"]
+ENTRYPOINT ["/bin/sh", "-c", "NODE_ENV=production bun run ./node_modules/.bin/runtime-env-cra && bun run index.js"]


### PR DESCRIPTION
## What changed

Removed the global install for runtime-env-cra and move to local, updated the entrypoint. 

## Issue

Base image seems to have broken bun installing globally

