### PR TITLE
3110: Add Funding Method, Received, and Type to CANS 

### DIFF
--- a/backend/data_tools/tests/load_cans/test_load_cans.py
+++ b/backend/data_tools/tests/load_cans/test_load_cans.py
@@ -187,6 +187,9 @@ def test_create_models(db_with_portfolios):
     assert can_funding_details.method_of_transfer == CANMethodOfTransfer.DIRECT
     assert can_funding_details.funding_source == CANFundingSource.OPRE
     assert can_funding_details.active_period == 1
+    assert can_funding_details.funding_method == "Direct"
+    assert can_funding_details.funding_frequency == "Quarterly"
+    assert can_funding_details.funding_type == "Discretionary"
     assert can_funding_details.obligate_by == 2024
 
     # Cleanup

--- a/backend/data_tools/tests/load_cans/test_load_cans.py
+++ b/backend/data_tools/tests/load_cans/test_load_cans.py
@@ -188,7 +188,7 @@ def test_create_models(db_with_portfolios):
     assert can_funding_details.funding_source == CANFundingSource.OPRE
     assert can_funding_details.active_period == 1
     assert can_funding_details.funding_method == "Direct"
-    assert can_funding_details.funding_frequency == "Quarterly"
+    assert can_funding_details.funding_received == "Quarterly"
     assert can_funding_details.funding_type == "Discretionary"
     assert can_funding_details.obligate_by == 2024
 

--- a/backend/models/cans.py
+++ b/backend/models/cans.py
@@ -116,10 +116,10 @@ class CAN(BaseModel):
         return self.funding_details.funding_method
 
     @property
-    def funding_release_method(self):
+    def funding_frequency(self):
         if self.funding_details is None:
             return None
-        return self.funding_details.funding_method
+        return self.funding_details.funding_received
 
     @property
     def funding_type(self):

--- a/backend/models/cans.py
+++ b/backend/models/cans.py
@@ -110,6 +110,25 @@ class CAN(BaseModel):
         return self.funding_details.active_period
 
     @property
+    def funding_method(self):
+        if self.funding_details is None:
+            return None
+        return self.funding_details.funding_method
+
+    @property
+    def funding_release_method(self):
+        if self.funding_details is None:
+            return None
+        return self.funding_details.funding_method
+
+    @property
+    def funding_type(self):
+        if self.funding_details is None:
+            return None
+        return self.funding_details.funding_type
+
+
+    @property
     def obligate_by(self):
         if self.funding_details is None:
             return None
@@ -175,6 +194,30 @@ class CANFundingDetails(BaseModel):
         if len(self.fund_code) != 14:
             return None
         return int(self.fund_code[10:11])
+
+    @property
+    def funding_method(self) -> Optional[str]:
+        """The way the funds are transferred by"""
+        if len(self.fund_code) == 14:
+            method = self.fund_code[11].upper()
+            return {"D": "Direct", "M": "Reimbursable"}.get(method)
+        return None
+
+    @property
+    def funding_received(self) -> Optional[str]:
+        """When the funds are received"""
+        if len(self.fund_code) == 14:
+            method = self.fund_code[12].upper()
+            return {"A": "Quarterly", "B": "FY Start"}.get(method)
+        return None
+
+    @property
+    def funding_type(self) -> Optional[str]:
+        """The type of funding"""
+        if len(self.fund_code) == 14:
+            funding_type = self.fund_code[13].upper()
+            return {"D": "Discretionary", "M": "Mandatory"}.get(funding_type)
+        return None
 
     @property
     def obligate_by(self) -> Optional[int]:

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -2689,6 +2689,12 @@ components:
       properties:
         active_period:
           type: integer
+        funding_method:
+          type: string
+        funding_frequency:
+          type: string
+        funding_type:
+          type: string
         display_name:
           type: string
         nick_name:
@@ -2727,6 +2733,12 @@ components:
       properties:
         active_period:
           type: integer
+        funding_method:
+          type: string
+        funding_frequency:
+          type: string
+        funding_type:
+          type: string
         budget_line_items:
           type: array
           items:
@@ -3541,6 +3553,12 @@ components:
           type: string
         active_period:
           type: integer
+        funding_method:
+          type: string
+        funding_frequency:
+          type: string
+        funding_type:
+          type: string
         expiration_date:
           type: integer
         appropriation_date:

--- a/backend/ops_api/ops/schemas/budget_line_items.py
+++ b/backend/ops_api/ops/schemas/budget_line_items.py
@@ -4,9 +4,9 @@ from datetime import date
 
 from _decimal import Decimal
 from flask import current_app
-from marshmallow import EXCLUDE, Schema, ValidationError, fields, validates_schema
 from marshmallow_enum import EnumField
 
+from marshmallow import EXCLUDE, Schema, ValidationError, fields, validates_schema
 from models import AgreementReason, BudgetLineItem, BudgetLineItemStatus, ContractAgreement, ServicesComponent
 from ops_api.ops.schemas.change_requests import GenericChangeRequestResponseSchema
 
@@ -261,6 +261,9 @@ class BudgetLineItemCANSchema(Schema):
     description = fields.Str(required=True)
     nick_name = fields.Str(required=True)
     active_period = fields.Int(required=True)
+    funding_method = fields.String(allow_none=True)
+    funding_frequency = fields.String(allow_none=True)
+    funding_type = fields.String(allow_none=True)
     portfolio_id = fields.Int(required=True)
     expiration_date = fields.Int(required=True)
     appropriation_date = fields.Int(required=True)

--- a/backend/ops_api/ops/schemas/cans.py
+++ b/backend/ops_api/ops/schemas/cans.py
@@ -1,5 +1,4 @@
 from marshmallow import Schema, fields
-
 from models import CANFundingSource, CANMethodOfTransfer, PortfolioStatus
 from ops_api.ops.schemas.budget_line_items import BudgetLineItemResponseSchema
 from ops_api.ops.schemas.projects import ProjectSchema
@@ -20,6 +19,9 @@ class CreateUpdateCANRequestSchema(Schema):
 
 class BasicCANSchema(Schema):
     active_period = fields.Integer(allow_none=True)
+    funding_method = fields.String(allow_none=True)
+    funding_frequency = fields.String(allow_none=True)
+    funding_type = fields.String(allow_none=True)
     display_name = fields.String(allow_none=True)
     nick_name = fields.String(allow_none=True)
     number = fields.String(required=True)
@@ -115,6 +117,9 @@ class CreateUpdateFundingDetailsSchema(Schema):
 
 class FundingDetailsSchema(Schema):
     active_period = fields.Integer(allow_none=True)
+    funding_method = fields.String(allow_none=True)
+    funding_frequency = fields.String(allow_none=True)
+    funding_type = fields.String(allow_none=True)
     allotment = fields.String(allow_none=True)
     allowance = fields.String(allow_none=True)
     display_name = fields.String(allow_none=True)

--- a/backend/ops_api/tests/ops/can/test_can_funding_details.py
+++ b/backend/ops_api/tests/ops/can/test_can_funding_details.py
@@ -99,7 +99,7 @@ def test_service_create_funding_details(loaded_db):
     assert funding_details.fiscal_year == 2024
     assert funding_details.active_period == 1
     assert funding_details.funding_method == "Direct"
-    assert funding_details.funding_frequency == "Quarterly"
+    assert funding_details.funding_received == "Quarterly"
     assert funding_details.funding_type == "Discretionary"
     assert funding_details == new_budget
 

--- a/backend/ops_api/tests/ops/can/test_can_funding_details.py
+++ b/backend/ops_api/tests/ops/can/test_can_funding_details.py
@@ -98,6 +98,9 @@ def test_service_create_funding_details(loaded_db):
     assert funding_details.method_of_transfer == CANMethodOfTransfer.DIRECT
     assert funding_details.fiscal_year == 2024
     assert funding_details.active_period == 1
+    assert funding_details.funding_method == "Direct"
+    assert funding_details.funding_frequency == "Quarterly"
+    assert funding_details.funding_type == "Discretionary"
     assert funding_details == new_budget
 
     loaded_db.delete(new_budget)


### PR DESCRIPTION
## What changed

Use the fund code to determine the Funding Method, Funding Received, and Funding Type, and then add these values as properties to the CANS model.

## Issue

[#3110 ](https://github.com/HHS/OPRE-OPS/issues/3110)

## How to test

Ensure backend unit tests pass.

## Screenshots

N/A

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated


## Links

[Fund Code Mapping](https://lucid.app/lucidspark/601d8f63-4ee4-4c0b-b020-55581ea0cb7a/edit?viewport_loc=-218%2C-142%2C2658%2C1320%2C0_0&invitationId=inv_8c620359-ca47-4da4-85a9-0b754d0563a5)
