### PR TITLE
fix: updating home landing page text based on environment

### DIFF
--- a/frontend/cypress/e2e/mainPage.cy.js
+++ b/frontend/cypress/e2e/mainPage.cy.js
@@ -12,7 +12,7 @@ afterEach(() => {
 });
 
 it("loads", () => {
-    cy.get("h1").contains("This is the OPRE OPS system prototype");
+    cy.get("h1").contains("Welcome to OPS");
 });
 
 it("clicking on /cans nav takes you to CAN page", () => {

--- a/frontend/cypress/e2e/mainPage.cy.js
+++ b/frontend/cypress/e2e/mainPage.cy.js
@@ -12,7 +12,7 @@ afterEach(() => {
 });
 
 it("loads", () => {
-    cy.get("h1").contains("Welcome to OPS");
+    cy.get("h1").contains("This is a non-production OPS environment");
 });
 
 it("clicking on /cans nav takes you to CAN page", () => {
@@ -22,7 +22,7 @@ it("clicking on /cans nav takes you to CAN page", () => {
 });
 
 it("clicking on /portfolio nav while unauthenticated, should keep you at home page.", () => {
-    cy.get("h1").contains("Welcome to OPS");
+    cy.get("h1").contains("This is a non-production OPS environment");
     cy.url().should("include", "/");
 });
 

--- a/frontend/cypress/e2e/mainPage.cy.js
+++ b/frontend/cypress/e2e/mainPage.cy.js
@@ -22,7 +22,7 @@ it("clicking on /cans nav takes you to CAN page", () => {
 });
 
 it("clicking on /portfolio nav while unauthenticated, should keep you at home page.", () => {
-    cy.get("h1").contains("This is the OPRE OPS system prototype");
+    cy.get("h1").contains("Welcome to OPS");
     cy.url().should("include", "/");
 });
 

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -5,10 +5,16 @@ const Home = () => {
     return (
         <App>
             <div className="display-flex flex-justify-center">
-                <RoundedBox className="margin-top-4 text-center">
-                    <h1>This is the OPRE OPS system prototype</h1>
-                    <p>⚠️Tread with caution</p>
-                </RoundedBox>
+                {!import.meta.env.PROD ? (
+                    <RoundedBox className="margin-top-4 text-center">
+                        <h1>This is a non-production OPS environment</h1>
+                        <p>⚠️This environment is not authorized for certain production datasets. Additionally, this environment may be updated regularly.</p>
+                    </RoundedBox>
+                ) : (
+                    <RoundedBox className="margin-top-4 text-center">
+                        <h1>Welcome to OPS!</h1>
+                    </RoundedBox>
+                )}
             </div>
         </App>
     );


### PR DESCRIPTION
## What changed

Adds some conditional text for the center div when a user first logs in that's more appropriate for where we're at. This makes the experience for the staging environment match what we're about to enter into for Phase 0 as well as the production environment.  Eagerly inviting better suggestions for text/appearance/user experience. 

I don't love the repetition of that react component tag but eslint wasn't having it any other way....

## Issue

N/A

## How to test

Log in!

## Screenshots

N/A

