### PR TITLE
Hotfix: fixed can id filtering

### DIFF
--- a/frontend/cypress/e2e/portfolioDetail.cy.js
+++ b/frontend/cypress/e2e/portfolioDetail.cy.js
@@ -69,5 +69,32 @@ describe("Portfolio Detail Page", () => {
             .should("contain", "$200,000.00 ")
             .should("contain", "$0")
             .should("contain", "Previous FYs Carry-Forward");
+
+        // check the can list for FY 2023
+        cy.get("#fiscal-year-select").select("2023");
+        // summary cards
+        cy.get('[data-cy="line-graph-with-legend-card"]')
+            .should("contain", "$10,200,000.00")
+            .should("contain", "51%")
+            .should("contain", "$20,000,000.00")
+            .should("contain", "100%");
+        cy.get('[data-cy="portfolio-budget-card"]')
+            .should("contain", "$20,000,000.00")
+            .should("contain", "$10,200,000.00");
+        // check the first can card for the correct values
+        cy.get('[data-cy="can-card-G990136"]')
+            .should("contain", "G990136")
+            .should("contain", "$6,000,000.00")
+            .should("contain", "$4,000,000.00")
+            .should("contain", "$0")
+            .should("contain", "$10,000,000.00")
+            .should("contain", "FY 2023 New Funding");
+        cy.get('[data-cy="can-card-G99IA14"]')
+            .should("contain", "G99IA14")
+            .should("contain", "$6,000,000.00")
+            .should("contain", "$4,000,000.00")
+            .should("contain", "$0")
+            .should("contain", "$10,000,000.00")
+            .should("contain", "FY 2023 New Funding");
     });
 });

--- a/frontend/src/pages/portfolios/detail/PortfolioDetail.jsx
+++ b/frontend/src/pages/portfolios/detail/PortfolioDetail.jsx
@@ -50,8 +50,8 @@ const PortfolioDetail = () => {
     const canIds =
         portfolioCans
             ?.filter(
-                /** @param {{id: number, appropriation_date: number}} can */
-                (can) => can.appropriation_date === fiscalYear
+                /** @param {import("../../../components/CANs/CANTypes").CAN} can */
+                (can) => can.funding_budgets?.some((budget) => budget.fiscal_year === fiscalYear)
             )
             .map(
                 /** @param {{id: number}} can */


### PR DESCRIPTION
## What changed

Filtering portfolio funding can by budget year instead of can fiscal year.

## Issue

#3274 

## How to test

1. e2e test pass or test manually
1. goto portfolio 1, portfolio funding tab.
1. select fiscal year 2023 
1. should show 2 can cards
1. switch to fiscal year 2021
1. should show 2 can cards 

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

