### PR TITLE
updating OWASP ZAP DAST scans to use our new staging environment URL

### DIFF
--- a/.github/workflows/nightly_scans.yml
+++ b/.github/workflows/nightly_scans.yml
@@ -22,7 +22,7 @@ jobs:
         uses: zaproxy/action-full-scan@d2a07475d467566c9a3e3c700f31f47724aa1060 # v0.10.0
         with:
           docker_name: 'owasp/zap2docker-stable'
-          target: 'https://ops-dev.fr.cloud.gov/'
+          target: 'https://stg.ops.opre.acf.gov/'
           allow_issue_writing: false
           fail_action: false
           cmd_options: '-I'

--- a/.github/workflows/nightly_scans.yml
+++ b/.github/workflows/nightly_scans.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
-      - name: Run OWASP Zap Scan on live-dev
+      - name: Run OWASP Zap Scan on staging
         uses: zaproxy/action-full-scan@d2a07475d467566c9a3e3c700f31f47724aa1060 # v0.10.0
         with:
-          docker_name: 'owasp/zap2docker-stable'
+          docker_name: 'ghcr.io/zaproxy/zaproxy:stable'
           target: 'https://stg.ops.opre.acf.gov/'
           allow_issue_writing: false
           fail_action: false


### PR DESCRIPTION
## What changed

Updating the URL for the OWASP ZAP DAST scans to reflect the new staging environment URL and to actually download the ZAP action from the correct source. It had been trying to download from Docker Hub.

## Issue

N/A

## How to test

I tested locally but check result of nightly scans once merged

