### PR TITLE
feat: adds welcome modal to can funding received tab

### DIFF
--- a/frontend/cypress/e2e/canDetail.cy.js
+++ b/frontend/cypress/e2e/canDetail.cy.js
@@ -176,6 +176,11 @@ describe("CAN detail page", () => {
         cy.visit(`/cans/${can504.number}/funding`);
         cy.get("#fiscal-year-select").select(currentFiscalYear);
         cy.get("#edit").click();
+        // Check welcome modal
+        cy.get("#ops-modal-heading").contains(
+            "Data from the previous fiscal year can no longer be edited, but can be viewed by changing the FY dropdown on the CAN details page."
+        );
+        cy.get("[data-cy=confirm-action]").click();
         cy.get("#carry-forward-card").should("contain", "$ 10,000,000.00");
         cy.get("#save-changes").should("be.disabled");
         cy.get("#add-fy-budget").should("be.disabled");
@@ -201,6 +206,8 @@ describe("CAN detail page", () => {
         cy.visit(`/cans/${can504.number}/funding`);
         cy.get("#fiscal-year-select").select(currentFiscalYear);
         cy.get("#edit").click();
+        // welcome modal should not be present
+        cy.get("#ops-modal-heading").should("not.exist");
         // check that all buttons (saved, all funding received) are disabled
         cy.get("[data-cy=add-funding-received-btn]").should("be.disabled");
         cy.get("[data-cy=save-btn]").should("be.disabled");
@@ -232,12 +239,12 @@ describe("CAN detail page", () => {
         // verify form is populated correctly
         cy.get("#funding-received-amount").invoke("val").should("equal", "1,000,000");
         cy.get("#notes").invoke("val").should("equal", "Test notes");
-        // edit form
+        // edit funding received form
         cy.get("#funding-received-amount").clear();
         cy.get("#funding-received-amount").type("2_000_000");
         cy.get("[data-cy=add-funding-received-btn]").click();
         cy.get("[data-cy=budget-received-card]").should("exist").and("contain", "2,000,000.00");
-        // validation check
+        // validation check to ensure amount does not exceed budget amount
         cy.get("tbody").find("tr").first().trigger("mouseover");
         cy.get("tbody").find("tr").first().find('[data-cy="edit-row"]').click();
         cy.get("#funding-received-amount").clear();
@@ -245,7 +252,6 @@ describe("CAN detail page", () => {
         cy.get("[data-cy=add-funding-received-btn]").should("be.disabled");
         cy.get(".usa-error-message").should("exist").contains("Amount cannot exceed FY Budget");
         cy.get("[data-cy=cancel-funding-received-btn]").click();
-
         // delete a funding received from table
         cy.get("#funding-received-amount").type("3_000_000");
         cy.get("#notes").type("Delete me please");
@@ -253,9 +259,9 @@ describe("CAN detail page", () => {
         cy.get("tbody").find("tr").eq(1).trigger("mouseover");
         cy.get("tbody").find("tr").eq(1).find('[data-cy="delete-row"]').click();
         cy.get("tbody").children().should("have.length", 1);
-        // make sure the funding received card on the right updates (to do after bug fix)
+        // make sure the funding received card on the right updates
         cy.get("[data-cy=budget-received-card]").should("exist").and("contain", "2,000,000.00");
-        // click on button at bottom of form
+        // click on save button at bottom of form
         cy.get("[data-cy=save-btn]").click();
         // check success alert
         cy.get(".usa-alert__body").should("contain", `The CAN ${can504.nickname} has been successfully updated.`);
@@ -327,6 +333,7 @@ describe("CAN detail page", () => {
         cy.visit(`/cans/500/funding`);
         cy.get("#fiscal-year-select").select(currentFiscalYear);
         cy.get("#edit").click();
+        cy.get("[data-cy=confirm-action]").click();
         cy.get("#carry-forward-card").should("not.exist");
     });
 });

--- a/frontend/src/components/CANs/CANBudgetByFYCard/CANBudgetByFYCard.jsx
+++ b/frontend/src/components/CANs/CANBudgetByFYCard/CANBudgetByFYCard.jsx
@@ -25,9 +25,10 @@ const CANBudgetByFYCard = ({ fundingBudgets }) => {
                 title="CAN Budget by FY"
                 dataCy="can-budget-fy-card"
             >
-                {chartData.map((item) => (
+                {chartData.map((item, i) => (
                     <LineBar
                         key={`budget-fy-${item.FY}`}
+                        iterator={i}
                         color={item.color}
                         ratio={item.ratio}
                         title={`FY ${item.FY}`}

--- a/frontend/src/components/CANs/CANBudgetForm/CANBudgetForm.jsx
+++ b/frontend/src/components/CANs/CANBudgetForm/CANBudgetForm.jsx
@@ -11,7 +11,7 @@ import icons from "../../../uswds/img/sprite.svg";
  * @property {number} fiscalYear
  * @property {(e: React.FormEvent<HTMLFormElement>) => void} handleAddBudget
  * @property {(name: string, value: string) => void} runValidate
- * @property { React.Dispatch<React.SetStateAction<string>>} setBudgetAmount
+ * @property {(value: string) => void} setBudgetAmount
  */
 
 /**

--- a/frontend/src/components/CANs/CANFundingReceivedForm/CanFundingReceivedForm.jsx
+++ b/frontend/src/components/CANs/CANFundingReceivedForm/CanFundingReceivedForm.jsx
@@ -10,10 +10,10 @@ import icons from "../../../uswds/img/sprite.svg";
  * @property {(e: React.FormEvent<HTMLFormElement>) => void} handleSubmit
  * @property {boolean} isEditing
  * @property {(name: string, value: string) => void} runValidate
- * @property { React.Dispatch<React.SetStateAction<string>>} setReceivedFundingAmount
+ * @property {(value: string) => void} setReceivedFundingAmount
  * @property {string} notes
- * @property { React.Dispatch<React.SetStateAction<string>>} setNotes
- * @property { () => void } cancelFundingReceived
+ * @property {(value: string) => void} setNotes
+ * @property {(e: React.FormEvent<HTMLFormElement>) => void } cancelFundingReceived
  */
 
 /**

--- a/frontend/src/components/CANs/CANFundingReceivedTable/CANFundingReceivedTable.jsx
+++ b/frontend/src/components/CANs/CANFundingReceivedTable/CANFundingReceivedTable.jsx
@@ -11,7 +11,7 @@ import CANFundingReceivedTableRow from "./CANFundingReceivedTableRow";
  * @property {FundingReceived[]} fundingReceived data for table
  * @property {boolean} isEditMode for if we're in edit mode
  * @property {(id: number | string) => void} populateFundingReceivedForm function for editing funding received
- * @property {() => void} deleteFundingReceived
+ * @property {(fundingReceivedId: number | string) => void} deleteFundingReceived
  */
 
 /**

--- a/frontend/src/components/UI/DataViz/LineBar/LineBar.jsx
+++ b/frontend/src/components/UI/DataViz/LineBar/LineBar.jsx
@@ -1,7 +1,7 @@
 import CurrencyFormat from "react-currency-format";
-import styles from "./LineBar.styles.module.css";
-import { getDecimalScale } from "../../../../helpers/currencyFormat.helpers";
 import { NO_DATA } from "../../../../constants";
+import { getDecimalScale } from "../../../../helpers/currencyFormat.helpers";
+import styles from "./LineBar.styles.module.css";
 
 /**
  * @typedef {Object} LineBarProps
@@ -9,6 +9,7 @@ import { NO_DATA } from "../../../../constants";
  * @property {number} ratio - The ratio value that determines the bar length
  * @property {string} color - The background color of the bar
  * @property {number} total - The total amount to display formatted as currency
+ * @property {number} iterator - The index of the current item in the list
  */
 
 /**
@@ -16,7 +17,7 @@ import { NO_DATA } from "../../../../constants";
  * @param {LineBarProps} props
  * @returns {JSX.Element} A line bar component
  */
-const LineBar = ({ title, ratio, color, total }) => {
+const LineBar = ({ title, ratio, color, total, iterator }) => {
     return (
         <div className={styles.container}>
             <span className={styles.title}>{title}</span>
@@ -27,7 +28,7 @@ const LineBar = ({ title, ratio, color, total }) => {
                 />
             </div>
             <div className={styles.amount}>
-                {total === 0 ? (
+                {total === 0 && iterator === 0 ? (
                     NO_DATA
                 ) : (
                     <CurrencyFormat

--- a/frontend/src/components/UI/DataViz/LineBar/LineBar.jsx
+++ b/frontend/src/components/UI/DataViz/LineBar/LineBar.jsx
@@ -1,6 +1,7 @@
 import CurrencyFormat from "react-currency-format";
 import styles from "./LineBar.styles.module.css";
 import { getDecimalScale } from "../../../../helpers/currencyFormat.helpers";
+import { NO_DATA } from "../../../../constants";
 
 /**
  * @typedef {Object} LineBarProps
@@ -26,14 +27,18 @@ const LineBar = ({ title, ratio, color, total }) => {
                 />
             </div>
             <div className={styles.amount}>
-                <CurrencyFormat
-                    value={total}
-                    displayType="text"
-                    thousandSeparator=","
-                    prefix="$"
-                    decimalScale={getDecimalScale(total)}
-                    fixedDecimalScale={true}
-                />
+                {total === 0 ? (
+                    NO_DATA
+                ) : (
+                    <CurrencyFormat
+                        value={total}
+                        displayType="text"
+                        thousandSeparator=","
+                        prefix="$"
+                        decimalScale={getDecimalScale(total)}
+                        fixedDecimalScale={true}
+                    />
+                )}
             </div>
         </div>
     );

--- a/frontend/src/pages/cans/detail/Can.jsx
+++ b/frontend/src/pages/cans/detail/Can.jsx
@@ -25,6 +25,8 @@ const Can = () => {
         canNumber,
         description,
         nickname,
+        modalProps,
+        resetModal,
         fundingDetails,
         fundingBudgets,
         fundingReceivedByFiscalYear,
@@ -115,6 +117,8 @@ const Can = () => {
                         <CanFunding
                             canId={canId}
                             canNumber={canNumber}
+                            welcomeModal={modalProps}
+                            setWelcomeModal={resetModal}
                             currentFiscalYearFundingId={currentFiscalYearFundingId}
                             funding={fundingDetails}
                             fundingBudgets={fundingBudgets}

--- a/frontend/src/pages/cans/detail/CanFunding.hooks.js
+++ b/frontend/src/pages/cans/detail/CanFunding.hooks.js
@@ -39,6 +39,7 @@ export default function useCanFunding(
     isBudgetTeamMember,
     isEditMode,
     toggleEditMode,
+    setWelcomeModal,
     receivedFunding,
     fundingReceived,
     currentFiscalYearFundingId
@@ -365,6 +366,7 @@ export default function useCanFunding(
         setShowModal(false);
         setFundingReceivedForm(initialFundingReceivedForm);
         toggleEditMode();
+        setWelcomeModal();
         setModalProps({
             heading: "",
             actionButtonText: "",

--- a/frontend/src/pages/cans/detail/CanFunding.hooks.js
+++ b/frontend/src/pages/cans/detail/CanFunding.hooks.js
@@ -27,6 +27,7 @@ import cryptoRandomString from "crypto-random-string";
  * @param {boolean} isBudgetTeamMember
  * @param {boolean} isEditMode
  * @param {() => void} toggleEditMode
+ * @param {() => void} setWelcomeModal
  * @param {string} receivedFunding
  * @param {FundingReceived[]} fundingReceived
  * @param {number} [currentFiscalYearFundingId] - The id of the current fiscal year funding. optional
@@ -292,9 +293,9 @@ export default function useCanFunding(
             return fundingEntry.id === newFundingReceived.id;
         });
 
-        console.log({ matchingFundingReceived });
-
-        const matchingFundingReceivedFunding = +matchingFundingReceived?.funding || 0;
+        const matchingFundingReceivedFunding =
+            // set matchingFundingReceivedFunding to 0 if matchingFundingReceived is undefined
+            matchingFundingReceived && matchingFundingReceived.funding ? +matchingFundingReceived.funding : 0;
         setTotalReceived(
             (currentTotal) => currentTotal - matchingFundingReceivedFunding + +fundingReceivedForm.enteredAmount
         );
@@ -343,7 +344,7 @@ export default function useCanFunding(
             const newDeletedFundingReceivedIds = [...deletedFundingReceivedIds, fundingReceivedId];
             setDeletedFundingReceivedIds(newDeletedFundingReceivedIds);
         }
-        setTotalReceived((currentTotal) => currentTotal - +matchingFundingReceived?.funding);
+        setTotalReceived((currentTotal) => currentTotal - +(matchingFundingReceived?.funding ?? 0));
     };
 
     const handleCancel = () => {

--- a/frontend/src/pages/cans/detail/CanFunding.jsx
+++ b/frontend/src/pages/cans/detail/CanFunding.jsx
@@ -4,6 +4,7 @@ import CurrencyFormat from "react-currency-format";
 import CANBudgetByFYCard from "../../../components/CANs/CANBudgetByFYCard/CANBudgetByFYCard";
 import CANBudgetForm from "../../../components/CANs/CANBudgetForm";
 import CANFundingInfoCard from "../../../components/CANs/CANFundingInfoCard";
+import CANFundingReceivedForm from "../../../components/CANs/CANFundingReceivedForm";
 import CANFundingReceivedTable from "../../../components/CANs/CANFundingReceivedTable";
 import Accordion from "../../../components/UI/Accordion";
 import ReceivedFundingCard from "../../../components/UI/Cards/BudgetCard/ReceivedFundingCard";
@@ -11,12 +12,20 @@ import CurrencyCard from "../../../components/UI/Cards/CurrencyCard";
 import ConfirmationModal from "../../../components/UI/Modals/index.js";
 import RoundedBox from "../../../components/UI/RoundedBox";
 import useCanFunding from "./CanFunding.hooks.js";
-import CANFundingReceivedForm from "../../../components/CANs/CANFundingReceivedForm";
 
 /**
  * @typedef {import("../../../components/CANs/CANTypes").FundingDetails} FundingDetails
  * @typedef {import("../../../components/CANs/CANTypes").FundingBudget} FundingBudget
  * @typedef {import("../../../components/CANs/CANTypes").FundingReceived} FundingReceived
+ */
+
+/**
+ * @typedef {Object} welcomeModal
+ * @property {boolean} showModal
+ * @property {string} heading
+ * @property {string} actionButtonText
+ * @property {() => void} setShowModal
+ * @property {() => void} handleConfirm
  */
 
 /**
@@ -34,7 +43,9 @@ import CANFundingReceivedForm from "../../../components/CANs/CANFundingReceivedF
  * @property {boolean} isEditMode
  * @property {() => void} toggleEditMode
  * @property {() => void} deleteFundingReceived
- * @property {string} carryForwardFunding
+ * @property {string} carryForwardFunding,
+ * @property {welcomeModal} welcomeModal
+ * @property {() => void} setWelcomeModal
  */
 
 /**
@@ -55,7 +66,9 @@ const CanFunding = ({
     isBudgetTeamMember,
     isEditMode,
     toggleEditMode,
-    carryForwardFunding
+    carryForwardFunding,
+    welcomeModal,
+    setWelcomeModal
 }) => {
     const {
         handleAddBudget,
@@ -88,6 +101,7 @@ const CanFunding = ({
         isBudgetTeamMember,
         isEditMode,
         toggleEditMode,
+        setWelcomeModal,
         receivedFunding,
         fundingReceived,
         currentFiscalYearFundingId
@@ -97,10 +111,18 @@ const CanFunding = ({
         return <div>No funding information available for this CAN.</div>;
     }
 
-    const showCarryForwardCard = funding.active_period != 1 && fiscalYear > funding.fiscal_year;
+    const showCarryForwardCard = funding.active_period !== 1 && fiscalYear > funding.fiscal_year;
 
     return (
         <div>
+            {+totalFunding === 0 && welcomeModal.showModal && (
+                <ConfirmationModal
+                    heading={welcomeModal.heading}
+                    setShowModal={setWelcomeModal}
+                    actionButtonText={welcomeModal.actionButtonText}
+                    handleConfirm={welcomeModal.handleConfirm}
+                />
+            )}
             {showModal && (
                 <ConfirmationModal
                     heading={modalProps.heading}
@@ -217,7 +239,7 @@ const CanFunding = ({
                         className="margin-bottom-4"
                     >
                         <h2>{`Add FY ${fiscalYear} Funding Received YTD`}</h2>
-                        <p>{`Add funding received towards the Total FY ${fiscalYear} Budget or come back to add funding later. Funding Received means the money is in OPRE’s hands and ready to spend against.`}</p>
+                        <p>{`Add funding received towards the Total FY ${fiscalYear} Budget or come back to add funding later. Funding Received means the money is in OPRE's hands and ready to spend against.`}</p>
                         <div className="display-flex flex-justify margin-top-4">
                             <div
                                 className="border-right-1px border-base-light"

--- a/frontend/src/pages/cans/detail/CanFunding.jsx
+++ b/frontend/src/pages/cans/detail/CanFunding.jsx
@@ -21,11 +21,11 @@ import useCanFunding from "./CanFunding.hooks.js";
 
 /**
  * @typedef {Object} welcomeModal
- * @property {boolean} showModal
  * @property {string} heading
  * @property {string} actionButtonText
- * @property {() => void} setShowModal
+ * @property {string} secondaryButtonText
  * @property {() => void} handleConfirm
+ * @property {boolean} showModal
  */
 
 /**


### PR DESCRIPTION
## What changed

- adds welcome modal to can funding received tab

## Issue

#310 #3299 

## How to test

1. e2e tests pass or:
2. goto `cans/504/funding`
3. click on edit
4. see welcome modal
5. 💰profit
6. add funding and save
7. click on edit
8. welcome modal should not appear

## Screenshots

<img width="817" alt="image" src="https://github.com/user-attachments/assets/482de4fe-afd6-4321-b7cf-130b0f388685" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- <del>[ ] Form validations updated
