### PR TITLE
fix: adds default to GCS

### DIFF
--- a/frontend/src/components/Agreements/ProcurementShopSelect/ProcurementShopSelect.jsx
+++ b/frontend/src/components/Agreements/ProcurementShopSelect/ProcurementShopSelect.jsx
@@ -1,5 +1,6 @@
-import { useGetProcurementShopsQuery } from "../../../api/opsAPI";
+import PropTypes from "prop-types";
 import { useEffect, useState } from "react";
+import { useGetProcurementShopsQuery } from "../../../api/opsAPI";
 
 /**
  * Object representing a procurement shop.
@@ -18,6 +19,7 @@ import { useEffect, useState } from "react";
  * @param {string} [props.legendClassname] - Additional CSS classes to apply to the label/legend (optional).
  * @param {string} [props.defaultString] - Initial text to display in select (optional).
  * @param {boolean} [props.defaultToGCS] - Whether to initially select GCS (optional).
+ * @param {boolean} [props.isFilter] - Whether the select is used as a filter (optional).
  * @returns {JSX.Element} - The procurement shop select element.
  */
 export const ProcurementShopSelect = ({
@@ -25,7 +27,8 @@ export const ProcurementShopSelect = ({
     onChangeSelectedProcurementShop,
     legendClassname = "",
     defaultString = "-Select Procurement Shop-",
-    defaultToGCS = true
+    defaultToGCS = true,
+    isFilter = false
 }) => {
     const [hasSelectedDefault, setHasSelectedDefault] = useState(defaultToGCS);
 
@@ -60,26 +63,27 @@ export const ProcurementShopSelect = ({
 
         setHasSelectedDefault(procurementShop.id === 2);
     };
+    const showValidation = !isFilter && !hasSelectedDefault;
 
     return (
-        <fieldset className={`usa-fieldset ${hasSelectedDefault ? "" : "usa-form-group--error"}`}>
+        <fieldset className={`usa-fieldset ${showValidation ? "usa-form-group--error" : ""}`}>
             <label
-                className={`usa-label margin-top-0 ${legendClassname} ${hasSelectedDefault ? "" : "usa-label--error"}`}
+                className={`usa-label margin-top-0 ${legendClassname} ${showValidation ? "usa-label--error" : ""}`}
                 htmlFor="procurement-shop-select"
             >
                 Procurement Shop
             </label>
-            {!hasSelectedDefault && <span className="usa-error-message">GCS is the only available type for now</span>}
+            {showValidation && <span className="usa-error-message">GCS is the only available type for now</span>}
             <div className="display-flex flex-align-center">
                 <select
-                    className={`usa-select margin-top-1 ${hasSelectedDefault ? "" : "usa-input--error"}`}
+                    className={`usa-select margin-top-1 ${showValidation ? "usa-input--error" : ""}`}
                     name="procurement-shop-select"
                     id="procurement-shop-select"
                     onChange={handleChange}
                     value={selectedProcurementShop?.id || 0}
                     required
                 >
-                    <option value="0">{defaultString}</option>
+                    <option value={0}>{defaultString}</option>
                     {procurementShops.map((shop) => (
                         <option
                             key={shop?.id}
@@ -95,3 +99,12 @@ export const ProcurementShopSelect = ({
 };
 
 export default ProcurementShopSelect;
+
+ProcurementShopSelect.propTypes = {
+    selectedProcurementShop: Object,
+    onChangeSelectedProcurementShop: PropTypes.func,
+    legendClassname: PropTypes.string,
+    defaultString: PropTypes.string,
+    defaultToGCS: PropTypes.bool,
+    isFilter: PropTypes.bool
+};

--- a/frontend/src/pages/agreements/list/AgreementsFilterButton.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsFilterButton.jsx
@@ -266,7 +266,8 @@ export const AgreementsFilterButton = ({ filters, setFilters }) => {
                 onChangeSelectedProcurementShop={setProcurementShop}
                 legendClassname={legendStyles}
                 defaultString={"All Shops"}
-                defaultToGCS={true}
+                defaultToGCS={false}
+                isFilter={true}
             />
         </fieldset>,
         <fieldset

--- a/frontend/src/pages/agreements/list/AgreementsFilterButton.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsFilterButton.jsx
@@ -266,7 +266,7 @@ export const AgreementsFilterButton = ({ filters, setFilters }) => {
                 onChangeSelectedProcurementShop={setProcurementShop}
                 legendClassname={legendStyles}
                 defaultString={"All Shops"}
-                defaultToGCS={false}
+                defaultToGCS={true}
             />
         </fieldset>,
         <fieldset


### PR DESCRIPTION
## What changed

removes validation from Agreement list filter for procurement shop.

## Issue

#2706 

## How to test

1. Goto Agreements list
2. open filter, no validation is set
3. create a new Agreement
4. select a different proc_shop than GCS
5. will show validation error

## Definition of Done Checklist
- [-] OESA: Code refactored for clarity
- [-] OESA: Dependency rules followed
- [X] Automated unit tests updated and passed
- [X] Automated integration tests updated and passed
- [X] Automated quality tests updated and passed
- [X] Automated load tests updated and passed
- [X] Automated a11y tests updated and passed
- [X] Automated security tests updated and passed
- [X] 90%+ Code coverage achieved
- [-] Form validations updated