### PR TITLE
chore: adding environment label to backend container builds as well

### DIFF
--- a/.github/workflows/dev_be_build_and_deploy.yml
+++ b/.github/workflows/dev_be_build_and_deploy.yml
@@ -47,7 +47,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.BE_DOCKER_FILE }}
-          image_tags: "unstable,${{ github.sha }}"
+          image_tags: "${{ env.ENVIRONMENT }},${{ github.sha }}"
 
   deploy-data-tools:
     needs: build-data-tools

--- a/.github/workflows/prod_be_build_and_deploy.yml
+++ b/.github/workflows/prod_be_build_and_deploy.yml
@@ -25,7 +25,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.DT_DOCKER_FILE }}
-          image_tags: "${{ github.sha }}"
+          image_tags: "${{ env.ENVIRONMENT }},${{ github.sha }}"
 
   build-backend:
     permissions:

--- a/.github/workflows/prod_be_build_and_deploy.yml
+++ b/.github/workflows/prod_be_build_and_deploy.yml
@@ -25,7 +25,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.DT_DOCKER_FILE }}
-          image_tags: "${{ env.ENVIRONMENT }},${{ github.sha }}"
+          image_tags: "${{ github.sha }}"
 
   build-backend:
     permissions:
@@ -42,7 +42,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.BE_DOCKER_FILE }}
-          image_tags: "${{ github.sha }}"
+          image_tags: "${{ env.ENVIRONMENT }},${{ github.sha }}"
 
   deploy-data-tools:
     needs: build-data-tools

--- a/.github/workflows/stg_be_build_and_deploy.yml
+++ b/.github/workflows/stg_be_build_and_deploy.yml
@@ -47,7 +47,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.BE_DOCKER_FILE }}
-          image_tags: "${{ github.sha }}"
+          image_tags: "${{ env.ENVIRONMENT }},${{ github.sha }}"
 
   deploy-data-tools:
     needs: build-data-tools


### PR DESCRIPTION
## What changed

The terraform for the backend containers when they're initially getting created or re-created really want a good image tag to use for deploying and since we weren't doing any tagging other than the sha and recently got rid of the unstable tag for dev, this is an off-nominal situation. So until our semantic versioning/release stuff gets more implemented, this is a near-term hack of sorts to allow the ACAs to be more happy when getting created as we've had to do this week and in the event we need to do it again.   

Regular typical deploys though will still specify images via sha as they have been doing.

## How to test

Blow away the backend ACAs and re-create

