### PR TITLE
fix: need runtime dependency of express

### DIFF
--- a/frontend/Dockerfile.azure
+++ b/frontend/Dockerfile.azure
@@ -32,7 +32,7 @@ RUN chown -R bun:bun .
 USER bun
 
 # Install the runtime script cli package
-RUN bun install runtime-env-cra
+RUN bun install runtime-env-cra express
 
 # Expose port
 EXPOSE 3000/tcp


### PR DESCRIPTION
## What changed

Added express to runtime install dependencies for azure. 

## Issue

Server was failing to start in container. 
