### PR TITLE
fix: update can funding summary openapi spec

### DIFF
--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -1138,7 +1138,7 @@ paths:
             minItems: 2
             maxItems: 2
             example: [ 50000, 100000 ]
-    responses:
+      responses:
         "200":
           description: OK
           content:

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -1076,29 +1076,69 @@ paths:
                         "purpose": ""
                       }
                     ]
-  /api/v1/can-funding-summary/{can_id}:
+  /api/v1/can-funding-summary:
     get:
       tags:
         - CAN Funding Summary
-      operationId: getFundingTotalsByCanId
-      description: Get Funding Totals by CAN Id
+      operationId: getFundingTotals
+      description: Get Funding Totals
       parameters:
         - $ref: "#/components/parameters/simulatedError"
-        - name: fiscal_year
+        - name: can_ids
           in: query
-          schema:
-            type: string
-          example: "2023"
-        - in: path
-          name: can_id
-          description: CAN Id
+          description: Comma-separated list of CAN Ids (required)
           required: true
           schema:
-            type: integer
-            format: int32
-            minimum: 0
-            default: 0
-      responses:
+            type: array
+            items:
+              type: integer
+            example: [ 12345, 12346, 12347 ]
+        - name: fiscal_year
+          in: query
+          description: Fiscal year (optional)
+          schema:
+            type: string
+            example: "2023"
+        - name: active_period
+          in: query
+          description: List of active periods (optional)
+          schema:
+            type: array
+            items:
+              type: integer
+            example: [ 1, 5 ]
+        - name: transfer
+          in: query
+          description: List of CAN Method of Transfer (optional)
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - DIRECT
+                - COST_SHARE
+                - IAA
+                - IDDA
+            example: [ "DIRECT", "IAA" ]
+        - name: portfolio
+          in: query
+          description: List of portfolios (optional)
+          schema:
+            type: array
+            items:
+              type: string
+            example: [ "HS", "HMRF", "CC" ]
+        - name: fy_budget
+          in: query
+          description: List of two values representing the min and max fiscal year budget (optional)
+          schema:
+            type: array
+            items:
+              type: integer
+            minItems: 2
+            maxItems: 2
+            example: [ 50000, 100000 ]
+    responses:
         "200":
           description: OK
           content:

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -1193,6 +1193,8 @@ paths:
                     type: string
                   expected_funding:
                     type: string
+                  new_funding:
+                    type: string
               examples:
                 "0":
                   value: |
@@ -1220,7 +1222,8 @@ paths:
                       "in_execution_funding": "2000000.00",
                       "obligated_funding": 0,
                       "planned_funding": 0,
-                      "total_funding": "10000000.00"
+                      "total_funding": "10000000.00",
+                      "new_funding": "2000000.00"
                     }
   /api/v1/users/:
     get:

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -1086,7 +1086,7 @@ paths:
         - $ref: "#/components/parameters/simulatedError"
         - name: can_ids
           in: query
-          description: Comma-separated list of CAN Ids (required)
+          description: List of CAN Ids (required)
           required: true
           schema:
             type: array
@@ -1109,7 +1109,7 @@ paths:
             example: [ 1, 5 ]
         - name: transfer
           in: query
-          description: List of CAN Method of Transfer (optional)
+          description: List of CAN Method of Transfers (optional)
           schema:
             type: array
             items:
@@ -1122,7 +1122,7 @@ paths:
             example: [ "DIRECT", "IAA" ]
         - name: portfolio
           in: query
-          description: List of portfolios (optional)
+          description: List of portfolio abbreviations (optional)
           schema:
             type: array
             items:


### PR DESCRIPTION
## What changed
This PR updates the openapi.yml file to reflect changes to the  CAN Funding Summary (`/api/v1/can-funding-summary/{can_id}`)  endpoint for supporting [CAN Summary Information](https://github.com/HHS/OPRE-OPS/issues/2842) cards.

- Removed `can_id` path parameter
- Added `can_ids` query parameter: _Required_  list of CAN Ids
- Added `active_period` query parameter: Optional list of active periods
- Added `transfer` query parameter: Optional list of method of transfer types
- Added `portfolio` query parameter: Optional list of portfolios
- Added `fy_budget` query parameter: Optional list of exactly two values (min and max)
- Added `new_funding` to the response object: String value of the spending amount

## Issue

[#2961](https://github.com/HHS/OPRE-OPS/issues/2961)

## How to test

The openapi.yml file has been successfully generated and is free of any syntax issues.

## Screenshots

N/A

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated


## Links

N/A