### PR TITLE
Hide portfolios UI menu option temporarily

### DIFF
--- a/frontend/cypress/e2e/portfolioDetail.cy.js
+++ b/frontend/cypress/e2e/portfolioDetail.cy.js
@@ -1,19 +1,20 @@
 /// <reference types="cypress" />
 import { terminalLog, testLogin } from "./utils";
 
-    beforeEach(() => {
-        testLogin("system-owner");
-        cy.visit("/portfolios/1");
-        cy.get("#fiscal-year-select").select("2023");
-    });
+beforeEach(() => {
+    testLogin("system-owner");
+    cy.visit("/portfolios/1");
+    cy.get("#fiscal-year-select").select("2023");
+});
 
-    afterEach(() => {
-        cy.injectAxe();
-        cy.checkA11y(null, null, terminalLog);
-    });
+afterEach(() => {
+    cy.injectAxe();
+    cy.checkA11y(null, null, terminalLog);
+});
 
-    // TODO: take away the skips when we're ready to show portfolios again
-    it.skip("loads", () => {
+// TODO: take away the skips when we're ready to show portfolios again
+describe.skip("Portfolio Detail Page", () => {
+    it("loads", () => {
         cy.visit("/portfolios/1");
         cy.get("h1").should("contain", "Child Welfare Research");
         cy.get("h2").should("contain", "Division of Child and Family Development");
@@ -37,18 +38,18 @@ import { terminalLog, testLogin } from "./utils";
         cy.get("span").should("contain", "Carry-Forward");
     });
 
-    it.skip("loads the Portfolio Budget Details component", () => {
+    it("loads the Portfolio Budget Details component", () => {
         cy.get("#fiscal-year-select").select("2021");
         cy.get("h2").should("contain", "Portfolio Budget Details by CAN");
         cy.get("section").should("contain", "G99IA14");
     });
 
-    it.skip("expands the description when one clicks read more", () => {
+    it("expands the description when one clicks read more", () => {
         cy.contains("read more").click();
         cy.get("a").should("contain", "See more on the website");
     });
 
-    it.skip("shows the Portfolio Projects and Spending tab", () => {
+    it("shows the Portfolio Projects and Spending tab", () => {
         cy.visit("/portfolios/1/research-projects/");
         cy.get("#fiscal-year-select").select("2023");
         // summary cards
@@ -60,3 +61,4 @@ import { terminalLog, testLogin } from "./utils";
         cy.get("h2").should("contain", "Research Projects");
         cy.get("h2").should("contain", "Administrative & Support Projects");
     });
+});

--- a/frontend/cypress/e2e/portfolioDetail.cy.js
+++ b/frontend/cypress/e2e/portfolioDetail.cy.js
@@ -60,5 +60,3 @@ import { terminalLog, testLogin } from "./utils";
         cy.get("h2").should("contain", "Research Projects");
         cy.get("h2").should("contain", "Administrative & Support Projects");
     });
-
-}

--- a/frontend/cypress/e2e/portfolioDetail.cy.js
+++ b/frontend/cypress/e2e/portfolioDetail.cy.js
@@ -1,61 +1,66 @@
 /// <reference types="cypress" />
 import { terminalLog, testLogin } from "./utils";
 
-beforeEach(() => {
-    testLogin("system-owner");
-    cy.visit("/portfolios/1");
-    cy.get("#fiscal-year-select").select("2023");
-});
+{/*TODO: remove flag once portfolio UI updates are ready */}
+if (import.meta.env.MODE === "development") {
 
-afterEach(() => {
-    cy.injectAxe();
-    cy.checkA11y(null, null, terminalLog);
-});
+    beforeEach(() => {
+        testLogin("system-owner");
+        cy.visit("/portfolios/1");
+        cy.get("#fiscal-year-select").select("2023");
+    });
 
-it("loads", () => {
-    cy.visit("/portfolios/1");
-    cy.get("h1").should("contain", "Child Welfare Research");
-    cy.get("h2").should("contain", "Division of Child and Family Development");
-    cy.get("dt").should("contain", "Team Leader");
-    cy.get("dd").should("contain", "Chris Fortunato");
-    cy.get("div.margin-top-1 > .text-base-dark").should("contain", "Portfolio Description");
-    cy.get("p").should("contain", "The promotion of children’s safety, permanence, and well-being");
-    cy.get("a").should("contain", "Budget and Funding");
-    cy.get("a").should("contain", "Projects and Spending");
-    cy.get("a").should("contain", "People and Teams");
-    cy.get("h2").should("contain", "Portfolio Budget Summary");
-    cy.get("h3").should("contain", "Budget");
-    cy.get("h3").should("contain", "Budget Status");
-    cy.get("option").should("contain", "2022");
-    cy.get("option").should("contain", "2023");
-    // add  two for  new  charts summary
-    cy.get("#currency-summary-card").should("be.visible");
-    cy.get("#portfolioBudgetStatusChart").should("be.visible");
-    cy.get(".usa-select").should("be.visible");
-    cy.get("span").should("contain", "$");
-    cy.get("span").should("contain", "Carry-Forward");
-});
+    afterEach(() => {
+        cy.injectAxe();
+        cy.checkA11y(null, null, terminalLog);
+    });
 
-it("loads the Portfolio Budget Details component", () => {
-    cy.get("#fiscal-year-select").select("2021");
-    cy.get("h2").should("contain", "Portfolio Budget Details by CAN");
-    cy.get("section").should("contain", "G99IA14");
-});
+    it("loads", () => {
+        cy.visit("/portfolios/1");
+        cy.get("h1").should("contain", "Child Welfare Research");
+        cy.get("h2").should("contain", "Division of Child and Family Development");
+        cy.get("dt").should("contain", "Team Leader");
+        cy.get("dd").should("contain", "Chris Fortunato");
+        cy.get("div.margin-top-1 > .text-base-dark").should("contain", "Portfolio Description");
+        cy.get("p").should("contain", "The promotion of children’s safety, permanence, and well-being");
+        cy.get("a").should("contain", "Budget and Funding");
+        cy.get("a").should("contain", "Projects and Spending");
+        cy.get("a").should("contain", "People and Teams");
+        cy.get("h2").should("contain", "Portfolio Budget Summary");
+        cy.get("h3").should("contain", "Budget");
+        cy.get("h3").should("contain", "Budget Status");
+        cy.get("option").should("contain", "2022");
+        cy.get("option").should("contain", "2023");
+        // add  two for  new  charts summary
+        cy.get("#currency-summary-card").should("be.visible");
+        cy.get("#portfolioBudgetStatusChart").should("be.visible");
+        cy.get(".usa-select").should("be.visible");
+        cy.get("span").should("contain", "$");
+        cy.get("span").should("contain", "Carry-Forward");
+    });
 
-it("expands the description when one clicks read more", () => {
-    cy.contains("read more").click();
-    cy.get("a").should("contain", "See more on the website");
-});
+    it("loads the Portfolio Budget Details component", () => {
+        cy.get("#fiscal-year-select").select("2021");
+        cy.get("h2").should("contain", "Portfolio Budget Details by CAN");
+        cy.get("section").should("contain", "G99IA14");
+    });
 
-it("shows the Portfolio Projects and Spending tab", () => {
-    cy.visit("/portfolios/1/research-projects/");
-    cy.get("#fiscal-year-select").select("2023");
-    // summary cards
-    cy.get("h2").should("contain", "Projects & Spending Summary");
-    cy.get("h3").should("contain", "FY 2023 Budget vs Spending");
-    cy.get("h3").should("contain", "FY 2023 Projects");
-    cy.get("h3").should("contain", "FY 2023 Agreements");
-    // tables
-    cy.get("h2").should("contain", "Research Projects");
-    cy.get("h2").should("contain", "Administrative & Support Projects");
-});
+    it("expands the description when one clicks read more", () => {
+        cy.contains("read more").click();
+        cy.get("a").should("contain", "See more on the website");
+    });
+
+    it("shows the Portfolio Projects and Spending tab", () => {
+        cy.visit("/portfolios/1/research-projects/");
+        cy.get("#fiscal-year-select").select("2023");
+        // summary cards
+        cy.get("h2").should("contain", "Projects & Spending Summary");
+        cy.get("h3").should("contain", "FY 2023 Budget vs Spending");
+        cy.get("h3").should("contain", "FY 2023 Projects");
+        cy.get("h3").should("contain", "FY 2023 Agreements");
+        // tables
+        cy.get("h2").should("contain", "Research Projects");
+        cy.get("h2").should("contain", "Administrative & Support Projects");
+    });
+
+}

--- a/frontend/cypress/e2e/portfolioDetail.cy.js
+++ b/frontend/cypress/e2e/portfolioDetail.cy.js
@@ -2,7 +2,7 @@
 import { terminalLog, testLogin } from "./utils";
 
 {/*TODO: remove flag once portfolio UI updates are ready */}
-if (import.meta.env.MODE === "development") {
+if (import.meta.env.DEV) {
 
     beforeEach(() => {
         testLogin("system-owner");

--- a/frontend/cypress/e2e/portfolioDetail.cy.js
+++ b/frontend/cypress/e2e/portfolioDetail.cy.js
@@ -1,9 +1,6 @@
 /// <reference types="cypress" />
 import { terminalLog, testLogin } from "./utils";
 
-{/*TODO: remove flag once portfolio UI updates are ready */}
-if (import.meta.env.DEV) {
-
     beforeEach(() => {
         testLogin("system-owner");
         cy.visit("/portfolios/1");
@@ -15,7 +12,8 @@ if (import.meta.env.DEV) {
         cy.checkA11y(null, null, terminalLog);
     });
 
-    it("loads", () => {
+    // TODO: take away the skips when we're ready to show portfolios again
+    it.skip("loads", () => {
         cy.visit("/portfolios/1");
         cy.get("h1").should("contain", "Child Welfare Research");
         cy.get("h2").should("contain", "Division of Child and Family Development");
@@ -39,18 +37,18 @@ if (import.meta.env.DEV) {
         cy.get("span").should("contain", "Carry-Forward");
     });
 
-    it("loads the Portfolio Budget Details component", () => {
+    it.skip("loads the Portfolio Budget Details component", () => {
         cy.get("#fiscal-year-select").select("2021");
         cy.get("h2").should("contain", "Portfolio Budget Details by CAN");
         cy.get("section").should("contain", "G99IA14");
     });
 
-    it("expands the description when one clicks read more", () => {
+    it.skip("expands the description when one clicks read more", () => {
         cy.contains("read more").click();
         cy.get("a").should("contain", "See more on the website");
     });
 
-    it("shows the Portfolio Projects and Spending tab", () => {
+    it.skip("shows the Portfolio Projects and Spending tab", () => {
         cy.visit("/portfolios/1/research-projects/");
         cy.get("#fiscal-year-select").select("2023");
         // summary cards

--- a/frontend/cypress/e2e/portfolioList.cy.js
+++ b/frontend/cypress/e2e/portfolioList.cy.js
@@ -1,23 +1,24 @@
 /// <reference types="cypress" />
 import { terminalLog, testLogin } from "./utils";
 
-    // TODO: take away the skips when we're ready to show portfolios again
-    beforeEach(() => {
-        testLogin("system-owner");
-        cy.visit("/portfolios");
-    });
+beforeEach(() => {
+    testLogin("system-owner");
+    cy.visit("/portfolios");
+});
 
-    afterEach(() => {
-        cy.injectAxe();
-        cy.checkA11y(null, null, terminalLog);
-    });
+afterEach(() => {
+    cy.injectAxe();
+    cy.checkA11y(null, null, terminalLog);
+});
 
-    it.skip("loads", () => {
+// TODO: take away the skips when we're ready to show portfolios again
+describe.skip("Portfolio List Page", () => {
+    it("loads", () => {
         cy.get("h1").should("have.text", "Portfolios");
         cy.get('a[href="/portfolios/1"]').should("exist");
     });
 
-    it.skip("clicking on a Portfolio takes you to the detail page", () => {
+    it("clicking on a Portfolio takes you to the detail page", () => {
         const portfolioName = "Healthy Marriage & Responsible Fatherhood";
 
         cy.contains(portfolioName).click();
@@ -25,3 +26,4 @@ import { terminalLog, testLogin } from "./utils";
         cy.url().should("include", "/portfolios/6");
         cy.get("h1").should("contain", portfolioName);
     });
+});

--- a/frontend/cypress/e2e/portfolioList.cy.js
+++ b/frontend/cypress/e2e/portfolioList.cy.js
@@ -2,7 +2,7 @@
 import { terminalLog, testLogin } from "./utils";
 
 {/*TODO: remove flag once portfolio UI updates are ready */}
-if (import.meta.env.MODE === "development") {
+if (import.meta.env.DEV) {
 
     beforeEach(() => {
         testLogin("system-owner");

--- a/frontend/cypress/e2e/portfolioList.cy.js
+++ b/frontend/cypress/e2e/portfolioList.cy.js
@@ -1,26 +1,31 @@
 /// <reference types="cypress" />
 import { terminalLog, testLogin } from "./utils";
 
-beforeEach(() => {
-    testLogin("system-owner");
-    cy.visit("/portfolios");
-});
+{/*TODO: remove flag once portfolio UI updates are ready */}
+if (import.meta.env.MODE === "development") {
 
-afterEach(() => {
-    cy.injectAxe();
-    cy.checkA11y(null, null, terminalLog);
-});
+    beforeEach(() => {
+        testLogin("system-owner");
+        cy.visit("/portfolios");
+    });
 
-it("loads", () => {
-    cy.get("h1").should("have.text", "Portfolios");
-    cy.get('a[href="/portfolios/1"]').should("exist");
-});
+    afterEach(() => {
+        cy.injectAxe();
+        cy.checkA11y(null, null, terminalLog);
+    });
 
-it("clicking on a Portfolio takes you to the detail page", () => {
-    const portfolioName = "Healthy Marriage & Responsible Fatherhood";
+    it("loads", () => {
+        cy.get("h1").should("have.text", "Portfolios");
+        cy.get('a[href="/portfolios/1"]').should("exist");
+    });
 
-    cy.contains(portfolioName).click();
+    it("clicking on a Portfolio takes you to the detail page", () => {
+        const portfolioName = "Healthy Marriage & Responsible Fatherhood";
 
-    cy.url().should("include", "/portfolios/6");
-    cy.get("h1").should("contain", portfolioName);
-});
+        cy.contains(portfolioName).click();
+
+        cy.url().should("include", "/portfolios/6");
+        cy.get("h1").should("contain", portfolioName);
+    });
+
+}

--- a/frontend/cypress/e2e/portfolioList.cy.js
+++ b/frontend/cypress/e2e/portfolioList.cy.js
@@ -1,9 +1,7 @@
 /// <reference types="cypress" />
 import { terminalLog, testLogin } from "./utils";
 
-{/*TODO: remove flag once portfolio UI updates are ready */}
-if (import.meta.env.DEV) {
-
+    // TODO: take away the skips when we're ready to show portfolios again
     beforeEach(() => {
         testLogin("system-owner");
         cy.visit("/portfolios");
@@ -14,12 +12,12 @@ if (import.meta.env.DEV) {
         cy.checkA11y(null, null, terminalLog);
     });
 
-    it("loads", () => {
+    it.skip("loads", () => {
         cy.get("h1").should("have.text", "Portfolios");
         cy.get('a[href="/portfolios/1"]').should("exist");
     });
 
-    it("clicking on a Portfolio takes you to the detail page", () => {
+    it.skip("clicking on a Portfolio takes you to the detail page", () => {
         const portfolioName = "Healthy Marriage & Responsible Fatherhood";
 
         cy.contains(portfolioName).click();
@@ -27,5 +25,3 @@ if (import.meta.env.DEV) {
         cy.url().should("include", "/portfolios/6");
         cy.get("h1").should("contain", portfolioName);
     });
-
-}

--- a/frontend/src/components/UI/Header/Menu.jsx
+++ b/frontend/src/components/UI/Header/Menu.jsx
@@ -1,7 +1,7 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
 import { CheckAuth } from "../../Auth/auth";
-import { useSelector } from "react-redux";
 
 export const Menu = () => {
     const isAuthorized = CheckAuth();
@@ -22,7 +22,7 @@ export const Menu = () => {
                 />
             </button>
             <ul className="usa-nav__primary usa-accordion">
-                {isAuthorized && (import.meta.env.MODE === "development") && (
+                {isAuthorized && import.meta.env.MODE === "development" && (
                     <li className="usa-nav__primary-item">
                         <Link to="/portfolios/">Portfolios</Link>
                     </li>

--- a/frontend/src/components/UI/Header/Menu.jsx
+++ b/frontend/src/components/UI/Header/Menu.jsx
@@ -22,7 +22,7 @@ export const Menu = () => {
                 />
             </button>
             <ul className="usa-nav__primary usa-accordion">
-                {isAuthorized && import.meta.env.MODE === "development" (
+                {isAuthorized && (import.meta.env.MODE === "development") && (
                     <li className="usa-nav__primary-item">
                         <Link to="/portfolios/">Portfolios</Link>
                     </li>

--- a/frontend/src/components/UI/Header/Menu.jsx
+++ b/frontend/src/components/UI/Header/Menu.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Link } from "react-router-dom";
-// import { CheckAuth } from "../../Auth/auth";
+import { CheckAuth } from "../../Auth/auth";
 import { useSelector } from "react-redux";
 
 export const Menu = () => {
-   // const isAuthorized = CheckAuth();
+    const isAuthorized = CheckAuth();
     const activeUser = useSelector((state) => state.auth.activeUser);
     const [isMenuOpen, setIsMenuOpen] = React.useState(false);
 
@@ -22,15 +22,11 @@ export const Menu = () => {
                 />
             </button>
             <ul className="usa-nav__primary usa-accordion">
-                {/* {isAuthorized ? (
+                {isAuthorized && import.meta.env.MODE === "development" (
                     <li className="usa-nav__primary-item">
                         <Link to="/portfolios/">Portfolios</Link>
                     </li>
-                ) : (
-                    <li>
-                        <span></span>
-                    </li>
-                )} */}
+                )}
                 <li className="usa-nav__primary-item">
                     <Link to="/cans/">CANs</Link>
                 </li>

--- a/frontend/src/components/UI/Header/Menu.jsx
+++ b/frontend/src/components/UI/Header/Menu.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { CheckAuth } from "../../Auth/auth";
+// import { CheckAuth } from "../../Auth/auth";
 import { useSelector } from "react-redux";
 
 export const Menu = () => {
-    const isAuthorized = CheckAuth();
+   // const isAuthorized = CheckAuth();
     const activeUser = useSelector((state) => state.auth.activeUser);
     const [isMenuOpen, setIsMenuOpen] = React.useState(false);
 
@@ -22,7 +22,7 @@ export const Menu = () => {
                 />
             </button>
             <ul className="usa-nav__primary usa-accordion">
-                {isAuthorized ? (
+                {/* {isAuthorized ? (
                     <li className="usa-nav__primary-item">
                         <Link to="/portfolios/">Portfolios</Link>
                     </li>
@@ -30,7 +30,7 @@ export const Menu = () => {
                     <li>
                         <span></span>
                     </li>
-                )}
+                )} */}
                 <li className="usa-nav__primary-item">
                     <Link to="/cans/">CANs</Link>
                 </li>

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -62,10 +62,13 @@ const router = createBrowserRouter(
                 }
             >
                 {/* BEGIN PROTECTED ROUTES */}
+                {(import.meta.env.MODE === "development") && (
                 <Route
                     path="/portfolios"
                     element={<PortfolioList />}
                 />
+                )}
+                {(import.meta.env.MODE === "development") && (
                 <Route
                     path="/portfolios/:id"
                     element={<PortfolioDetail />}
@@ -103,6 +106,7 @@ const router = createBrowserRouter(
                         element={<PeopleAndTeams />}
                     />
                 </Route>
+                )}
                 <Route
                     path="/research-projects/:id/*"
                     element={<ResearchProjectDetail />}


### PR DESCRIPTION
## What changed

Removes the Portfolios menu option from the horizontal navigation in OPS based on discussions this week

## Issue

N/A

## How to test

Log in and see if the Portfolios menu option is displayed
