### PR TITLE
style: update button text for budget line status change

### DIFF
--- a/frontend/cypress/e2e/reviewAgreement.cy.js
+++ b/frontend/cypress/e2e/reviewAgreement.cy.js
@@ -294,7 +294,7 @@ describe("Should not allow non-team members from submitting status changes", () 
     it("should disable submit button", () => {
         testLogin("basic");
         cy.visit("/agreements/9/budget-lines").wait(1000);
-        cy.get("span").contains("Plan or Execute Budget Lines").should("have.attr", "aria-disabled", "true");
+        cy.get("span").contains("Request BL Status Change").should("have.attr", "aria-disabled", "true");
     });
     it("should show error page", () => {
         testLogin("basic");

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
@@ -160,7 +160,7 @@ const AgreementBudgetLines = ({ agreement, isEditMode, setIsEditMode }) => {
                             to={`/agreements/review/${agreement?.id}`}
                             data-cy="bli-tab-continue-btn"
                         >
-                            Plan or Execute Budget Lines
+                            Request BL Status Change
                         </Link>
                     ) : (
                         <Tooltip label="Only team members on this agreement can send to approval">
@@ -168,7 +168,7 @@ const AgreementBudgetLines = ({ agreement, isEditMode, setIsEditMode }) => {
                                 className="usa-button margin-top-4 margin-right-0 usa-button--disabled"
                                 aria-disabled="true"
                             >
-                                Plan or Execute Budget Lines
+                                Request BL Status Change
                             </span>
                         </Tooltip>
                     )}


### PR DESCRIPTION
## What changed

- update button text for budget line status change

## Issue

- closes #3402 

## How to test

1. goto agreements/budget lines tab
2. see button label
3. 💰 profit

## Screenshots

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/0cc097a7-ad47-422c-b3b1-b014fc91d0b5" />

## Definition of Done Checklist
- [-] OESA: Code refactored for clarity
- [-] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated