### PR TITLE
chore: adding requested user stakeholders for non-prod environments

### DIFF
--- a/backend/data_tools/data/user_data.json5
+++ b/backend/data_tools/data/user_data.json5
@@ -581,7 +581,7 @@
       first_name: "Sheila",
       last_name: "Celentano",
       email: "sheila.celentano@acf.hhs.gov",
-      roles: [{"tablename":  "role", "id": 1}, {"tablename":  "role", "id": 5}], {"tablename":  "role", "id": 6}]],
+      roles: [{"tablename":  "role", "id": 1}, {"tablename":  "role", "id": 5}, {"tablename":  "role", "id": 6}],
       status: "ACTIVE"
     }
   ],

--- a/backend/data_tools/data/user_data.json5
+++ b/backend/data_tools/data/user_data.json5
@@ -569,6 +569,18 @@
       email: "system.admin@email.com",
       oidc_id: "00000000-0000-1111-a111-000000000026",
       status: "LOCKED"
+    },
+    { // 527
+      first_name: "Amare",
+      last_name: "Beza",
+      email: "amare.beza@acf.hhs.gov",
+      status: "ACTIVE"
+    },
+    { // 528
+      first_name: "Sheila",
+      last_name: "Celentano",
+      email: "sheila.celentano@acf.hhs.gov",
+      status: "ACTIVE"
     }
   ],
   notification: [

--- a/backend/data_tools/data/user_data.json5
+++ b/backend/data_tools/data/user_data.json5
@@ -574,12 +574,14 @@
       first_name: "Amare",
       last_name: "Beza",
       email: "amare.beza@acf.hhs.gov",
+      roles: [{"tablename":  "role", "id": 2}],
       status: "ACTIVE"
     },
     { // 528
       first_name: "Sheila",
       last_name: "Celentano",
       email: "sheila.celentano@acf.hhs.gov",
+      roles: [{"tablename":  "role", "id": 1}, {"tablename":  "role", "id": 5}], {"tablename":  "role", "id": 6}]],
       status: "ACTIVE"
     }
   ],


### PR DESCRIPTION
## What changed

Adding in a couple of real human users with AMS accounts for non-prod environments

## Issue

N/A

## How to test

Verify if the named users can log in

## Screenshots

## Links

