### PR TITLE
Add a couple of missing uses of requestor_notes, reviewer_notes in openapi docs

### DIFF
--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -1655,10 +1655,13 @@ paths:
                 action:
                   type: string
                   description: 'APROVE or REJECT'
+                reviewer_notes:
+                  description: optional notes from the reviewer added the change request
+                  type: string
             examples:
               '0':
                 value: >-
-                  {"change_request_id": 123, "action": "APPROVE"}
+                  {"change_request_id": 123, "action": "APPROVE", "reviewer_notes": "Looks good to me"}
       responses:
         '200':
           description: OK
@@ -2183,6 +2186,10 @@ components:
           $ref: '#/components/parameters/created_by_user'
         updated_by_user:
           $ref: '#/components/parameters/updated_by_user'
+        requestor_notes:
+          description: optional notes added to a Change Request when a PATCH is made that creates a CR
+          type: string
+          writeOnly: true
     BudgetLineItemRequest:
       type: object
       properties:


### PR DESCRIPTION
## What changed

just added a bit of missing openapi docs

