### PR TITLE
3561: hides documents tab for non direct contracts

### DIFF
--- a/frontend/src/components/Agreements/DetailsTabs/DetailsTabs.jsx
+++ b/frontend/src/components/Agreements/DetailsTabs/DetailsTabs.jsx
@@ -15,10 +15,11 @@ import styles from "./DetailsTabs.module.scss";
  * @param {number} props.agreementId - The ID of the agreement.
  * @param {boolean} props.isEditMode - Indicates whether the component is in edit mode.
  * @param {Function} props.setIsEditMode - Function to set the `isEditMode` state.
+ * @param {boolean} props.isDirectContract - Indicates whether this specific distinct agreement is of an agreement of type (direct) CONTRACT
  *
  * @returns {JSX.Element} The rendered JSX element.
  */
-const DetailsTabs = ({ hasAgreementChanged, setHasAgreementChanged, agreementId, isEditMode, setIsEditMode }) => {
+const DetailsTabs = ({ hasAgreementChanged, setHasAgreementChanged, agreementId, isEditMode, setIsEditMode, isDirectContract }) => {
     const location = useLocation();
     const navigate = useNavigate();
 
@@ -33,12 +34,14 @@ const DetailsTabs = ({ hasAgreementChanged, setHasAgreementChanged, agreementId,
         {
             name: "/budget-lines",
             label: "SCs & Budget Lines"
-        },
-        {
-            name: "/documents",
-            label: "Documents"
         }
     ];
+
+    if (isDirectContract) paths.push({
+            name: "/documents",
+            label: "Documents"
+        })
+
 
     const [showModal, setShowModal] = React.useState(false);
     const [modalProps, setModalProps] = React.useState({});
@@ -111,7 +114,8 @@ DetailsTabs.propTypes = {
     setHasAgreementChanged: PropTypes.func.isRequired,
     agreementId: PropTypes.number.isRequired,
     isEditMode: PropTypes.bool.isRequired,
-    setIsEditMode: PropTypes.func.isRequired
+    setIsEditMode: PropTypes.func.isRequired,
+    isDirectContract: PropTypes.bool.isRequired,
 };
 
 export default DetailsTabs;

--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -55,6 +55,8 @@ const Agreement = () => {
     }
     let changeRequests = useChangeRequestsForAgreement(agreement?.id);
 
+    const isDirectContract = agreement?.agreement_type == "CONTRACT" ? true : false;
+
     useEffect(() => {
         /**
          *
@@ -125,6 +127,7 @@ const Agreement = () => {
                         agreementId={agreement.id}
                         isEditMode={isEditMode}
                         setIsEditMode={setIsEditMode}
+                        isDirectContract={isDirectContract}
                     />
                 </section>
 


### PR DESCRIPTION
## What changed

Hides the `Documents` tab on an Agreement's detail page. 

## Issue

One of many things as part of #3561 

## How to test

Navigate to a Direct contract, you should see the Documents tab.  For other contracts, you should not see the tab present. 

## Screenshots

![Screenshot 2025-04-08 at 19 18 56](https://github.com/user-attachments/assets/f6edf57f-6d7f-47eb-bc68-0656a96dc1d7)


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
~- [ ] Form validations updated~


## Links

