### PR TITLE
fix: correct type on funding received response

### DIFF
--- a/backend/ops_api/ops/schemas/cans.py
+++ b/backend/ops_api/ops/schemas/cans.py
@@ -171,7 +171,7 @@ class FundingReceivedSchema(Schema):
 class CreateUpdateFundingReceivedSchema(Schema):
     fiscal_year = fields.Integer(required=True)
     can_id = fields.Integer(required=True)
-    funding = fields.Integer(required=True)
+    funding = fields.Float(required=True, places=2)
     notes = fields.String(load_default=None)
 
 


### PR DESCRIPTION
## What changed

The mapping for the funding received amount is incorrect. It should be a float (or decimal) instead of an integer.

## Issue

[See @fpigeonjr's comment on #3465](https://github.com/HHS/OPRE-OPS/issues/3465#issuecomment-2657920963)

## How to test

Create a `funding received` from the frontend and check that the backend returns the `funding` value as a decimal.

https://github.com/user-attachments/assets/851ed001-aa65-4936-b060-2c5e3c7b9b4c


## Screenshots

_If relevant, e.g. for a front-end feature_

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated


## Links

N/A
