### PR TITLE
remove ip check and always create a new session on login

### DIFF
--- a/backend/ops_api/ops/auth/decorators.py
+++ b/backend/ops_api/ops/auth/decorators.py
@@ -14,7 +14,6 @@ from ops_api.ops.auth.utils import (
     get_all_user_sessions,
     get_bearer_token,
     get_latest_user_session,
-    get_request_ip_address,
     get_user_from_userinfo,
 )
 from ops_api.ops.utils.errors import error_simulator
@@ -138,10 +137,6 @@ def check_user_session_function(user: User):
         if access_token != latest_user_session.access_token:
             deactivate_all_user_sessions(user_sessions)
             raise InvalidUserSessionError(f"User with id={user.id} is using an invalid access token")
-    # Check if the ip address in the request is the same as the latest user session ip address
-    if get_request_ip_address() != latest_user_session.ip_address:
-        deactivate_all_user_sessions(user_sessions)
-        raise InvalidUserSessionError(f"User with id={user.id} is using an invalid ip address")
     # Check if the last_accessed_at field of the latest user session is not more than a configurable threshold ago
     if check_last_active_at(latest_user_session):
         deactivate_all_user_sessions(user_sessions)

--- a/backend/ops_api/ops/auth/service.py
+++ b/backend/ops_api/ops/auth/service.py
@@ -112,32 +112,24 @@ def _get_or_create_user_session(
         .order_by(UserSession.created_on.desc())  # type: ignore
     )
     user_sessions = current_app.db_session.execute(stmt).scalars().all()
-    latest_user_session = get_latest_user_session(user.id, current_app.db_session)
 
-    if (
-        latest_user_session
-        and latest_user_session.is_active
-        and not is_token_expired(latest_user_session.access_token, current_app.config["JWT_PRIVATE_KEY"])
-    ):
-        return latest_user_session
-    else:
-        # set all other sessions to inactive before creating a new one
-        deactivate_all_user_sessions(user_sessions)
+    # set all other sessions to inactive before creating a new one
+    deactivate_all_user_sessions(user_sessions)
 
-        user_session = UserSession(
-            user_id=user.id,
-            is_active=True,
-            ip_address=ip_address,
-            access_token=access_token,
-            refresh_token=refresh_token,
-            last_active_at=datetime.now(),
-            created_by=user.id,
-            updated_by=user.id,
-        )
-        current_app.db_session.add(user_session)
-        current_app.db_session.commit()
+    user_session = UserSession(
+        user_id=user.id,
+        is_active=True,
+        ip_address=ip_address,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        last_active_at=datetime.now(),
+        created_by=user.id,
+        updated_by=user.id,
+    )
+    current_app.db_session.add(user_session)
+    current_app.db_session.commit()
 
-        return user_session
+    return user_session
 
 
 def get_roles(session: Session, **kwargs) -> list[Role]:

--- a/backend/ops_api/tests/auth/test_check_user_session.py
+++ b/backend/ops_api/tests/auth/test_check_user_session.py
@@ -96,34 +96,6 @@ def test_check_user_session_token_doesnt_match(mocker, loaded_db):
 
 
 @pytest.mark.usefixtures("app_ctx")
-def test_ip_address_doesnt_match(mocker, loaded_db):
-    # Arrange
-    mock_get_latest_user_session = mocker.patch("ops_api.ops.auth.decorators.get_latest_user_session")
-    mock_user_session = mocker.MagicMock()
-    mock_user_session.is_active = True
-    mock_user_session.ip_address = "192.168.0.1"  # UserSession ip_address is different from the request
-    mock_get_latest_user_session.return_value = mock_user_session
-
-    mocker.patch("flask.request.remote_addr", return_value="127.0.0.1")  # Request ip_address
-
-    @check_user_session
-    def dummy_function(*args, **kwargs):
-        return "success"
-
-    # Act
-    verify_jwt_in_request(optional=True)  # This is needed to set the current_user
-    mock_current_user = mocker.patch("ops_api.ops.auth.decorators.current_user")
-    mock_current_user.id = 503
-
-    # Assert
-    with pytest.raises(InvalidUserSessionError):
-        dummy_function()
-
-    user_sessions = get_all_user_sessions(503, loaded_db)
-    assert all([not user_session.is_active for user_session in user_sessions])
-
-
-@pytest.mark.usefixtures("app_ctx")
 def test_idle_timeout(mocker, loaded_db):
     # Arrange
     mock_get_latest_user_session = mocker.patch("ops_api.ops.auth.decorators.get_latest_user_session")

--- a/backend/ops_api/tests/auth/test_login.py
+++ b/backend/ops_api/tests/auth/test_login.py
@@ -157,11 +157,11 @@ def test_login_with_active_session(client, db_with_active_user_session, mocker):
     stmt = select(UserSession).where(UserSession.user_id == user.id).order_by(UserSession.created_on.desc())
     user_sessions = db_with_active_user_session.execute(stmt).scalars().all()
     assert user_sessions[0].is_active
-    assert user_sessions[0].access_token == "6526adb0e0777586804035802f48d8"
-    assert user_sessions[0].refresh_token == "14b0c1c59859cf1a7cca71af11283c"
+    assert user_sessions[0].access_token != "6526adb0e0777586804035802f48d8"
+    assert user_sessions[0].refresh_token != "14b0c1c59859cf1a7cca71af11283c"
     assert user_sessions[0].user_id == user.id
-    assert user_sessions[0].ip_address == "26.13.164.12"
-    assert user_sessions[0].last_active_at == datetime.datetime(2021, 10, 1, 0)
+    assert user_sessions[0].ip_address != "26.13.164.12"
+    assert user_sessions[0].last_active_at != datetime.datetime(2021, 10, 1, 0)
 
     # cleanup
     db_with_active_user_session.execute(text("DELETE FROM user_session"))


### PR DESCRIPTION
## What changed

- Remove check for IP address used in user session.
- Always create a new session at `/login`

## Issue

While testing OPS in Azure we found that the client IP address was unpredictable and unreliable for this purpose. 

## How to test

Automated tests pass.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated
