### PR TITLE
refactor: ux feedback from temp ui

### DIFF
--- a/frontend/cypress/e2e/agreementDetails.cy.js
+++ b/frontend/cypress/e2e/agreementDetails.cy.js
@@ -49,12 +49,15 @@ it("Non contract type agreement loads with details", () => {
     cy.get("h1").contains("Support Contract #1");
     cy.get("h2").first().contains("Support Project #1");
     cy.get("h2").eq(1).contains("Agreement Details");
-    cy.get('[data-cy="details-left-col"] > :nth-child(1) > .text-base-dark').contains("Description");
     cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(1)').contains("Agreement Type");
     cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(2) > .font-12px').contains("Contract");
     cy.get('[data-cy="details-right-col"] > :nth-child(2) > :nth-child(1)').contains("COR");
+    cy.get("span").contains("Amelia Popham");
     cy.get('[data-cy="details-right-col"] > :nth-child(2) > :nth-child(2)').contains("Alternate COR");
+    cy.get("span").contains("TBD");
     cy.get('[data-cy="details-right-col"] > :nth-child(3) > :nth-child(1)').contains("Team Members");
+    cy.get("span").contains("Niki Denmark");
+    cy.get("span").contains("System Owner");
 });
 
 it("Contract type agreement loads with budget lines", () => {
@@ -82,7 +85,11 @@ it("Contract type agreement loads with budget lines", () => {
         .should("contain", "$205,214,167.20")
         .and("contain", "$1,776,195,239.33")
         .and("contain", "$2,904,442,371.61");
-        cy.get("[data-testid='budget-line-row-16008']").find(".usa-tooltip").trigger("mouseover").find(".usa-tooltip__body").should("contain","If you need to edit a budget line in Executing Status, please contact the budget team")
+    cy.get("[data-testid='budget-line-row-16008']")
+        .find(".usa-tooltip")
+        .trigger("mouseover")
+        .find(".usa-tooltip__body")
+        .should("contain", "If you need to edit a budget line in Executing Status, please contact the budget team");
 });
 
 it("Non contract type agreement loads with budget lines", () => {

--- a/frontend/cypress/e2e/editAgreement.cy.js
+++ b/frontend/cypress/e2e/editAgreement.cy.js
@@ -117,7 +117,7 @@ it("cannot navigate to edit an agreement with budget line items obligated from r
 
 it("cannot edit an agreement with budget line items in executing", () => {
     cy.visit(`/agreements/2`);
-    closeAccordions();
+    closeNonContractAccordion();
     cy.get("h1").should("have.text", "DIRECT ALLOCATION #2: African American Child and Family Research Center");
     cy.get("#edit").should("not.exist");
 });
@@ -146,7 +146,7 @@ it("cannot edit budget lines if a team member and project officer", () => {
 
 it("can not edit an agreement that's procurement shop is NOT GCS", () => {
     cy.visit(`/agreements/2/budget-lines`);
-    closeAccordions();
+    closeNonContractAccordion();
     cy.get("h1").should("have.text", "DIRECT ALLOCATION #2: African American Child and Family Research Center");
     cy.get("#edit").should("not.exist"); // not GCS
     cy.get("tbody").children().as("table-rows").should("exist");
@@ -158,7 +158,7 @@ it("can not edit an agreement that's procurement shop is NOT GCS", () => {
 //NOTE: This test is failing because the procurement shop is not-GCS
 it.skip("can not edit a budget line if it is in OBLIGATED", () => {
     cy.visit(`/agreements/2/budget-lines`);
-    closeAccordions();
+    closeNonContractAccordion();
     cy.get("h1").should("have.text", "DIRECT ALLOCATION #2: African American Child and Family Research Center");
     cy.get("#edit").should("exist");
     cy.get("#edit").click();
@@ -171,7 +171,7 @@ it.skip("can not edit a budget line if it is in OBLIGATED", () => {
 //NOTE: This test is failing because the procurement shop is not-GCS
 it.skip("can not edit a budget line if it is in EXECUTING", () => {
     cy.visit(`/agreements/2/budget-lines`);
-    closeAccordions();
+    closeNonContractAccordion();
     cy.get("h1").should("have.text", "DIRECT ALLOCATION #2: African American Child and Family Research Center");
     cy.get("#edit").should("exist");
     cy.get("#edit").click();
@@ -216,7 +216,7 @@ const closeAwardedContractAlert = () => {
     cy.get("[data-cy='close-alert']").click();
 };
 
-const closeAccordions = () => {
+const closeNonContractAccordion = () => {
     cy.get(".usa-alert__body")
         .eq(1)
         .should("contain", "This page is in progress")
@@ -226,5 +226,4 @@ const closeAccordions = () => {
         );
     // click on close button data-cy=close-alert
     cy.get("[data-cy='close-alert']").eq(0).click();
-    closeAwardedContractAlert();
 };

--- a/frontend/cypress/e2e/researchProjectDetail.cy.js
+++ b/frontend/cypress/e2e/researchProjectDetail.cy.js
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 import { testLogin } from "./utils";
 
-before(() => {
+beforeEach(() => {
     testLogin("system-owner");
     cy.visit("/research-projects/1000");
     cy.wait(1000);
@@ -12,7 +12,7 @@ afterEach(() => {
     cy.checkA11y();
 });
 
-it.skip("loads", () => {
+it("loads", () => {
     cy.get("h1").should("contain", "Human Services Interoperability Support");
     cy.get("h2").should("contain", "Division");
     cy.get("span").should("contain", "Chris Fortunato");

--- a/frontend/cypress/e2e/researchProjectDetail.cy.js
+++ b/frontend/cypress/e2e/researchProjectDetail.cy.js
@@ -12,7 +12,7 @@ afterEach(() => {
     cy.checkA11y();
 });
 
-it("loads", () => {
+it.skip("loads", () => {
     cy.get("h1").should("contain", "Human Services Interoperability Support");
     cy.get("h2").should("contain", "Division");
     cy.get("span").should("contain", "Chris Fortunato");

--- a/frontend/cypress/e2e/researchProjectDetail.cy.js
+++ b/frontend/cypress/e2e/researchProjectDetail.cy.js
@@ -4,6 +4,7 @@ import { testLogin } from "./utils";
 before(() => {
     testLogin("system-owner");
     cy.visit("/research-projects/1000");
+    cy.wait(1000);
 });
 
 afterEach(() => {

--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -43,7 +43,7 @@ const Agreement = () => {
         refetchOnMountOrArgChange: true
     });
     let doesAgreementHaveBlIsInReview = false;
-    let doesAgreementHaveBlIsObligated = false;
+    let doesContractHaveBlIsObligated = false;
     const activeUser = useSelector((state) => state.auth.activeUser);
 
     let user_agreement_notifications = [];
@@ -57,7 +57,7 @@ const Agreement = () => {
 
     if (isSuccess) {
         doesAgreementHaveBlIsInReview = hasBlIsInReview(agreement?.budget_line_items);
-        doesAgreementHaveBlIsObligated = hasBlIsObligated(agreement?.budget_line_items);
+        doesContractHaveBlIsObligated = hasBlIsObligated(agreement?.budget_line_items);
     }
 
     let changeRequests = useChangeRequestsForAgreement(agreement?.id);
@@ -118,7 +118,7 @@ const Agreement = () => {
                     setIsAlertVisible={setIsTempUiAlertVisible}
                 />
             )}
-            {doesAgreementHaveBlIsObligated && isAwardedAlertVisible && (
+            {!isAgreementNotaContract && doesContractHaveBlIsObligated && isAwardedAlertVisible && (
                 <SimpleAlert
                     type="warning"
                     heading="This page is in progress"
@@ -129,7 +129,7 @@ const Agreement = () => {
             )}
             {!(doesAgreementHaveBlIsInReview && isAlertVisible) &&
                 !(isAgreementNotaContract && isTempUiAlertVisible) &&
-                !(doesAgreementHaveBlIsObligated && isAwardedAlertVisible) && (
+                !(doesContractHaveBlIsObligated && isAwardedAlertVisible) && (
                     <>
                         <h1 className={`font-sans-2xl margin-0 text-brand-primary`}>{agreement.name}</h1>
                         <h2 className={`font-sans-3xs text-normal margin-top-1 margin-bottom-2`}>
@@ -156,7 +156,7 @@ const Agreement = () => {
                         isEditMode={isEditMode}
                         setIsEditMode={setIsEditMode}
                         isAgreementNotaContract={isAgreementNotaContract}
-                        isAgreementAwarded={doesAgreementHaveBlIsObligated}
+                        isAgreementAwarded={doesContractHaveBlIsObligated}
                     />
                 </section>
 
@@ -183,7 +183,7 @@ const Agreement = () => {
                                 isEditMode={isEditMode}
                                 setIsEditMode={setIsEditMode}
                                 isAgreementNotaContract={isAgreementNotaContract}
-                                isAgreementAwarded={doesAgreementHaveBlIsObligated}
+                                isAgreementAwarded={doesContractHaveBlIsObligated}
                             />
                         }
                     />

--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -100,16 +100,19 @@ const Agreement = () => {
         return <div>Oops, an error occurred</div>;
     }
 
+    const showReviewAlert = doesAgreementHaveBlIsInReview && isAlertVisible;
+    const showNonContractAlert = isAgreementNotaContract && isTempUiAlertVisible;
+    const showAwardedAlert = !isAgreementNotaContract && doesContractHaveBlIsObligated && isAwardedAlertVisible;
     return (
         <App breadCrumbName={agreement?.name}>
-            {doesAgreementHaveBlIsInReview && isAlertVisible && (
+            {showReviewAlert && (
                 <AgreementChangesAlert
                     changeRequests={changeRequests}
                     isAlertVisible={isAlertVisible}
                     setIsAlertVisible={setIsAlertVisible}
                 />
             )}
-            {isAgreementNotaContract && isTempUiAlertVisible && (
+            {showNonContractAlert && (
                 <SimpleAlert
                     type="warning"
                     heading="This page is in progress"
@@ -118,7 +121,7 @@ const Agreement = () => {
                     setIsAlertVisible={setIsTempUiAlertVisible}
                 />
             )}
-            {!isAgreementNotaContract && doesContractHaveBlIsObligated && isAwardedAlertVisible && (
+            {showAwardedAlert && (
                 <SimpleAlert
                     type="warning"
                     heading="This page is in progress"
@@ -127,16 +130,14 @@ const Agreement = () => {
                     setIsAlertVisible={setIsAwardedAlertVisible}
                 />
             )}
-            {!(doesAgreementHaveBlIsInReview && isAlertVisible) &&
-                !(isAgreementNotaContract && isTempUiAlertVisible) &&
-                !(doesContractHaveBlIsObligated && isAwardedAlertVisible) && (
-                    <>
-                        <h1 className={`font-sans-2xl margin-0 text-brand-primary`}>{agreement.name}</h1>
-                        <h2 className={`font-sans-3xs text-normal margin-top-1 margin-bottom-2`}>
-                            {agreement.project?.title}
-                        </h2>
-                    </>
-                )}
+            {!showReviewAlert && !showNonContractAlert && !showAwardedAlert && (
+                <>
+                    <h1 className={`font-sans-2xl margin-0 text-brand-primary`}>{agreement.name}</h1>
+                    <h2 className={`font-sans-3xs text-normal margin-top-1 margin-bottom-2`}>
+                        {agreement.project?.title}
+                    </h2>
+                </>
+            )}
 
             {user_agreement_notifications?.length > 0 && (
                 <AgreementChangesResponseAlert

--- a/frontend/src/pages/agreements/details/AgreementDetailsView.jsx
+++ b/frontend/src/pages/agreements/details/AgreementDetailsView.jsx
@@ -25,28 +25,33 @@ const AgreementDetailsView = ({ agreement, projectOfficer, alternateProjectOffic
                     data-cy="details-left-col"
                 >
                     {/* // NOTE: Left Column */}
-                    <dl className="margin-0 font-12px">
-                        <dt className="margin-0 text-base-dark margin-top-3">Description</dt>
-                        <dd className="margin-0 margin-top-05 text-semibold">
-                            {agreement?.description ? agreement.description : NO_DATA}
-                        </dd>
-                    </dl>
-                    <h3 className="text-base-dark margin-top-3 text-normal font-12px">Notes</h3>
-                    {agreement.notes ? (
-                        <div
-                            className="font-12px overflow-y-scroll force-show-scrollbars"
-                            style={{ height: "11.375rem" }}
-                            data-cy="details-notes"
-                            // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-                            tabIndex={0}
-                            role="region"
-                            aria-live="polite"
-                            aria-label="Agreement Notes"
-                        >
-                            {agreement.notes}
-                        </div>
-                    ) : (
-                        <p className="font-12px">There are currently no notes for this agreement.</p>
+                    {!isAgreementNotaContract && (
+                        <>
+                            <dl className="margin-0 font-12px">
+                                <dt className="margin-0 text-base-dark margin-top-3">Description</dt>
+                                <dd className="margin-0 margin-top-05 text-semibold">
+                                    {agreement?.description ? agreement.description : NO_DATA}
+                                </dd>
+                            </dl>
+
+                            <h3 className="text-base-dark margin-top-3 text-normal font-12px">Notes</h3>
+                            {agreement.notes ? (
+                                <div
+                                    className="font-12px overflow-y-scroll force-show-scrollbars"
+                                    style={{ height: "11.375rem" }}
+                                    data-cy="details-notes"
+                                    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                                    tabIndex={0}
+                                    role="region"
+                                    aria-live="polite"
+                                    aria-label="Agreement Notes"
+                                >
+                                    {agreement.notes}
+                                </div>
+                            ) : (
+                                <p className="font-12px">There are currently no notes for this agreement.</p>
+                            )}
+                        </>
                     )}
                     <h3 className="text-base-dark margin-top-3 text-normal font-12px">History</h3>
                     <AgreementHistoryPanel

--- a/frontend/src/pages/portfolios/list/PortfolioList.jsx
+++ b/frontend/src/pages/portfolios/list/PortfolioList.jsx
@@ -50,12 +50,16 @@ const PortfolioList = () => {
                                 <Card
                                     style={{
                                         width: "300px",
+                                        minHeight: "100px",
                                         display: "flex",
                                         alignItems: "center",
-                                        justifyContent: "center"
+                                        justifyContent: "start",
+                                        padding: "10px 30px"
                                     }}
                                 >
-                                    <h3 className="font-sans-lg text-brand-primary">{portfolio.name}</h3>
+                                    <h3 className="font-sans-lg text-brand-primary margin-0 text-center">
+                                        {portfolio.name}
+                                    </h3>
                                 </Card>
                             </Link>
                         ))}


### PR DESCRIPTION
## What changed

- For agreeements that are grants, IAAs, AAs and direct obligation; hide the description and hide the notes (I believe this came up in team collab, that these agreements don’t have descriptions so no need to display that)
- For some reason, when I view a direct obligation, I am seeing both banners (the banner for other agreement types and the banner for awarded agreements)
- Same for awarded agreements, I am seeing both banners (the banner for other agreement types and the banner for awarded agreements)

## Issue

#3561 

## How to test

look at what changed section

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated