### PR TITLE
Remove Planned mod from Glossary.jsx

### DIFF
--- a/frontend/src/pages/help/Glossary.jsx
+++ b/frontend/src/pages/help/Glossary.jsx
@@ -107,7 +107,6 @@ The status of a budget line. These are the current statuses in OPS:
 - Executing - BL is in the procurement process, in progress to be formally committed
 - Obligated - BL is committed in the signed award and can be invoiced against
 - In Review - BL has pending edits or a pending status change request
-- Planned MOD - BL is accounted for in the award, but will require a modification in order to be executed when the FY it is planned for approaches
         `
     },
     { heading: "CAN", content: `Common Accounting Number` },


### PR DESCRIPTION
Removed Planned Mod from the list of BL statuses in the Glossary. Planned Mod Status is an out-of-date design that we did not end up using. Thus, its not going to appear as a status and does not need to be included in the glossary

## What changed
Removed Planned Mod from the list of BL statuses in the Glossary

_Described what changes in this PR, at a high level_
edited the definition for Budget Line Status

## Issue

_Add link to issue here_

## How to test
Click on Glossary
Navigate to Budget Line Status
Review listed BL statuses

## Screenshots

_If relevant, e.g. for a front-end feature_

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated


## Links

_If relevant, e.g. for a link to a piece of markdown documentation_
