### PR TITLE
Phase 1 launch day UI tweaks

### DIFF
--- a/frontend/cypress/e2e/helpCenter.cy.js
+++ b/frontend/cypress/e2e/helpCenter.cy.js
@@ -15,7 +15,6 @@ describe("Help Center", () => {
         cy.visit("/help-center");
         cy.get("h1").contains("Help Center");
         cy.get("h2").contains("How-to Guide");
-        cy.get("h3").contains("Table of Contents");
         // click on How to edit a budget line from nav and check url to have slug
         cy.get("a").contains("How to edit a budget line").click();
         cy.url().should("include", "how-to-edit-a-budget-line");

--- a/frontend/cypress/e2e/helpCenter.cy.js
+++ b/frontend/cypress/e2e/helpCenter.cy.js
@@ -14,7 +14,7 @@ describe("Help Center", () => {
     it("renders the How-to Guide", () => {
         cy.visit("/help-center");
         cy.get("h1").contains("Help Center");
-        cy.get("h2").contains("How-to Guide");
+        cy.get("h2").contains("How-to Guides");
     });
     it("renders the FAQ", () => {
         cy.visit("/help-center/faq");

--- a/frontend/cypress/e2e/helpCenter.cy.js
+++ b/frontend/cypress/e2e/helpCenter.cy.js
@@ -11,13 +11,10 @@ afterEach(() => {
 });
 
 describe("Help Center", () => {
-    it("renders the User Guide", () => {
+    it("renders the How-to Guide", () => {
         cy.visit("/help-center");
         cy.get("h1").contains("Help Center");
         cy.get("h2").contains("How-to Guide");
-        // click on How to edit a budget line from nav and check url to have slug
-        cy.get("a").contains("How to edit a budget line").click();
-        cy.url().should("include", "how-to-edit-a-budget-line");
     });
     it("renders the FAQ", () => {
         cy.visit("/help-center/faq");

--- a/frontend/cypress/e2e/helpCenter.cy.js
+++ b/frontend/cypress/e2e/helpCenter.cy.js
@@ -14,7 +14,7 @@ describe("Help Center", () => {
     it("renders the User Guide", () => {
         cy.visit("/help-center");
         cy.get("h1").contains("Help Center");
-        cy.get("h2").contains("User Guide");
+        cy.get("h2").contains("How-to Guide");
         cy.get("h3").contains("Table of Contents");
         // click on How to edit a budget line from nav and check url to have slug
         cy.get("a").contains("How to edit a budget line").click();

--- a/frontend/src/components/CANs/CANBudgetForm/CANBudgetForm.jsx
+++ b/frontend/src/components/CANs/CANBudgetForm/CANBudgetForm.jsx
@@ -1,3 +1,4 @@
+import icons from "../../../uswds/img/sprite.svg";
 import CurrencyInput from "../../UI/Form/CurrencyInput";
 
 /**
@@ -55,6 +56,14 @@ const CANBudgetForm = ({
                 className="usa-button usa-button--outline margin-top-4"
                 data-cy="add-fy-budget"
             >
+                {!totalFunding ? (
+                    <svg
+                        className="height-2 width-2 margin-right-05 cursor-pointer"
+                        style={{ fill: "#005ea2" }}
+                    >
+                    <use xlinkHref={`${icons}#add`}></use>
+                    </svg>
+                ) : null}
                 {buttonText}
             </button>
         </form>

--- a/frontend/src/components/CANs/CANBudgetForm/CANBudgetForm.jsx
+++ b/frontend/src/components/CANs/CANBudgetForm/CANBudgetForm.jsx
@@ -1,4 +1,3 @@
-import icons from "../../../uswds/img/sprite.svg";
 import CurrencyInput from "../../UI/Form/CurrencyInput";
 
 /**
@@ -56,12 +55,6 @@ const CANBudgetForm = ({
                 className="usa-button usa-button--outline margin-top-4"
                 data-cy="add-fy-budget"
             >
-                <svg
-                    className="height-2 width-2 margin-right-05 cursor-pointer"
-                    style={{ fill: "#005ea2" }}
-                >
-                    <use xlinkHref={`${icons}#add`}></use>
-                </svg>
                 {buttonText}
             </button>
         </form>

--- a/frontend/src/pages/help/Feedback.jsx
+++ b/frontend/src/pages/help/Feedback.jsx
@@ -14,15 +14,6 @@ const Feedback = () => {
                     Click the link here to get started:{" "}
                     <a href="ops-feedback@formsgoogle.com">ops-feedback@formsgoogle.com</a>
                 </p>
-                <p>For immediate assistance:</p>
-                <ul>
-                    <li>
-                        Call <a href="tel:+15555555555">(555) 555-5555</a>
-                    </li>
-                    <li>
-                        Email <a href="mailto:acf-ops-help@acf.org">acf-ops-help@acf.org</a>
-                    </li>
-                </ul>
             </section>
         </>
     );

--- a/frontend/src/pages/help/Feedback.test.jsx
+++ b/frontend/src/pages/help/Feedback.test.jsx
@@ -16,8 +16,5 @@ describe("Feedback Component", () => {
         // Check for the feedback email link
         const emailLink = screen.getByRole("link", { name: "ops-feedback@formsgoogle.com" });
         expect(emailLink).toBeInTheDocument();
-        // Check for phone link and help email link
-        expect(screen.getByRole("link", { name: /\(555\) 555-5555/i })).toBeInTheDocument();
-        expect(screen.getByRole("link", { name: /acf-ops-help@acf.org/i })).toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/help/HelpCenter.jsx
+++ b/frontend/src/pages/help/HelpCenter.jsx
@@ -5,7 +5,7 @@ import Tabs from "../../components/UI/Tabs";
 import FAQ from "./FAQ";
 import Feedback from "./Feedback";
 import Glossary from "./Glossary";
-import UserGuides from "./UserGuides";
+import HowToGuides from "./HowToGuides";
 
 const HelpCenter = () => {
     return (
@@ -20,7 +20,7 @@ const HelpCenter = () => {
             <Routes>
                 <Route
                     path=""
-                    element={<UserGuides />}
+                    element={<HowToGuides />}
                 />
                 <Route
                     path="faq"
@@ -42,7 +42,7 @@ const HelpCenter = () => {
 const HelpTabs = () => {
     const paths = [
         {
-            label: "User Guides",
+            label: "How-to Guides",
             pathName: "/help-center/"
         },
         {

--- a/frontend/src/pages/help/HowToGuides.jsx
+++ b/frontend/src/pages/help/HowToGuides.jsx
@@ -16,19 +16,6 @@ const HowToGuides = () => {
     return (
         <>
             <h2 className="margin-bottom-4">How-to Guides</h2>
-            <nav className="margin-y-2">
-                <h3>Table of Contents</h3>
-                <ul className="usa-list--unstyled">
-                    {data.map((item) => (
-                        <li
-                            key={item.heading}
-                            className="margin-y-05"
-                        >
-                            <a href={`#${toSlugCase(item.heading)}`}>{item.heading}</a>
-                        </li>
-                    ))}
-                </ul>
-            </nav>
             <section className="usa-prose">
                 {data.map((item) => (
                     <div

--- a/frontend/src/pages/help/HowToGuides.jsx
+++ b/frontend/src/pages/help/HowToGuides.jsx
@@ -3,7 +3,7 @@ import remarkGfm from "remark-gfm";
 import Accordion from "../../components/UI/Accordion";
 import { toSlugCase } from "../../helpers/utils";
 
-const UserGuides = () => {
+const HowToGuides = () => {
     const components = {
         table: (props) => (
             <table
@@ -15,7 +15,7 @@ const UserGuides = () => {
 
     return (
         <>
-            <h2 className="margin-bottom-4">User Guide</h2>
+            <h2 className="margin-bottom-4">How-to Guides</h2>
             <nav className="margin-y-2">
                 <h3>Table of Contents</h3>
                 <ul className="usa-list--unstyled">
@@ -413,4 +413,4 @@ Funding received means funding received to OPRE towards a CANs FY budget
     }
 ];
 
-export default UserGuides;
+export default HowToGuides;

--- a/frontend/src/pages/help/HowToGuides.jsx
+++ b/frontend/src/pages/help/HowToGuides.jsx
@@ -1,7 +1,6 @@
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import Accordion from "../../components/UI/Accordion";
-import { toSlugCase } from "../../helpers/utils";
 
 const HowToGuides = () => {
     const components = {
@@ -17,23 +16,20 @@ const HowToGuides = () => {
         <>
             <h2 className="margin-bottom-4">How-to Guides</h2>
             <section className="usa-prose">
-                {data.map((item) => (
-                    <div
-                        key={item.heading}
-                        id={toSlugCase(item.heading)}
+            {data.map((item) => (
+                <Accordion
+                    key={item.heading}
+                    heading={item.heading}
+                    level={3}
+                    isClosed={true}
+                >
+                    <ReactMarkdown
+                        remarkPlugins={[remarkGfm]}
+                        components={components}
                     >
-                        <Accordion
-                            heading={item.heading}
-                            isClosed={true}
-                        >
-                            <ReactMarkdown
-                                remarkPlugins={[remarkGfm]}
-                                components={components}
-                            >
-                                {item.content}
-                            </ReactMarkdown>
-                        </Accordion>
-                    </div>
+                        {item.content}
+                    </ReactMarkdown>
+                </Accordion>
                 ))}
             </section>
         </>

--- a/frontend/src/pages/help/HowToGuides.test.jsx
+++ b/frontend/src/pages/help/HowToGuides.test.jsx
@@ -1,11 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect } from "vitest";
-import UserGuides from "./UserGuides";
+import HowToGuides from "./HowToGuides";
 
-describe("UserGuides Page", () => {
+describe("How-to Guides Page", () => {
     it("renders header and table of contents", () => {
-        render(<UserGuides />);
+        render(<HowToGuides />);
         // Check header
         expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("User Guide");
         // Check a TOC link exists
@@ -13,7 +13,7 @@ describe("UserGuides Page", () => {
     });
 
     it("expands accordion on click", async () => {
-        render(<UserGuides />);
+        render(<HowToGuides />);
         // Assume the accordion heading renders as a button
         const accordionButton = screen.getByRole("button", { name: /What is OPS\?/i });
         await userEvent.click(accordionButton);

--- a/frontend/src/pages/help/HowToGuides.test.jsx
+++ b/frontend/src/pages/help/HowToGuides.test.jsx
@@ -7,7 +7,7 @@ describe("How-to Guides Page", () => {
     it("renders header and table of contents", () => {
         render(<HowToGuides />);
         // Check header
-        expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("User Guide");
+        expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("How-to Guides");
         // Check a TOC link exists
         expect(screen.getByRole("link", { name: /What is OPS\?/i })).toBeInTheDocument();
     });

--- a/frontend/src/pages/help/HowToGuides.test.jsx
+++ b/frontend/src/pages/help/HowToGuides.test.jsx
@@ -8,8 +8,6 @@ describe("How-to Guides Page", () => {
         render(<HowToGuides />);
         // Check header
         expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("How-to Guides");
-        // Check a TOC link exists
-        expect(screen.getByRole("link", { name: /What is OPS\?/i })).toBeInTheDocument();
     });
 
     it("expands accordion on click", async () => {


### PR DESCRIPTION
## What changed

* Changed the text in the Help Center to say "How-to guides" instead of "User guides"
* Removed the "plus" from the button when updating a CAN's FY budget, but keep it for adding when not previously existing
* Removes the table of contents from the How-to Guides tab of the Help Center

## Issue

#3490 

## How to test
Log in to the UI, access the UI elements in question

## Screenshots

![Screenshot 2025-02-18 at 13 02 15](https://github.com/user-attachments/assets/5059adfa-df73-4ace-99c8-d8a7c643a11f)
![Screenshot 2025-02-18 at 13 00 14](https://github.com/user-attachments/assets/d10de83c-e278-472f-8700-33a0afbf5160)
![Screenshot 2025-02-18 at 18 16 58](https://github.com/user-attachments/assets/6b308906-f5f2-495e-8ea8-bbcd9de7b5b2)



## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~


## Links