### PR TITLE
remove bun from exceptions on renovate upgrades

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,13 +41,12 @@
     },
     "packageRules": [
         {
-            "matchPackageNames": ["python", "oven/bun"],
+            "matchPackageNames": ["python"],
             "enabled": false
         },
         {
             "matchPackageNames": [
-                "python",
-                "oven/bun"
+                "python"
             ],
             "enabled": false,
             "platformAutomerge": true


### PR DESCRIPTION
## What changed

Basically reverses #1872 and allows bun to be managed and kept upgraded with any other dependency. 

## Issue

It's been about a month now since we've been on 1.1.8 and as long as bun has no regressions or other changes in behavior to prevent nominal co-existence with cypress and keep out node, then we should be all set to let it autoupdate

## How to test

Watch CI/CD pipeline and let renovate do its thing each day.

## Screenshots

N/A
