### PR TITLE
chore: update ZAP DAST scan to ignore warning and below

### DIFF
--- a/.github/workflows/nightly_scans.yml
+++ b/.github/workflows/nightly_scans.yml
@@ -25,7 +25,7 @@ jobs:
           target: 'https://stg.ops.opre.acf.gov/'
           allow_issue_writing: false
           fail_action: false
-          cmd_options: '-I'
+          cmd_options: '-I -l FAIL'
 
       ## Manually reviewed the action, and validated it performs basic
       ## conversion from zap.json to zap.sarif.


### PR DESCRIPTION
## What changed

Further modified the command line options to the ZAP docker container to further attempt to silence warning-level and below threshold of findings. This is believed to be the intent of the current config but it has been still producing an undesirable level/quality of findings.

This is a pre-cursor to a future PR that will change this action over to testing the production environment instead of the staging environment.

## Issue

N/A

## How to test

Manually run or wait for scheduled run of this GHA and see if warning-level issues and below are produced.

## Links

https://www.zaproxy.org/docs/docker/full-scan/
https://github.com/marketplace/actions/zap-full-scan