### PR TITLE
feat: auto select how-to guides in help center

### DIFF
--- a/frontend/src/components/UI/Header/Menu.jsx
+++ b/frontend/src/components/UI/Header/Menu.jsx
@@ -33,7 +33,7 @@ export const Menu = () => {
                     <Link to="/budget-lines">Budget Lines</Link>
                 </li>
                 <li className="usa-nav__primary-item">
-                    <Link to="/help-center">Help Center</Link>
+                    <Link to="/help-center/">Help Center</Link>
                 </li>
                 {isUserAdmin && (
                     <li className="usa-nav__primary-item">

--- a/frontend/src/components/UI/Header/Menu.jsx
+++ b/frontend/src/components/UI/Header/Menu.jsx
@@ -33,7 +33,7 @@ export const Menu = () => {
                     <Link to="/budget-lines">Budget Lines</Link>
                 </li>
                 <li className="usa-nav__primary-item">
-                    <Link to="/help-center/">Help Center</Link>
+                    <Link to="/help-center">Help Center</Link>
                 </li>
                 {isUserAdmin && (
                     <li className="usa-nav__primary-item">

--- a/frontend/src/pages/help/HelpCenter.jsx
+++ b/frontend/src/pages/help/HelpCenter.jsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom";
+import { useNavigate, Route, Routes } from "react-router-dom";
 import App from "../../App";
 import PageHeader from "../../components/UI/PageHeader";
 import Tabs from "../../components/UI/Tabs";
@@ -6,8 +6,18 @@ import FAQ from "./FAQ";
 import Feedback from "./Feedback";
 import Glossary from "./Glossary";
 import HowToGuides from "./HowToGuides";
+import { useEffect } from "react";
 
 const HelpCenter = () => {
+    // Remove trailing slash to default Help Center to auto select How-to Guides
+    const navigate = useNavigate();
+    useEffect(() => {
+        const currentPath = window.location.pathname;
+        if (currentPath.endsWith("/")) {
+            navigate(currentPath.slice(0, -1), { replace: true });
+        }
+    }, [navigate]);
+
     return (
         <App breadCrumbName="Help Center">
             <PageHeader
@@ -43,7 +53,7 @@ const HelpTabs = () => {
     const paths = [
         {
             label: "How-to Guides",
-            pathName: "/help-center/"
+            pathName: "/help-center"
         },
         {
             label: "Frequently Asked Questions",


### PR DESCRIPTION
## What changed

Auto-select the How-to Guides when on the Help Center page.

## Issue

Point 2 of @npage123's review on [#3320](https://github.com/HHS/OPRE-OPS/issues/3320)

## How to test
- Test passes.
- Navigating to `/help-center` or `/help-center/`, or clicking the **Help Center** button in the main navigation, will take you to the Help Center page with the _How-to Guides_ section automatically selected.

## Screenshots
https://github.com/user-attachments/assets/17550b27-7059-4da0-a403-10c87a943596

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated


## Links
None
