### PR TITLE
fix: add pagination fix for CAN list filtering

### DIFF
--- a/frontend/cypress/e2e/canList.cy.js
+++ b/frontend/cypress/e2e/canList.cy.js
@@ -53,7 +53,7 @@ describe("CAN List", () => {
         cy.get("h1").should("contain", canNumber);
     });
 
-    it("pagination on the bli table works as expected", () => {
+    it("pagination on the CAN table works as expected", () => {
         cy.get("ul").should("have.class", "usa-pagination__list");
         cy.get("li").should("have.class", "usa-pagination__item").contains("1");
         cy.get("button").should("have.class", "usa-current").contains("1");
@@ -322,5 +322,24 @@ describe("CAN List Filtering", () => {
         // click the button that has text Apply
         cy.get("button").contains("Apply").click();
         cy.get("tbody").find("tr").should("have.length", 10);
+    });
+
+    it("pagination should work when filtering on page 2", () => {
+        // go to the second page
+        cy.get("li").should("have.class", "usa-pagination__item").contains("2").click();
+        // table should have more than 3 rows
+        cy.get("tbody").find("tr").should("have.length.greaterThan", 3);
+        cy.get("button").contains("Filter").click();
+        // set a number of filters
+        // eslint-disable-next-line cypress/unsafe-to-chain-command
+        cy.get(".can-active-period-combobox__control")
+            .click()
+            .get(".can-active-period-combobox__menu")
+            .find(".can-active-period-combobox__option")
+            .first()
+            .click();
+        cy.get("button").contains("Apply").click();
+        // 1st page should have more than 3 rows
+        cy.get("tbody").find("tr").should("have.length.greaterThan", 3);
     });
 });

--- a/frontend/src/components/CANs/CANTable/CANTable.jsx
+++ b/frontend/src/components/CANs/CANTable/CANTable.jsx
@@ -23,7 +23,7 @@ const CANTable = ({ cans, fiscalYear }) => {
 
     useEffect(() => {
         setCurrentPage(1);
-    }, [fiscalYear]);
+    }, [fiscalYear, cans]);
 
     if (cans.length === 0) {
         return <p className="text-center">No CANs found</p>;


### PR DESCRIPTION
## What changed

- fixes #3540 pagination bug

## How to test

- navigate to CANs list, select FY23
- apply filter for “1 year” active period and see results
- clear filter
- start again at CANs list, FY23
- click page 2
- apply filter for “1 year” active period and see 0 results :bug:
- 💰 but now you will see results

## Screenshots

_If relevant, e.g. for a front-end feature_

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated