### PR TITLE
hiding login.gov authn option for anything but local dev

### DIFF
--- a/frontend/src/components/Auth/MultiAuthSection.jsx
+++ b/frontend/src/components/Auth/MultiAuthSection.jsx
@@ -111,7 +111,7 @@ const MultiAuthSection = () => {
                         You can access your account by signing in with one of the options below.
                     </p>
                 </div>
-                {!import.meta.env.PROD && (
+                {import.meta.env  && ( //testing for existence of the env being set at all since we don't seem to do that for local environments
                     <p>
                         <button
                             className="usa-button usa-button--outline width-full"

--- a/frontend/src/components/Auth/MultiAuthSection.jsx
+++ b/frontend/src/components/Auth/MultiAuthSection.jsx
@@ -111,7 +111,7 @@ const MultiAuthSection = () => {
                         You can access your account by signing in with one of the options below.
                     </p>
                 </div>
-                {import.meta.env  && ( //testing for existence of the env being set at all since we don't seem to do that for local environments
+                {window.location.href.includes("localhost")  && ( // login.gov is only configured to work locally at the moment
                     <p>
                         <button
                             className="usa-button usa-button--outline width-full"


### PR DESCRIPTION
## What changed

Given [John's recent PR](https://github.com/HHS/OPRE-OPS/pull/2494) that ripped out the config for login.gov in azure and given that our `redirect_uri `on the login.gov side only works for `localhost` anyway and not any hosted environment, I modified the conditional to only show the login.gov authn option when doing local dev. The intent is to create a better UX so that an unknowing user doesn't try to innocently auth with their login.gov sandbox account.

However, this presumes that we don't set the environment variable to something for the non-static FE container build or for local, which seems to be the current practice for the time being. 

## Issue

N/A

## How to test

Hit the front login page.  For any azure non-prod environment, you should see only AMS or AMS plus FakeAuth.  On localhost you should see all 3.