### PR TITLE
fix: proc shop to AllBLIRow

### DIFF
--- a/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.jsx
+++ b/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.jsx
@@ -72,7 +72,7 @@ const AllBLIRow = ({
                     setProcShopCode(NO_DATA);
                 });
         }
-    }, [isExpanded]);
+    }, [isExpanded, budgetLine?.agreement_id, trigger]);
 
     const changeIcons = (
         <ChangeIcons

--- a/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.jsx
+++ b/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.jsx
@@ -1,6 +1,5 @@
 import { faClock } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import PropTypes from "prop-types";
 import React from "react";
 import CurrencyFormat from "react-currency-format";
 import { useLazyGetAgreementByIdQuery } from "../../../api/opsAPI";
@@ -247,16 +246,6 @@ const AllBLIRow = ({
             data-testid={`budget-line-row-${budgetLine?.id}`}
         />
     );
-};
-
-AllBLIRow.propTypes = {
-    budgetLine: PropTypes.object.isRequired,
-    canUserEditBudgetLines: PropTypes.bool,
-    isReviewMode: PropTypes.bool,
-    handleSetBudgetLineForEditing: PropTypes.func,
-    handleDeleteBudgetLine: PropTypes.func,
-    handleDuplicateBudgetLine: PropTypes.func,
-    readOnly: PropTypes.bool
 };
 
 export default AllBLIRow;

--- a/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.test.jsx
+++ b/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.test.jsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import AllBLIRow from "./AllBLIRow";
+
+// Mock the required hooks and components
+vi.mock("../../../hooks/agreement.hooks", () => ({
+    useIsUserAllowedToEditAgreement: () => true
+}));
+
+vi.mock("../../../hooks/budget-line.hooks", () => ({
+    useIsBudgetLineCreator: () => true
+}));
+
+vi.mock("../../../hooks/user.hooks", () => ({
+    default: () => "John Doe"
+}));
+
+vi.mock("../../../hooks/useServicesComponents.hooks", () => ({
+    useGetServicesComponentDisplayName: () => "Test Service"
+}));
+
+vi.mock("../../../hooks/useChangeRequests.hooks", () => ({
+    useChangeRequestsForTooltip: () => null
+}));
+
+vi.mock("../../../api/opsAPI", () => ({
+    useLazyGetAgreementByIdQuery: () => [
+        vi.fn().mockResolvedValue({
+            data: {
+                procurement_shop: {
+                    abbr: "TEST"
+                }
+            }
+        })
+    ]
+}));
+
+const mockBudgetLine = {
+    id: 123,
+    agreement: {
+        name: "Test Agreement",
+        agreement_type: "IAA"
+    },
+    agreement_id: 456,
+    portfolio_id: 789,
+    services_component_id: 1,
+    date_needed: "2024-12-31",
+    fiscal_year: 2024,
+    can: {
+        id: 1,
+        display_name: "Test CAN",
+        number: "123456",
+        portfolio: {
+            id: 789,
+            name: "Test Portfolio",
+            abbreviation: "TP",
+            division_id: 1,
+            division: {
+                id: 1,
+                name: "Test Division",
+                abbreviation: "TD",
+                division_director_id: 1,
+                deputy_division_director_id: 2
+            }
+        },
+        portfolio_id: 789
+    },
+    amount: 1000,
+    proc_shop_fee_percentage: 0.1,
+    status: "DRAFT",
+    created_by: "user123",
+    created_by_user: { id: "user123", name: "John Doe" },
+    created_on: "2024-01-01",
+    comments: "Test comments",
+    in_review: false,
+    team_members: [],
+    updated_by: "user123",
+    updated_by_user: { id: "user123", name: "John Doe" },
+    updated_on: "2024-01-01"
+};
+
+describe("AllBLIRow", () => {
+    it("renders basic budget line information", () => {
+        render(<AllBLIRow budgetLine={mockBudgetLine} />);
+
+        expect(screen.getByText("123")).toBeInTheDocument();
+        expect(screen.getByText("Test Agreement")).toBeInTheDocument();
+        expect(screen.getByText("Test Service")).toBeInTheDocument();
+        expect(screen.getByText("Test CAN")).toBeInTheDocument();
+        expect(screen.getByText("$1,100.00")).toBeInTheDocument();
+    });
+
+    it("expands to show additional information when clicked", async () => {
+        const user = userEvent.setup();
+        render(<AllBLIRow budgetLine={mockBudgetLine} />);
+
+        // Find and click the expand button
+        const expandButton = screen.getByTestId("expand-row");
+        await user.click(expandButton);
+
+        // Verify expanded content is visible
+        const expandedRow = screen.getByTestId("expanded-data");
+        expect(expandedRow).toBeInTheDocument();
+
+        // Check for specific expanded row content
+        expect(screen.getByText("Created By")).toBeInTheDocument();
+        expect(screen.getByText("John Doe")).toBeInTheDocument();
+        expect(screen.getByText(/December 31, 2023/)).toBeInTheDocument();
+        expect(screen.getByText("Notes")).toBeInTheDocument();
+        expect(screen.getByText("Test comments")).toBeInTheDocument();
+        expect(screen.getByText("Procurement Shop")).toBeInTheDocument();
+        expect(screen.getByText("TEST-Fee Rate: 10%")).toBeInTheDocument();
+        expect(screen.getByText("Fees")).toBeInTheDocument();
+        expect(screen.getByText("$100.00")).toBeInTheDocument();
+        expect(screen.getByText("SubTotal")).toBeInTheDocument();
+        expect(screen.getByText("$1,100.00")).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.test.jsx
+++ b/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.test.jsx
@@ -45,8 +45,8 @@ const mockBudgetLine = {
     agreement_id: 456,
     portfolio_id: 789,
     services_component_id: 1,
-    date_needed: "2024-12-31",
-    fiscal_year: 2024,
+    date_needed: "2043-06-13",
+    fiscal_year: 2043,
     can: {
         id: 1,
         display_name: "Test CAN",
@@ -71,7 +71,7 @@ const mockBudgetLine = {
     status: "DRAFT",
     created_by: "user123",
     created_by_user: { id: "user123", name: "John Doe" },
-    created_on: "2024-01-01",
+    created_on: "2024-05-27T19:20:46.105099Z",
     comments: "Test comments",
     in_review: false,
     team_members: [],
@@ -106,7 +106,7 @@ describe("AllBLIRow", () => {
         // Check for specific expanded row content
         expect(screen.getByText("Created By")).toBeInTheDocument();
         expect(screen.getByText("John Doe")).toBeInTheDocument();
-        expect(screen.getByText(/December 31, 2023/)).toBeInTheDocument();
+        expect(screen.getByText("May 27, 2024")).toBeInTheDocument();
         expect(screen.getByText("Notes")).toBeInTheDocument();
         expect(screen.getByText("Test comments")).toBeInTheDocument();
         expect(screen.getByText("Procurement Shop")).toBeInTheDocument();


### PR DESCRIPTION
make api call to agreements/{id} to get the procurement shop data

## What changed

Procurement shop was missing
![SCR-20250408-inep](https://github.com/user-attachments/assets/7eed7982-eaa0-4ca0-82b6-e95e725a9cda)

## Issue

#3648

## How to test

1. goto Budget Lines list
2. open table row
3. see procurement shop

## Definition of Done Checklist
- [-] OESA: Code refactored for clarity
- [-] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
