### PR TITLE
pre-commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,4 +56,4 @@ repos:
         # For running trufflehog in docker, use the following entry instead:
         entry: bash -c 'docker run --rm -v "$(pwd):/workdir" -i --rm trufflesecurity/trufflehog:latest git file:///workdir --since-commit HEAD --only-verified --fail'
         language: system
-        stages: ["commit", "push"]
+        stages: ["pre-commit", "pre-push"]


### PR DESCRIPTION
## What changed

Updates pre-commit to use new/non-deprecated stage names for the TruffleHog pre-commit

## Issue

The folks at [pre-commit](https://pre-commit.com) [updated their stage names](https://pre-commit.com#pre-commit-configyaml---top-level) and even [inserted a warning about deprecation of old stage names](https://github.com/pre-commit/pre-commit/pull/3312/files).

## How to test

insure TruffleHog runs as expected locally on pre-commit

## Screenshots

N/A

## Definition of Done Checklist
N/A

## Links

see above
