### PR TITLE
test: add test CANs without funding budgets

### DIFF
--- a/backend/data_tools/data/can_data.json5
+++ b/backend/data_tools/data/can_data.json5
@@ -103,6 +103,18 @@
       fund_code: "QQXXXX20235DAD",
       method_of_transfer: "IDDA",
     },
+    {
+      // 18
+      fiscal_year: 2023,
+      fund_code: "0GXXXX20241DAD",
+      method_of_transfer: "DIRECT",
+    },
+    {
+      // 19
+      fiscal_year: 2023,
+      fund_code: "0GXXXX20241RAD",
+      method_of_transfer: "IDDA",
+    }
   ],
   can: [
     {
@@ -241,6 +253,22 @@
       portfolio_id: 3,
       funding_details_id: 17,
     },
+    {
+      // 517
+      number: "G1183CE",
+      description: "Central Common Expenses",
+      nick_name: "CCE",
+      portfolio_id: 9,
+      funding_details_id: 18,
+    },
+    {
+      // 518
+      number: "G996400",
+      description: "Head Start CDC Reimbursable",
+      nick_name: "HS CDC",
+      portfolio_id: 2,
+      funding_details_id: 19,
+    }
   ],
   can_funding_budget: [
     { // 1

--- a/backend/ops_api/tests/ops/can/test_can.py
+++ b/backend/ops_api/tests/ops/can/test_can.py
@@ -224,7 +224,7 @@ def test_service_create_can(loaded_db):
     assert can.number == "G998235"
     assert can.description == "Test CAN Created by unit test"
     assert can.portfolio_id == 6
-    assert can.id == 517
+    assert can.id == 519
     assert can == new_can
 
     loaded_db.delete(new_can)
@@ -250,7 +250,7 @@ def test_can_patch(budget_team_auth_client, mocker, unadded_can):
 
 @pytest.mark.usefixtures("app_ctx")
 def test_can_patch_404(budget_team_auth_client, mocker, loaded_db, unadded_can):
-    test_can_id = 518
+    test_can_id = 519
     update_data = {
         "description": "Test CAN Created by unit test",
     }
@@ -335,7 +335,7 @@ def test_basic_user_cannot_put_cans(basic_user_auth_client):
 
 @pytest.mark.usefixtures("app_ctx")
 def test_can_put_404(budget_team_auth_client):
-    test_can_id = 518
+    test_can_id = 519
     update_data = {
         "number": "G123456",
         "description": "Test CAN Created by unit test",

--- a/backend/ops_api/tests/ops/funding_summary/test_can_funding_summary.py
+++ b/backend/ops_api/tests/ops/funding_summary/test_can_funding_summary.py
@@ -558,4 +558,4 @@ def test_aggregate_funding_summaries():
 def test_can_get_can_funding_summary_all_cans(auth_client: FlaskClient) -> None:
     response = auth_client.get(f"/api/v1/can-funding-summary?can_ids={0}")
     assert response.status_code == 200
-    assert len(response.json["cans"]) == 17
+    assert len(response.json["cans"]) == 19


### PR DESCRIPTION
## What changed

Add two test CANs without funding budgets. 

## Issue

https://github.com/HHS/OPRE-OPS/issues/3420

## How to test
Ensure the local `can` table has line items with `id=517` and `id=518`.
![Screenshot 2025-02-05 at 1 58 28 PM](https://github.com/user-attachments/assets/76b3a57d-ee3a-4f5a-9ac8-a5296626ee62)

Check the local `can_funding_budget` table to ensure there are no line items with `can_id` 517 or 518.
![Screenshot 2025-02-05 at 2 00 40 PM](https://github.com/user-attachments/assets/2ef650cd-05d4-445a-bdaf-352a91a2e938)

## Screenshots

N/A

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated


## Links

N/A