### PR TITLE
100 percent more texas in the BLI model statecode enum

### DIFF
--- a/backend/models/budget_line_items.py
+++ b/backend/models/budget_line_items.py
@@ -278,6 +278,7 @@ class StateCode(Enum):
     SC = "South Carolina"
     SD = "South Dakota"
     TN = "Tennessee"
+    TX - "Texas"
     VT = "Vermont"
     VA = "Virginia"
     WA = "Washington"


### PR DESCRIPTION
## What changed

[Earlier](https://github.com/HHS/OPRE-OPS/pull/3706), Texas was added into the DB's enum via alembic. However, this adds it into the backend model too to cover bases, proverbially. 

## Issue

N/A

## How to test

