### PR TITLE
Refactor Azure Document Repository to route through the App Gateway

### DIFF
--- a/backend/ops_api/ops/document/azure_document_repository.py
+++ b/backend/ops_api/ops/document/azure_document_repository.py
@@ -74,7 +74,14 @@ def generate_account_sas_url(account_name, account_key, expiry_hours=1):
         )
 
         # Construct the SAS URL
-        sas_url = f"https://{account_name}.blob.core.windows.net/?{sas_token}"
+        DEFAULT_DEV_OPS_URL = "https://dev.ops.opre.acf.gov"
+        OPS_URL = (
+            DEFAULT_DEV_OPS_URL
+            if "localhost" in current_app.config.get("OPS_FRONTEND_URL")
+            else current_app.config.get("OPS_FRONTEND_URL")
+        )
+        # https://dev.ops.opre.acf.gov/?{sas_token} in dev
+        sas_url = f"{OPS_URL}/?{sas_token}"
         return sas_url
 
     except SasUrlGenerationError as e:

--- a/backend/ops_api/ops/document/document_gateway.py
+++ b/backend/ops_api/ops/document/document_gateway.py
@@ -1,5 +1,4 @@
 from flask import Config
-from flask_jwt_extended import current_user
 
 from ops_api.ops.document.azure_document_repository import AzureDocumentRepository
 from ops_api.ops.document.document_repository import DocumentRepository
@@ -16,11 +15,7 @@ class DocumentGateway:
         # Validate and register providers with the factory
         self.register_providers()
 
-        # Select provider based on the current user
-        if current_user.id >= 500:  # Users with id 5xx are test users
-            self.provider = DocumentProviders.fake.name
-        else:
-            self.provider = DocumentProviders.azure.name
+        self.provider = DocumentProviders.azure.name
 
     def register_providers(self) -> None:
         """

--- a/frontend/src/components/Agreements/Documents/Documents.constants.js
+++ b/frontend/src/components/Agreements/Documents/Documents.constants.js
@@ -10,7 +10,7 @@ export const DOCUMENT_TYPES = [
 
 export const VALID_EXTENSIONS = ["pdf", "doc", "docx", "xls", "xlsx"];
 
-export const DOCUMENT_CONTAINER_NAME = "documents";
+export const DOCUMENT_CONTAINER_NAME = "docs";
 
 export const ALLOWED_FAKE_HOSTS = "FakeDocumentRepository";
-export const ALLOWED_HOSTS = "blob.core.windows.net";
+export const ALLOWED_HOSTS = "ops.opre.acf.gov";


### PR DESCRIPTION
## What changed

Previously, the app uploaded files directly to the blob storage. As part of our security efforts, we're routing document upload through the app gateway instead. At the moment there are some issues with CORS that I do not expect to be present on the dev branch because dev is deployed to the same url as the dev app gateway. Part of this PR is to test this in dev

## Issue

[OPS-2362](https://github.com/HHS/OPRE-OPS/issues/2362)

## How to test

1. Navigate to the dev page and log in as an admin user
2. Add /upload-document to the URL
3. upload a document via the UI
4. verify there were no failed requests in the network tab to a URL that has UUID?se={rest of token goes here)
5. Verify in azure doc storage that your file was uploaded under its UUID as the name


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

