### PR TITLE
 reverting codeql version

### DIFF
--- a/.github/workflows/nightly_scans.yml
+++ b/.github/workflows/nightly_scans.yml
@@ -34,6 +34,6 @@ jobs:
         uses: SvanBoxel/zaproxy-to-ghas@cfc77481d74a17a4c3d6b753aa9d7abef453d501 # v1.0.2
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3
+        uses: github/codeql-action/upload-sarif@17a820bf2e43b47be2c72b39cc905417bc1ab6d0 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security_codeql.yml
+++ b/.github/workflows/security_codeql.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3
+        uses: github/codeql-action/init@17a820bf2e43b47be2c72b39cc905417bc1ab6d0 # v3
         with:
           languages: javascript, python
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -33,4 +33,4 @@ jobs:
           queries: +security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3
+        uses: github/codeql-action/analyze@17a820bf2e43b47be2c72b39cc905417bc1ab6d0 # v3

--- a/.github/workflows/security_semgrep.yml
+++ b/.github/workflows/security_semgrep.yml
@@ -25,7 +25,7 @@ jobs:
           SEMGREP_RULES: "p/default"
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3
+        uses: github/codeql-action/upload-sarif@17a820bf2e43b47be2c72b39cc905417bc1ab6d0 # v3
         with:
           sarif_file: ${{ env.SEMGREP_TO_UPLOAD }}
         if: always()


### PR DESCRIPTION
## What changed

Reverting codeql version back to a known-working version (3.28.6) as 3.28.8 seems to have broken things that use it.

## Issue

codeql was recently upgraded in #3378 but the various security GHA have been failing since then. 

## How to test

Wait for the next CI run  and nightly run

https://github.com/github/codeql-action/blob/v3.28.8/CHANGELOG.md