### PR TITLE
Adding comments and line_description fields to BL export

### DIFF
--- a/frontend/src/pages/budgetLines/list/BudgetLineItemList.jsx
+++ b/frontend/src/pages/budgetLines/list/BudgetLineItemList.jsx
@@ -103,13 +103,15 @@ const BudgetLineItemList = () => {
                 "BL ID #",
                 "Agreement",
                 "SC",
+                "Description",
                 "Obligate By",
                 "FY",
                 "CAN",
                 "SubTotal",
                 "Procurement shop fee",
                 "Procurement shop fee rate",
-                "Status"
+                "Status",
+                "Comments"
             ];
 
             await exportTableToXlsx({
@@ -125,6 +127,7 @@ const BudgetLineItemList = () => {
                         budgetLine.id,
                         budgetLine.agreement?.name || "TBD",
                         budgetLinesDataMap[budgetLine.id]?.service_component_name,
+                        budgetLine.line_description,
                         formatDateNeeded(budgetLine?.date_needed),
                         budgetLine.fiscal_year,
                         budgetLine.can?.display_name || "TBD",
@@ -137,7 +140,8 @@ const BudgetLineItemList = () => {
                             currency: "USD"
                         }) ?? "",
                         feeRate,
-                        budgetLine?.in_review ? "In Review" : budgetLine?.status
+                        budgetLine?.in_review ? "In Review" : budgetLine?.status,
+                        budgetLine.comments
                     ];
                 },
                 filename: "budget_lines"


### PR DESCRIPTION
## What changed

Adds `line_description` and `comments` fields to Budget Line export

## Issue

N/A - customer expressed this as a vital need

## How to test

Attempt to do an export of budget lines

## Screenshots

N/A

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~


