### PR TITLE
OPS-2362: Refactor azure document repository to route through app gateway

### DIFF
--- a/backend/ops_api/ops/document/azure_document_repository.py
+++ b/backend/ops_api/ops/document/azure_document_repository.py
@@ -2,7 +2,8 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from azure.storage.blob import AccountSasPermissions, ResourceTypes, generate_account_sas
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import AccountSasPermissions, BlobServiceClient, ResourceTypes, generate_container_sas
 from flask import Config, current_app
 
 from ops_api.ops.document.document_repository import DocumentRepository
@@ -13,8 +14,8 @@ from ops_api.ops.document.utils import get_by_agreement_id, insert_new_document,
 class AzureDocumentRepository(DocumentRepository):
     def __init__(self) -> None:
         self.config = Config
-        self.account_key = os.getenv("DOCUMENT_STORAGE_ACCOUNT_ACCESS_KEY")
         self.storage_account_name = os.getenv("DOCUMENT_STORAGE_ACCOUNT_NAME")
+        self.storage_container_name = os.getenv("DOCUMENT_STORAGE_CONTAINER_NAME")
 
     def add_document(self, document_data):
         try:
@@ -23,7 +24,10 @@ class AzureDocumentRepository(DocumentRepository):
             document_record = insert_new_document(document_data)
             document_id = document_record.document_id
 
-            return {"url": generate_account_sas_url(self.storage_account_name, self.account_key), "uuid": document_id}
+            return {
+                "url": generate_container_sas_url(self.storage_account_name, "docs", upload=True),
+                "uuid": document_id,
+            }
 
         except SasUrlGenerationError as e:
             current_app.logger.error(f"Failed to generate SAS URL: {e}")
@@ -42,36 +46,28 @@ class AzureDocumentRepository(DocumentRepository):
         pass
 
     def get_documents_by_agreement_id(self, agreement_id):
-        url = generate_account_sas_url(self.storage_account_name, self.account_key)
+        url = generate_container_sas_url(self.storage_account_name, "docs", download=True)
         return {"url": url, "documents": get_by_agreement_id(agreement_id)}
 
     def update_document_status(self, document_id, status):
         process_status_update(document_id, status)
 
 
-def generate_account_sas_url(account_name, account_key, expiry_hours=1):
+def generate_container_sas_url(account_name, container_name, download=False, upload=False, expiry_hours=1):
     """
-    Generate an SAS URL for the Azure Blob Storage account level.
+    Generate an SAS URL for the Azure Blob Storage at the container level.
 
     :param account_name: The name of the Azure Storage account.
-    :param account_key: The account key for the Azure Storage account.
+    :param container_name: The container to work within the Azure Storage Account.
+    :param download: Boolean value which indicates the SAS token generated is for downloading a file.
+    :param upload: Boolean value which indicates that the SAS token generated is for uploading a file.
     :param expiry_hours: The number of hours for which the SAS token should be valid.
     :return: The SAS URL for the storage account.
     """
     try:
         # Define the expiration time of the SAS token. Default is one hour.
-        expiry_time = datetime.now(tz=timezone.utc) + timedelta(hours=expiry_hours)
-
-        # Generate the SAS token
-        sas_token = generate_account_sas(
-            account_name=account_name,
-            account_key=account_key,
-            resource_types=ResourceTypes(service=True, container=True, object=True),
-            permission=AccountSasPermissions(
-                read=True, write=True, delete=True, list=True, add=True, create=True, update=True, process=True
-            ),
-            expiry=expiry_time,
-        )
+        now_time = datetime.now(tz=timezone.utc)
+        expiry_time = now_time + timedelta(hours=expiry_hours)
 
         # Construct the SAS URL
         DEFAULT_DEV_OPS_URL = "https://dev.ops.opre.acf.gov"
@@ -80,6 +76,32 @@ def generate_account_sas_url(account_name, account_key, expiry_hours=1):
             if "localhost" in current_app.config.get("OPS_FRONTEND_URL")
             else current_app.config.get("OPS_FRONTEND_URL")
         )
+        old_url = f"https://{account_name}.blob.core.windows.net/"
+        credential = DefaultAzureCredential()
+        blob_service_client = BlobServiceClient(account_url=old_url, credential=credential)
+
+        user_delegation_key = blob_service_client.get_user_delegation_key(
+            key_start_time=now_time, key_expiry_time=expiry_time
+        )
+        sas_permissions = None
+        if download:
+            sas_permissions = AccountSasPermissions(read=True, list=True)
+        if upload:
+            sas_permissions = AccountSasPermissions(write=True)
+
+        if sas_permissions is None:
+            raise ValueError("Neither Upload nor Download was specified for SAS Token generation.")
+        # Generate the SAS token
+        sas_token = generate_container_sas(
+            account_name=account_name,
+            container_name=container_name,
+            user_delegation_key=user_delegation_key,
+            resource_types=ResourceTypes(service=True, container=True, object=True),
+            permission=sas_permissions,
+            start=now_time,
+            expiry=expiry_time,
+        )
+
         # https://dev.ops.opre.acf.gov/?{sas_token} in dev
         sas_url = f"{OPS_URL}/?{sas_token}"
         return sas_url

--- a/backend/ops_api/ops/document/document_gateway.py
+++ b/backend/ops_api/ops/document/document_gateway.py
@@ -1,4 +1,4 @@
-from flask import Config
+from flask import Config, current_app
 
 from ops_api.ops.document.azure_document_repository import AzureDocumentRepository
 from ops_api.ops.document.document_repository import DocumentRepository
@@ -15,7 +15,10 @@ class DocumentGateway:
         # Validate and register providers with the factory
         self.register_providers()
 
-        self.provider = DocumentProviders.azure.name
+        if "localhost" in current_app.config.get("OPS_FRONTEND_URL"):
+            self.provider = DocumentProviders.fake.name
+        else:
+            self.provider = DocumentProviders.azure.name
 
     def register_providers(self) -> None:
         """

--- a/frontend/cypress/e2e/uploadDocument.cy.js
+++ b/frontend/cypress/e2e/uploadDocument.cy.js
@@ -14,7 +14,7 @@ it("should loads", () => {
     cy.get("h1").should("have.text", "Temporary Upload Document Page");
 });
 
-it.skip("should create a document database record and upload to in memory storage", () => {
+it("should create a document database record and upload to in memory storage", () => {
     // Entering an Agreement ID in the Upload Document section
     cy.get('#agreement-id-upload').type('1');
     // Selecting a file


### PR DESCRIPTION
## What changed
Instead of having the azure document repository return a URI that is directly referencing the azure storage blob, instead change the URI to be the app gateway instead. Additionally, adjusted the SAS token generated to be limited to just the specified container (docs in the storage account) as opposed to the full account. 

## Issue

[OPS-2362](https://github.com/HHS/OPRE-OPS/issues/2362)

## How to test

Run unit tests

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

