### PR TITLE
OPS-2362: Fix GET documents routing in flask 

### DIFF
--- a/backend/ops_api/ops/urls.py
+++ b/backend/ops_api/ops/urls.py
@@ -310,7 +310,7 @@ def register_api(api_bp: Blueprint) -> None:
         view_func=CHANGE_REQUEST_REVIEW_API_VIEW_FUNC,
     )
     api_bp.add_url_rule(
-        "/documents/<int:agreement_id>/",
+        "/documents/<int:agreement_id>",
         view_func=DOCUMENT_API_FUNC,
     )
     api_bp.add_url_rule(

--- a/frontend/cypress/e2e/uploadDocument.cy.js
+++ b/frontend/cypress/e2e/uploadDocument.cy.js
@@ -27,24 +27,27 @@ it("should create a document database record and upload to in memory storage", (
     // Verifying the document database record exists
     expect(localStorage.getItem("access_token")).to.exist;
     const bearer_token = `Bearer ${window.localStorage.getItem("access_token")}`;
-    cy.request({
-        method: "GET",
-        url: "http://localhost:8080/api/v1/documents/1",
-        headers: {
-            Authorization: bearer_token,
-            "Content-Type": "application/json",
-            Accept: "application/json"
-        }
-    }).then((response) => {
-        expect(response.status).to.eq(200);
-        expect(response.body.url).to.exist;
-        expect(response.body.url).to.include("FakeDocumentRepository");
-        expect(response.body.documents).to.exist;
-        expect(response.body.documents[0].document_name).to.eq("sample_document.xlsx");
-        expect(response.body.documents[0].document_type).to.eq("DocumentType.ADDITIONAL_DOCUMENT");
-        expect(response.body.documents[0].agreement_id).to.eq(1);
-        expect(response.body.documents[0].status).to.eq("uploaded");
-    });
+    cy.wait(2000).then(() => {
+        cy.request({
+            method: "GET",
+            url: "http://localhost:8080/api/v1/documents/1",
+            headers: {
+                Authorization: bearer_token,
+                "Content-Type": "application/json",
+                Accept: "application/json"
+            }
+        }).then((response) => {
+            expect(response.status).to.eq(200);
+            expect(response.body.url).to.exist;
+            expect(response.body.url).to.include("FakeDocumentRepository");
+            expect(response.body.documents).to.exist;
+            const mostRecentDoc = response.body.documents.length - 1;
+            expect(response.body.documents[mostRecentDoc].document_name).to.eq("sample_document.xlsx");
+            expect(response.body.documents[mostRecentDoc].document_type).to.eq("DocumentType.ADDITIONAL_DOCUMENT");
+            expect(response.body.documents[mostRecentDoc].agreement_id).to.eq(1);
+            expect(response.body.documents[mostRecentDoc].status).to.eq("uploaded");
+        });
+    })
 });
 
 it.skip("Should download document in memory storage and verify logs", () => {


### PR DESCRIPTION
## What changed

The flask document routing for the GET /documents/<id> endpoint had a trailing slash, which is inconsistent with any of our other /route/<id> routes. This caused an HTTP308 (Permanent Redirect) When attempting to get the document list in our upload-document page. 
## Issue

OPS-2362

## How to test

Run all tests

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated
