### PR TITLE
2647: Changing nginx logs to stdout

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,6 +1,6 @@
 worker_processes                auto; # it will be determinate automatically by the number of core
 
-error_log                       /var/log/nginx/error.log warn;
+error_log                       /dev/stdout warn;
 
 events {
     worker_connections          1024;
@@ -10,7 +10,7 @@ http {
     include                     /etc/nginx/mime.types;
     default_type                application/octet-stream;
     sendfile                    on;
-    access_log                  /var/log/nginx/access.log;
+    access_log                  /dev/stdout;
     keepalive_timeout           3000;
     server {
         listen                  3000;


### PR DESCRIPTION
## What changed

Redirects the output for nginx's access and error logs from a file running in the container to the container's stdout. 

## Issue

#2647 
ACF Tech has a requirement to see frontend web server logs, both access and error logs. Presently, the statically-built content for the frontend container deployed in Azure has Nginx's logging output going to a file and the LAW in Azure can't grab it from there and it needs to be in the ACA container's stdout for the KQL query in LAW to be effective.

## How to test

Upon a redeploy in Azure, see if logging output ceases to the /var/log/nginx/* files and is going to the stdout viewable in Azure and in KQL queries.

## Screenshots

N/A
