### PR TITLE
fix: updating the tag for the imageToDeploy for the frontend containers

### DIFF
--- a/.github/workflows/dev_be_build_and_deploy.yml
+++ b/.github/workflows/dev_be_build_and_deploy.yml
@@ -7,7 +7,7 @@ on:
       - main
     paths:
       - backend/**
-      
+
 env:
   WORKING_DIR: "backend"
   DT_DOCKER_FILE: "Dockerfile.data-tools-import"
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      
+
       - name: Build and publish the Docker image for ${{ github.repository }}
         uses: ./.github/actions/build-and-push
         with:
@@ -30,8 +30,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.DT_DOCKER_FILE }}
-          image_tags: "unstable,${{ github.sha }}"
-  
+          image_tags: "${{ github.sha }}"
+
   build-backend:
     permissions:
       contents: read
@@ -49,18 +49,18 @@ jobs:
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.BE_DOCKER_FILE }}
           image_tags: "unstable,${{ github.sha }}"
 
-  deploy-data-tools: 
+  deploy-data-tools:
     needs: build-data-tools
 
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      
+
       - name: Log in to Azure
         uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
         with:
           creds: ${{ secrets.SDLC_AZURE_CREDS }}
-      
+
       - name: Trigger Data-Tools Job
         uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd # v2
         with:
@@ -78,14 +78,14 @@ jobs:
       #     containerAppName: opre-ops-${{ env.ENVIRONMENT }}-data-tools
       #     resourceGroup: opre-ops-services-${{ env.ENVIRONMENT }}-app
       #     imageToDeploy: ghcr.io/hhs/opre-ops/ops-data-tools:${{ github.sha }}
-        
-  deploy-backend: 
+
+  deploy-backend:
     needs: build-backend
 
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      
+
       - name: Log in to Azure
         uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2.2.0
         with:

--- a/.github/workflows/dev_fe_build_and_deploy.yml
+++ b/.github/workflows/dev_fe_build_and_deploy.yml
@@ -30,7 +30,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.DOCKER_FILE }}
-          image_tags: "unstable,${{ github.sha }},${{ env.ENVIRONMENT }}"
+          image_tags: "${{ github.sha }},${{ env.ENVIRONMENT }}"
           build_args: "VITE_BACKEND_DOMAIN=https://${{ env.ENVIRONMENT }}.${{ env.DOMAIN_NAME }}, MODE=${{ env.ENVIRONMENT }}"
 
   deploy-frontend:
@@ -50,4 +50,4 @@ jobs:
         with:
             containerAppName: opre-ops-${{ env.ENVIRONMENT }}-app-${{ env.WORKING_DIR }}
             resourceGroup: opre-ops-${{ env.ENVIRONMENT }}-app-rg
-            imageToDeploy: ghcr.io/hhs/opre-ops/ops-${{ env.WORKING_DIR }}:${{ github.sha }}
+            imageToDeploy: ghcr.io/hhs/opre-ops/ops-${{ env.WORKING_DIR }}:${{ env.ENVIRONMENT }}

--- a/.github/workflows/prod_fe_build_and_deploy.yml
+++ b/.github/workflows/prod_fe_build_and_deploy.yml
@@ -2,7 +2,7 @@ name: Production Frontend Build and Deploy
 
 on:
   workflow_dispatch:
-  
+
 env:
   WORKING_DIR: "frontend"
   DOCKER_FILE: "Dockerfile.azure"
@@ -45,4 +45,4 @@ jobs:
         with:
             containerAppName: opre-ops-${{ env.ENVIRONMENT }}-app-${{ env.WORKING_DIR }}
             resourceGroup: opre-ops-${{ env.ENVIRONMENT }}-app-rg
-            imageToDeploy: ghcr.io/hhs/opre-ops/ops-${{ env.WORKING_DIR }}:${{ github.sha }}
+            imageToDeploy: ghcr.io/hhs/opre-ops/ops-${{ env.WORKING_DIR }}:${{ env.ENVIRONMENT }}

--- a/.github/workflows/stg_fe_build_and_deploy.yml
+++ b/.github/workflows/stg_fe_build_and_deploy.yml
@@ -50,4 +50,4 @@ jobs:
         with:
             containerAppName: opre-ops-${{ env.ENVIRONMENT }}-app-${{ env.WORKING_DIR }}
             resourceGroup: opre-ops-${{ env.ENVIRONMENT }}-app-rg
-            imageToDeploy: ghcr.io/hhs/opre-ops/ops-${{ env.WORKING_DIR }}:${{ github.sha }}
+            imageToDeploy: ghcr.io/hhs/opre-ops/ops-${{ env.WORKING_DIR }}:${{ env.ENVIRONMENT }}


### PR DESCRIPTION
## What changed

changes the `imageToDeploy` for the staging frontend container such that it looks for a tag matching the environment (`stg`) instead of the sha of the image.

Although there are multiple possible ways to solve this, and maybe larger more wide-reaching solutions are warranted as part of #2758 or other initiatives, this seems a minimally-invasive change to make to fix the pain being experienced. maybe ? Better ideas welcomed. Never compromise on quality. 

## Issue

This is being proposed/done because:
* Currently there's no difference at build time between the dev and staging frontend containers so they end up coming out with the same checksum/sha.
* the build GHA tries publishing image with tags matching the environment and the sha image. 
* The dev container image is usually taking a second or more longer to build than staging for whatever reason and so effectively, since the sha's match, the dev container gets the tag for that sha tag. 
* Thusly, when the GHA for deploying the frontend staging container runs, it's looking for the ops frontend container matching the correct staging frontend container it's expecting to have based on sha, but because dev finished building last, it ends up getting the dev container image matching that sha tag and deploying that.
* Thusly, when hitting what's supposed to be the staging frontend, it's trying to reach the dev backend, and that's 👎 

## How to test

merge to main, or fire off a manual build and deploy workflows for dev and staging and see if staging deploys the correct container

## Screenshots

<img width="999" alt="Screenshot 2024-12-14 at 23 55 49" src="https://github.com/user-attachments/assets/d717fd4d-fb20-40b8-a5b7-d95dc3aa9622" />
This screenshot shows the the frontend container for staging is tagged only with `stg` but the dev one has `dev` and the `sha` tag that both dev and staging would share. Due to whatever is causing dev to usually take a bit longer, dev gets the sha tag and thusly you can see it has all the downloads. 

## Definition of Done Checklist
~- [ ] OESA: Code refactored for clarity~
~- [ ] OESA: Dependency rules followed~
~- [ ] Automated unit tests updated and passed~
~- [ ] Automated integration tests updated and passed~
~- [ ] Automated quality tests updated and passed~
~- [ ] Automated load tests updated and passed~
~- [ ] Automated a11y tests updated and passed~
~- [ ] Automated security tests updated and passed~
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~


## Links

