### PR TITLE
removing tf pre-commit and updating main hooks version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: detect-aws-credentials
         args: [--allow-missing-credentials]
@@ -27,11 +27,6 @@ repos:
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
-  - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.86.0
-    hooks:
-      - id: terraform_fmt
-      - id: terraform_tflint
   - repo: local
     hooks:
       - id: nox-lint


### PR DESCRIPTION
## What changed

- It occurred to me that renovate is (sadly) not updating versions specified in the pre-commit config file so I'm doing some manual updating. Version `4.5.0` of the main hooks has some fixes necessary for some scenarios of f-strings in python 3.12, or [so they say](https://github.com/pre-commit/pre-commit-hooks/issues/971). 

- Also I'm removing the terraform config from our pre-commit since we don't have any files currently that it would scan anyway and since all our TF is in a different repo currently anyway.

## Issue

none

## How to test

test out your pre-commit locally on this branch if desired. 

## Screenshots

N/A

