### PR TITLE
feat: add starting script for loading blis to test container app job

### DIFF
--- a/backend/data_tools/src/load_budget_lines/utils.py
+++ b/backend/data_tools/src/load_budget_lines/utils.py
@@ -1,0 +1,19 @@
+from csv import DictReader
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from models import User
+
+
+def transform(data: DictReader, session: Session, sys_user: User) -> None:
+    """
+    Transform the data from the TSV file and persist the models to the database.
+
+    :param data: The data from the TSV file.
+    :param session: The database session to use.
+    :param sys_user: The system user to use.
+
+    :return: None
+    """
+    logger.info("transform triggered")

--- a/backend/data_tools/src/load_data.py
+++ b/backend/data_tools/src/load_data.py
@@ -48,6 +48,7 @@ logger.add(sys.stderr, format=format, level=LOG_LEVEL)
             "iaas",
             "iaa_budget_lines",
             "iaa_agency",
+            "budget_lines",
         ],
         case_sensitive=False,
     ),
@@ -116,6 +117,8 @@ def main(
                     from data_tools.src.load_iaa_budget_lines.utils import transform
                 case "iaa_agency":
                     from data_tools.src.load_iaa_agency.utils import transform
+                case "budget_lines":
+                    from data_tools.src.load_budget_lines.utils import transform
                 case _:
                     raise ValueError(f"Unsupported data type: {type}")
             transform(csv_f, session, sys_user)


### PR DESCRIPTION
## What changed

Create a starting script for loading BLIs and add a new type option to the main shell script. 

The primary goal of this change is to create a starting script that can be used for testing the container app job and ensuring that uploading a spreadsheet triggers the `transform` function. 

## Issue

[#3590](https://github.com/HHS/OPRE-OPS/issues/3590)

## How to test

Spin up the stack and ensure that running the command `python data_tools/src/load_data.py --env dev --type budget_lines --input-csv data_tools/test_csv/contract_budget_lines.tsv` from the `backend` generates the log "transform triggered":

```
2025-03-25 05:49:56 | INFO     | __main__:main:71 | Starting the ETL process.
2025-03-25 05:49:56 | INFO     | __main__:main:71 | Starting the ETL process.
2025-03-25 05:49:57 | INFO     | __main__:main:82 | Successfully connected to the database.
2025-03-25 05:49:57 | INFO     | __main__:main:82 | Successfully connected to the database.
2025-03-25 05:49:57 | INFO     | __main__:main:86 | Loaded CSV file from data_tools/test_csv/contract_budget_lines.tsv.
2025-03-25 05:49:57 | INFO     | __main__:main:86 | Loaded CSV file from data_tools/test_csv/contract_budget_lines.tsv.
2025-03-25 05:49:57 | INFO     | __main__:main:92 | Retrieved system user <models.users.User object at 0x110efe1e0>
2025-03-25 05:49:57 | INFO     | __main__:main:92 | Retrieved system user <models.users.User object at 0x110efe1e0>
2025-03-25 05:49:57 | INFO     | data_tools.src.load_budget_lines.utils:transform:19 | transform triggered
2025-03-25 05:49:57 | INFO     | data_tools.src.load_budget_lines.utils:transform:19 | transform triggered
2025-03-25 05:49:57 | INFO     | __main__:main:129 | Finished the ETL process.
2025-03-25 05:49:57 | INFO     | __main__:main:129 | Finished the ETL process.
```
You might need to set the PYTHONPATH directly in your terminal session before running the script (to allow Python to locate the `data_tools` directory).

## Screenshots

N/A

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated


## Links

N/A
