### PR TITLE
2560: making sample data reflect `user` role matching that of `data-initial`

### DIFF
--- a/backend/data_tools/data/user_data.json5
+++ b/backend/data_tools/data/user_data.json5
@@ -101,15 +101,50 @@
       name: "user",
       permissions: [
         "GET_AGREEMENT",
+        "PUT_AGREEMENT",
+        "PATCH_AGREEMENT",
+        "POST_AGREEMENT",
+
         "GET_BUDGET_LINE_ITEM",
+        "PUT_BUDGET_LINE_ITEM",
+        "PATCH_BUDGET_LINE_ITEM",
+        "POST_BUDGET_LINE_ITEM",
+
         "GET_SERVICES_COMPONENT",
+        "PUT_SERVICES_COMPONENT",
+        "PATCH_SERVICES_COMPONENT",
+        "POST_SERVICES_COMPONENT",
+
+        "GET_BLI_PACKAGE",
+        "PUT_BLI_PACKAGE",
+        "PATCH_BLI_PACKAGE",
+        "POST_BLI_PACKAGE",
+
         "GET_CAN",
+
         "GET_DIVISION",
+
         "GET_NOTIFICATION",
+        "PUT_NOTIFICATION",
+        "PATCH_NOTIFICATION",
+
         "GET_PORTFOLIO",
+
         "GET_RESEARCH_PROJECT",
+        "POST_RESEARCH_PROJECT",
+
         "GET_USER",
+        "GET_USERS",
+
         "GET_HISTORY",
+
+        "GET_WORKFLOW",
+
+        "GET_CHANGE_REQUEST",
+        "PATCH_CHANGE_REQUEST",
+        "POST_CHANGE_REQUEST",
+
+        "GET_CHANGE_REQUEST_REVIEW",
       ],
     },
     { // 3 Unassigned (new user)


### PR DESCRIPTION
## What changed

Brings the `user` role the desired permissions for standard OPS users for our sample data load--matching the `user` role that's loaded for the `data-initial` load of a more-empty DB environment.

The context and impetus for this is that in #2541, the `COR` role was rightfully removed. However, necessary permissions were never added to the standard user role and thusly, presently, a standard `user` cannot do various PUTS and PATCHES that are necessary on certain objects

## Issue

#2560 

## How to test

* As User Demo, try creating a SC within a contract, a BL, and the contract itself. You should receive no errors. 

## Screenshots


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [] 90%+ Code coverage achieved~
~- [ ] Form validations updated~


## Links


