### PR TITLE
fix: remove budget pills with state using defaults

### DIFF
--- a/frontend/src/pages/cans/list/CANFilterButton/CANFilterButton.hooks.js
+++ b/frontend/src/pages/cans/list/CANFilterButton/CANFilterButton.hooks.js
@@ -41,15 +41,26 @@ export const useCANFilterButton = (filters, setFilters, fyBudgetRange) => {
     }, [fyBudgetRange, filters.budget]);
 
     const applyFilter = () => {
-        setFilters((prevState) => {
-            return {
-                ...prevState,
-                activePeriod: activePeriod,
-                transfer: transfer,
-                portfolio: portfolio,
-                budget: budget
-            };
-        });
+        if(budget === fyBudgetRange) {
+            setFilters((prevState) => {
+                return {
+                    ...prevState,
+                    activePeriod: activePeriod,
+                    transfer: transfer,
+                    portfolio: portfolio,
+                };
+            });
+        } else {
+            setFilters((prevState) => {
+                return {
+                    ...prevState,
+                    activePeriod: activePeriod,
+                    transfer: transfer,
+                    portfolio: portfolio,
+                    budget: budget
+                };
+            });
+        }
     };
     const resetFilter = () => {
         setFilters({


### PR DESCRIPTION
One way to potentially solve not showing the budget pills when there is no user interaction with the budget range slider. 


https://github.com/user-attachments/assets/35668d70-5c98-4893-af6c-361d0e661cfc

