### PR TITLE
3052: Add additional agreement attributes to /cans/ response #3092

### DIFF
--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -3519,6 +3519,14 @@ components:
           description: optional notes added to a Change Request when a PATCH is made that creates a CR
           type: string
           writeOnly: true
+        agreement_name:
+          type: string
+          example: "Contract #2: African American Child and Family Research Center"
+        agreement_type:
+          type: string
+          example: "CONTRACT"
+        awarding_entity_id:
+          type: integer
     BudgetLineItemCAN:
       type: object
       properties:

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -217,7 +217,11 @@ paths:
       description: Get CANs
       responses:
         "200":
-          description: OK
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CAN"
     post:
       tags:
         - CANs
@@ -3519,14 +3523,21 @@ components:
           description: optional notes added to a Change Request when a PATCH is made that creates a CR
           type: string
           writeOnly: true
-        agreement_name:
-          type: string
-          example: "Contract #2: African American Child and Family Research Center"
+        agreement:
+          type: object
+          $ref: "#/components/schemas/SimpleAgreementSchema"
+    SimpleAgreementSchema:
+      type: object
+      properties:
         agreement_type:
           type: string
-          example: "CONTRACT"
+          example: 'AgreementType.DIRECT_ALLOCATION'
+        name:
+          type: string
+          example: 'DIRECT ALLOCATION #2: African American Child and Family Research Center'
         awarding_entity_id:
           type: integer
+          example: 3
     BudgetLineItemCAN:
       type: object
       properties:

--- a/backend/ops_api/ops/schemas/budget_line_items.py
+++ b/backend/ops_api/ops/schemas/budget_line_items.py
@@ -4,9 +4,9 @@ from datetime import date
 
 from _decimal import Decimal
 from flask import current_app
-from marshmallow import EXCLUDE, Schema, ValidationError, fields, validates_schema
 from marshmallow_enum import EnumField
 
+from marshmallow import EXCLUDE, Schema, ValidationError, fields, validates_schema
 from models import AgreementReason, BudgetLineItem, BudgetLineItemStatus, ContractAgreement, ServicesComponent
 from ops_api.ops.schemas.change_requests import GenericChangeRequestResponseSchema
 
@@ -291,3 +291,6 @@ class BudgetLineItemResponseSchema(Schema):
     change_requests_in_review = fields.Nested(
         GenericChangeRequestResponseSchema(), many=True, default=None, allow_none=True
     )
+    agreement_name = fields.String(allow_none=True)
+    agreement_type = fields.String(allow_none=True)
+    awarding_entity_id = fields.Integer(allow_none=True)

--- a/backend/ops_api/ops/schemas/budget_line_items.py
+++ b/backend/ops_api/ops/schemas/budget_line_items.py
@@ -266,6 +266,12 @@ class BudgetLineItemCANSchema(Schema):
     appropriation_date = fields.Int(required=True)
 
 
+class SimpleAgreementSchema(Schema):
+    agreement_type = fields.String(allow_none=True)
+    name = fields.String(allow_none=True)
+    awarding_entity_id = fields.Integer(allow_none=True)
+
+
 class BudgetLineItemResponseSchema(Schema):
     class Meta:
         unknown = EXCLUDE  # Exclude unknown fields
@@ -291,6 +297,4 @@ class BudgetLineItemResponseSchema(Schema):
     change_requests_in_review = fields.Nested(
         GenericChangeRequestResponseSchema(), many=True, default=None, allow_none=True
     )
-    agreement_name = fields.String(allow_none=True)
-    agreement_type = fields.String(allow_none=True)
-    awarding_entity_id = fields.Integer(allow_none=True)
+    agreement = fields.Nested(SimpleAgreementSchema(), required=True)

--- a/backend/ops_api/tests/ops/can/test_can.py
+++ b/backend/ops_api/tests/ops/can/test_can.py
@@ -85,9 +85,15 @@ def test_can_is_inactive(loaded_db, mocker):
 def test_can_get_all(auth_client, mocker, test_can):
     mocker_get_can = mocker.patch("ops_api.ops.services.cans.CANService.get_list")
     mocker_get_can.return_value = [test_can]
+    mock_simple_agreement = {
+        "agreement_type": "AgreementType.DIRECT_ALLOCATION",
+        "name": "DIRECT ALLOCATION #2: African American Child and Family Research Center",
+        "awarding_entity_id": 3,
+    }
     response = auth_client.get("/api/v1/cans/")
     assert response.status_code == 200
     assert len(response.json) == 1
+    assert response.json[0]["budget_line_items"][0]["agreement"] == mock_simple_agreement
     mocker_get_can.assert_called_once()
 
 

--- a/frontend/src/components/Agreements/AgreementTypes.d.ts
+++ b/frontend/src/components/Agreements/AgreementTypes.d.ts
@@ -43,3 +43,9 @@ type ProcurementShop = {
     id: number;
     name: string;
 };
+
+type SimpleAgreement = {
+    agreement_type: string;
+    awarding_entity_id?: number;
+    name: string;
+};

--- a/frontend/src/components/BudgetLineItems/BudgetLineTypes.d.ts
+++ b/frontend/src/components/BudgetLineItems/BudgetLineTypes.d.ts
@@ -1,9 +1,11 @@
 import { CAN } from "../CANs/CANTypes";
 import { ChangeRequest } from "../ChangeRequests/ChangeRequestsTypes";
 import { SafeUser } from "../Users/UserTypes";
+import { SimpleAgreement } from "../Agreements/AgreementTypes";
 
 export type BudgetLine = {
     agreement_id: number;
+    agreement: SimpleAgreement[];
     amount?: number;
     can?: CAN;
     can_id?: number;


### PR DESCRIPTION
## What changed
Include the following fields in the **_BudgetLineItem_** response object returned by the /cans/ endpoint:
- `agreement_name`
- `agreement_type`
- `awarding_entity_id` (Agreement Procurement Shop Code) 

## Issue

[#3052 ](https://github.com/HHS/OPRE-OPS/issues/3052)

## How to test

Unit tests passing. 

## Screenshots

N/A

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated


## Links

N/A
