### PR TITLE
Update bug template with new label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugs.md
+++ b/.github/ISSUE_TEMPLATE/bugs.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Use this template for reporting details about an application bug
 title: ''
-labels: bug
+labels: bug-medium
 assignees: ''
 ---
 


### PR DESCRIPTION
## What changed

Abandons the legacy `bug` label used as a default label on new bug issues and instead defaults to `bug-medium` leaving the user to change the label as desired

## Issue

N/A

## How to test

Create a new GH issue of type bug

## Screenshots


