### PR TITLE
build: attempt to use node for dependency rather than bun

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      # Install and cache NPM dependencies
-      - uses: ./.github/actions/setup-javascript
-
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "lts/*"
+      - name: Install semantic-release
+        run: npm install -g semantic-release
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        working-directory: frontend
-        run: bun run semantic-release
+        run: npx semantic-release


### PR DESCRIPTION
## What changed

Bun does not seem to work well with `semantic-release` - attempt to use Node instead

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated
