### PR TITLE
Ops 2659/validate fund code

### DIFF
--- a/backend/data_tools/src/load_cans/utils.py
+++ b/backend/data_tools/src/load_cans/utils.py
@@ -1,12 +1,12 @@
 from csv import DictReader
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List
 
 from loguru import logger
 from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 
-from models import CAN, BaseModel, CANFundingDetails, CANFundingSource, CANMethodOfTransfer, Portfolio, User
+from models import CAN, CANFundingDetails, CANFundingSource, CANMethodOfTransfer, Portfolio, User
 
 
 @dataclass
@@ -120,51 +120,90 @@ def create_models(data: CANData, sys_user: User, session: Session) -> None:
 
         can.portfolio = portfolio
 
-        # get or create funding details
-        fiscal_year = int(data.FUND[6:10])
-        fund_code = data.FUND
-        allowance = data.ALLOWANCE
-        sub_allowance = data.SUB_ALLOWANCE
-        allotment = data.ALLOTMENT_ORG
-        appropriation = "-".join([data.APPROP_PREFIX or "", data.APPROP_YEAR[0:2] or "", data.APPROP_POSTFIX or ""])
-        method_of_transfer = CANMethodOfTransfer[data.METHOD_OF_TRANSFER]
-        funding_source = CANFundingSource[data.FUNDING_SOURCE]
+        try:
+            validate_fund_code(data)
+        except ValueError as e:
+            logger.info(f"Skipping creating funding details for {data} due to invalid fund code. {e}")
 
-        existing_funding_details = session.execute(select(CANFundingDetails).where(
-            and_(
-                CANFundingDetails.fiscal_year == fiscal_year,
-                CANFundingDetails.fund_code == fund_code,
-                CANFundingDetails.allowance == allowance,
-                CANFundingDetails.sub_allowance == sub_allowance,
-                CANFundingDetails.allotment == allotment,
-                CANFundingDetails.appropriation == appropriation,
-                CANFundingDetails.method_of_transfer == method_of_transfer,
-                CANFundingDetails.funding_source == funding_source,
-            ))).scalar_one_or_none()
-
-        if not existing_funding_details:
-            funding_details = CANFundingDetails(
-                fiscal_year=fiscal_year,
-                fund_code=fund_code,
-                allowance=allowance,
-                sub_allowance=sub_allowance,
-                allotment=allotment,
-                appropriation=appropriation,
-                method_of_transfer=method_of_transfer,
-                funding_source=funding_source,
-                created_by=sys_user.id,
-            )
-            session.add(funding_details)
-            session.commit()
-            can.funding_details = funding_details
-        else:
-            can.funding_details = existing_funding_details
-
+        can.funding_details = get_or_create_funding_details(data, sys_user, session)
         session.merge(can)
         session.commit()
     except Exception as e:
         logger.error(f"Error creating models for {data}")
         raise e
+
+
+def get_or_create_funding_details(data: CANData, sys_user: User, session: Session) -> CANFundingDetails:
+    """
+    Get or create a CANFundingDetails instance.
+
+    :param data: The CANData instance to use.
+    :param sys_user: The system user to use.
+    :param session: The database session to use.
+
+    :return: A CANFundingDetails instance.
+    """
+    fiscal_year = int(data.FUND[6:10])
+    fund_code = data.FUND
+    allowance = data.ALLOWANCE
+    sub_allowance = data.SUB_ALLOWANCE
+    allotment = data.ALLOTMENT_ORG
+    appropriation = "-".join([data.APPROP_PREFIX or "", data.APPROP_YEAR[0:2] or "", data.APPROP_POSTFIX or ""])
+    method_of_transfer = CANMethodOfTransfer[data.METHOD_OF_TRANSFER]
+    funding_source = CANFundingSource[data.FUNDING_SOURCE]
+    existing_funding_details = session.execute(select(CANFundingDetails).where(
+        and_(
+            CANFundingDetails.fiscal_year == fiscal_year,
+            CANFundingDetails.fund_code == fund_code,
+            CANFundingDetails.allowance == allowance,
+            CANFundingDetails.sub_allowance == sub_allowance,
+            CANFundingDetails.allotment == allotment,
+            CANFundingDetails.appropriation == appropriation,
+            CANFundingDetails.method_of_transfer == method_of_transfer,
+            CANFundingDetails.funding_source == funding_source,
+        ))).scalar_one_or_none()
+    if not existing_funding_details:
+        funding_details = CANFundingDetails(
+            fiscal_year=fiscal_year,
+            fund_code=fund_code,
+            allowance=allowance,
+            sub_allowance=sub_allowance,
+            allotment=allotment,
+            appropriation=appropriation,
+            method_of_transfer=method_of_transfer,
+            funding_source=funding_source,
+            created_by=sys_user.id,
+        )
+        return funding_details
+    else:
+        return existing_funding_details
+
+
+def validate_fund_code(data: CANData) -> None:
+    """
+    Validate the fund code in a CANData instance.
+
+    :param data: The CANData instance to validate.
+
+    :return: None
+    :raises ValueError: If the fund code is invalid.
+    """
+    if len(data.FUND) != 14:
+        raise ValueError(f"Invalid fund code length {data.FUND}")
+    int(data.FUND[6:10])
+    length_of_appropriation = data.FUND[10]
+    if length_of_appropriation not in ["0", "1", "5"]:
+        raise ValueError(f"Invalid length of appropriation {length_of_appropriation}")
+    direct_or_reimbursable = data.FUND[11]
+    if direct_or_reimbursable not in ["D", "R"]:
+        raise ValueError(f"Invalid direct or reimbursable {direct_or_reimbursable}")
+    category = data.FUND[12]
+    if category not in ["A", "B", "C"]:
+        raise ValueError(f"Invalid category {category}")
+    discretionary_or_mandatory = data.FUND[13]
+    if discretionary_or_mandatory not in ["D", "M"]:
+        raise ValueError(f"Invalid discretionary or mandatory {discretionary_or_mandatory}")
+
 
 def create_all_models(data: List[CANData], sys_user: User, session: Session) -> None:
     """

--- a/docker-compose.initial.yml
+++ b/docker-compose.initial.yml
@@ -1,0 +1,90 @@
+services:
+
+  db:
+    image: "postgres:16"
+    container_name: ops-db
+    security_opt:
+      - no-new-privileges:true  # Resolve semgrep https://sg.run/0n8q
+    environment:
+      - POSTGRES_PASSWORD=local_password
+    read_only: true  # Resolve semgrep https://sg.run/e4JE
+    tmpfs: /var/run/postgresql/
+    volumes:
+      - ./backend/data_tools/ops_db_sql_init:/docker-entrypoint-initdb.d
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  data-import:
+    build:
+      context: ./backend/
+      dockerfile: Dockerfile.data-tools
+    container_name: ops-data-import
+    environment:
+      - ENV=local
+      - SQLALCHEMY_DATABASE_URI=postgresql://ops:ops@db:5432/postgres
+    command: /bin/sh -c "./data_tools/scripts/initial_data.sh"
+    volumes:
+      - ./backend/ops_api:/home/app/ops_api
+    depends_on:
+      db:
+        condition: service_healthy
+
+  disable-users:
+    build:
+      context: ./backend/
+      dockerfile: Dockerfile.data-tools
+    container_name: disable-users
+    environment:
+      - ENV=local
+      - SQLALCHEMY_DATABASE_URI=postgresql://ops:ops@db:5432/postgres
+    command: ["/home/app/.venv/bin/python", "./data_tools/src/disable_users/disable_users.py"]
+    depends_on:
+      db:
+        condition: service_healthy
+      data-import:
+        condition: service_completed_successfully
+
+  backend:
+    build:
+      context: ./backend/
+      dockerfile: Dockerfile.ops-api
+    container_name: ops-backend
+    ports:
+      - "8080:8080"
+    command: /bin/sh -c " . .venv/bin/activate && python -m flask run --debug --host=0.0.0.0 --port=8080"
+    environment:
+      - JWT_PRIVATE_KEY
+      - JWT_PUBLIC_KEY
+      - OPS_CONFIG=environment/local/container.py
+    volumes:
+      - ./backend/ops_api/ops:/home/app/ops_api/ops
+    depends_on:
+      db:
+        condition: service_healthy
+      data-import:
+        condition: service_completed_successfully
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
+  frontend:
+    build:
+      context: ./frontend/
+      dockerfile: Dockerfile
+    container_name: ops-frontend
+    environment:
+      - REACT_APP_BACKEND_DOMAIN=http://localhost:8080
+      - VITE_BACKEND_DOMAIN=http://localhost:8080
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+    volumes:
+      - ./frontend/src:/home/app/src


### PR DESCRIPTION
## What changed

When ingesting CANs, if the `fund code` is invalid, set the `funding details` to `None`.

## Issue

https://github.com/HHS/OPRE-OPS/issues/2660

## How to test

Automated tests pass.

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated
