### PR TITLE
docs: fix CreateUpdateCANFundingBudgetRequest example values

### DIFF
--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -4401,7 +4401,7 @@ components:
         {
           can_id: 500,
           fiscal_year: 2024,
-          funding: 123456,
+          budget: 123456,
           notes: "A new test Funding Funding"
         }
 


### PR DESCRIPTION
## What changed

`/api/v1/can-funding-budgets/` POST request body is [expecting a `budget` field](https://github.com/HHS/OPRE-OPS/blob/b13b4a435d21a460d2b0309e23d543d26c8d9644/backend/ops_api/ops/schemas/cans.py#L97). Change updates the `CreateUpdateCANFundingBudgetRequest` example in the openapi file to include `budget` and remove `funding`.

## Issue

[3104](https://github.com/HHS/OPRE-OPS/issues/3104)

## How to test

OpenAPI spec displays correct fields. 

## Screenshots

N/A

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
<del>- [ ] 90%+ Code coverage achieved
<del>- [ ] Form validations updated


## Links

N/A
