### PR TITLE
Can Spending Tab

### DIFF
--- a/frontend/src/pages/cans/detail/Can.hooks.js
+++ b/frontend/src/pages/cans/detail/Can.hooks.js
@@ -71,6 +71,7 @@ export default function useCan() {
         plannedFunding: CANFunding?.planned_funding,
         obligatedFunding: CANFunding?.obligated_funding,
         inExecutionFunding: CANFunding?.in_execution_funding,
+        inDraftFunding: CANFunding?.in_draft_funding,
         expectedFunding: CANFunding?.expected_funding,
         receivedFunding: CANFunding?.received_funding,
         subTitle: can ? `${can.nick_name} - ${can.active_period} ${can.active_period > 1 ? "Years" : "Year"}` : "",

--- a/frontend/src/pages/cans/detail/Can.jsx
+++ b/frontend/src/pages/cans/detail/Can.jsx
@@ -34,6 +34,7 @@ const Can = () => {
         plannedFunding,
         obligatedFunding,
         inExecutionFunding,
+        inDraftFunding,
         subTitle,
         projectTypesCount,
         budgetLineTypesCount,
@@ -87,6 +88,7 @@ const Can = () => {
                             budgetLineTypesCount={budgetLineTypesCount}
                             agreementTypesCount={testAgreements}
                             inExecutionFunding={inExecutionFunding}
+                            inDraftFunding={inDraftFunding}
                             obligatedFunding={obligatedFunding}
                             plannedFunding={plannedFunding}
                             totalFunding={totalFunding}

--- a/frontend/src/pages/cans/detail/CanSpending.jsx
+++ b/frontend/src/pages/cans/detail/CanSpending.jsx
@@ -41,19 +41,19 @@ const CanSpending = ({
     agreementTypesCount,
     plannedFunding,
     inExecutionFunding,
+    inDraftFunding,
     obligatedFunding,
     totalFunding
 }) => {
     const totalSpending = Number(plannedFunding) + Number(obligatedFunding) + Number(inExecutionFunding);
-    const DRAFT_FUNDING = 1_000_000; // replace with actual data
 
     const graphData = [
         {
             id: 1,
             label: "Draft",
-            value: Math.round(DRAFT_FUNDING) || 0,
+            value: Math.round(inDraftFunding) || 0,
             color: "var(--neutral-lighter)",
-            percent: `${calculatePercent(DRAFT_FUNDING, totalFunding)}%`
+            percent: `${calculatePercent(inDraftFunding, totalFunding)}%`
         },
         {
             id: 2,


### PR DESCRIPTION
Update CAN Spending Tab:
- use in draft funding  in Right Card
- 
