### PR TITLE
fix: 🐛 Agreement List edit button logic

### DIFF
--- a/frontend/cypress/e2e/agreementList.cy.js
+++ b/frontend/cypress/e2e/agreementList.cy.js
@@ -1,166 +1,172 @@
 /// <reference types="cypress" />
 import { terminalLog, testLogin } from "./utils";
 
-beforeEach(() => {
-    testLogin("system-owner");
-    cy.visit("/agreements");
-    cy.wait(1000);
-});
+describe("Agreement List", () => {
+    beforeEach(() => {
+        testLogin("system-owner");
+        cy.visit("/agreements");
+        cy.wait(1000);
+    });
 
-afterEach(() => {
-    cy.wait(1000);
-    cy.injectAxe();
-    cy.checkA11y(null, null, terminalLog);
-});
+    afterEach(() => {
+        cy.wait(1000);
+        cy.injectAxe();
+        cy.checkA11y(null, null, terminalLog);
+    });
 
-it("loads", () => {
-    cy.get("h1").should("have.text", "Agreements");
-});
+    it("loads", () => {
+        cy.get("h1").should("have.text", "Agreements");
+    });
 
-it("Agreements list table has correct headers and first row", () => {
-    cy.get(".usa-table").should("exist");
-    cy.get("h1").should("exist");
-    cy.get("h1").should("have.text", "Agreements");
-    // table headers
-    cy.get("thead > tr > :nth-child(1)").should("have.text", "Agreement");
-    cy.get("thead > tr > :nth-child(2)").should("have.text", "Project");
-    cy.get("thead > tr > :nth-child(3)").should("have.text", "Type");
-    cy.get("thead > tr > :nth-child(4)").should("have.text", "Agreement Total");
-    cy.get("thead > tr > :nth-child(5)").should("have.text", "Next Budget Line");
-    cy.get("thead > tr > :nth-child(6)").should("have.text", "Next Obligate By");
+    it("Agreements list table has correct headers and first row", () => {
+        cy.get(".usa-table").should("exist");
+        cy.get("h1").should("exist");
+        cy.get("h1").should("have.text", "Agreements");
+        // table headers
+        cy.get("thead > tr > :nth-child(1)").should("have.text", "Agreement");
+        cy.get("thead > tr > :nth-child(2)").should("have.text", "Project");
+        cy.get("thead > tr > :nth-child(3)").should("have.text", "Type");
+        cy.get("thead > tr > :nth-child(4)").should("have.text", "Agreement Total");
+        cy.get("thead > tr > :nth-child(5)").should("have.text", "Next Budget Line");
+        cy.get("thead > tr > :nth-child(6)").should("have.text", "Next Obligate By");
 
-    // select the row with data-testid="agreement-table-row-9"
-    cy.get("[data-testid='agreement-table-row-9']").should("exist");
+        // select the row with data-testid="agreement-table-row-9"
+        cy.get("[data-testid='agreement-table-row-9']").should("exist");
 
-    // 4th row (including tooltips)
-    cy.get(
-        "tbody > [data-testid='agreement-table-row-9'] > :nth-child(1) > a > .usa-tooltip > .usa-tooltip__trigger"
-    ).should("have.text", "Interoperability Initiatives");
-    cy.get(
-        "tbody > [data-testid='agreement-table-row-9'] > :nth-child(1) > a > .usa-tooltip > .usa-tooltip__body"
-    ).should("have.text", "Interoperability Initiatives");
-    cy.get(
-        "tbody > [data-testid='agreement-table-row-9'] > :nth-child(2) > .usa-tooltip > .usa-tooltip__trigger"
-    ).should("have.text", "Annual Performance Plans and Reports");
-    cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(2) > .usa-tooltip > .usa-tooltip__body").should(
-        "have.text",
-        "Annual Performance Plans and Reports"
-    );
-    cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(3)").should("have.text", "Contract");
-    cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(4)").should("have.text", "$1,000,000.00");
-    cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(5)").should("have.text", "$703,500.00");
-    cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(6)").should("have.text", "6/13/2043");
+        // 4th row (including tooltips)
+        cy.get(
+            "tbody > [data-testid='agreement-table-row-9'] > :nth-child(1) > a > .usa-tooltip > .usa-tooltip__trigger"
+        ).should("have.text", "Interoperability Initiatives");
+        cy.get(
+            "tbody > [data-testid='agreement-table-row-9'] > :nth-child(1) > a > .usa-tooltip > .usa-tooltip__body"
+        ).should("have.text", "Interoperability Initiatives");
+        cy.get(
+            "tbody > [data-testid='agreement-table-row-9'] > :nth-child(2) > .usa-tooltip > .usa-tooltip__trigger"
+        ).should("have.text", "Annual Performance Plans and Reports");
+        cy.get(
+            "tbody > [data-testid='agreement-table-row-9'] > :nth-child(2) > .usa-tooltip > .usa-tooltip__body"
+        ).should("have.text", "Annual Performance Plans and Reports");
+        cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(3)").should("have.text", "Contract");
+        cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(4)").should("have.text", "$1,000,000.00");
+        cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(5)").should("have.text", "$703,500.00");
+        cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(6)").should("have.text", "6/13/2043");
 
-    cy.get("[data-testid='agreement-table-row-9']").trigger("mouseover");
-    cy.get("button[id^='submit-for-approval-']").first().should("exist");
-    cy.get("button[id^='submit-for-approval-']").first().should("not.be.disabled");
+        cy.get("[data-testid='agreement-table-row-9']").trigger("mouseover");
+        cy.get("button[id^='submit-for-approval-']").first().should("exist");
+        cy.get("button[id^='submit-for-approval-']").first().should("not.be.disabled");
 
-    // expand 4th row
-    cy.get(':nth-child(1) > :nth-child(7) > [data-cy="expand-row"]').should("exist");
-    cy.get(':nth-child(1) > :nth-child(7) > [data-cy="expand-row"]').click();
-    cy.get(".padding-right-9 > :nth-child(1) > :nth-child(1)").should("have.text", "Created By");
-    cy.get(".width-mobile > .text-base-dark").should("have.text", "Description");
-    cy.get('[style="margin-left: 3.125rem;"] > .text-base-dark').should("have.text", "Budget Lines");
-});
+        // expand 4th row
+        cy.get(':nth-child(1) > :nth-child(7) > [data-cy="expand-row"]').should("exist");
+        cy.get(':nth-child(1) > :nth-child(7) > [data-cy="expand-row"]').click();
+        cy.get(".padding-right-9 > :nth-child(1) > :nth-child(1)").should("have.text", "Created By");
+        cy.get(".width-mobile > .text-base-dark").should("have.text", "Description");
+        cy.get('[style="margin-left: 3.125rem;"] > .text-base-dark').should("have.text", "Budget Lines");
+    });
 
-it("navigates to the ReviewAgreements page when the review button is clicked", () => {
-    cy.get(".usa-table").should("exist");
-    cy.get("[data-testid='agreement-table-row-9']").trigger("mouseover");
-    cy.get("button[id^='submit-for-approval-']").first().should("exist");
-    cy.get("button[id^='submit-for-approval-']").first().should("not.be.disabled");
-    cy.get("button[id^='submit-for-approval-']").first().click();
-    cy.url().should("include", "/agreements/review");
-    cy.get("h1").should("exist");
-    cy.get("h1").should("have.text", "Request BL Status Change");
-});
+    it("navigates to the ReviewAgreements page when the review button is clicked", () => {
+        cy.get(".usa-table").should("exist");
+        cy.get("[data-testid='agreement-table-row-9']").trigger("mouseover");
+        cy.get("button[id^='submit-for-approval-']").first().should("exist");
+        cy.get("button[id^='submit-for-approval-']").first().should("not.be.disabled");
+        cy.get("button[id^='submit-for-approval-']").first().click();
+        cy.url().should("include", "/agreements/review");
+        cy.get("h1").should("exist");
+        cy.get("h1").should("have.text", "Request BL Status Change");
+    });
 
-it("Agreements Table is correctly filtered on all-agreements or my-agreements", () => {
-    cy.visit("/agreements?filter=all-agreements");
-    cy.get("tbody").children().should("have.length.at.least", 1);
+    it("Agreements Table is correctly filtered on all-agreements or my-agreements", () => {
+        cy.visit("/agreements?filter=all-agreements");
+        cy.get("tbody").children().should("have.length.at.least", 1);
 
-    cy.visit("/agreements?filter=my-agreements");
-    cy.get("tbody").children().should("have.length.at.least", 1);
-});
+        cy.visit("/agreements?filter=my-agreements");
+        cy.get("tbody").children().should("have.length.at.least", 1);
+    });
 
-it("the filter button works as expected", () => {
-    cy.visit("/agreements?filter=all-agreements");
-    cy.wait(1000);
-    cy.get("button").contains("Filter").click();
+    it("the filter button works as expected", () => {
+        cy.visit("/agreements?filter=all-agreements");
+        cy.wait(1000);
+        cy.get("button").contains("Filter").click();
 
-    // set a number of filters
-    // get select element by name "project-react-select"
-    // eslint-disable-next-line cypress/unsafe-to-chain-command
-    cy.get(".fiscal-year-combobox__control")
-        .click()
-        .get(".fiscal-year-combobox__menu")
-        .find(".fiscal-year-combobox__option")
-        .first()
-        .click();
-    // eslint-disable-next-line cypress/unsafe-to-chain-command
-    cy.get(".portfolios-combobox__control")
-        .click()
-        .get(".portfolios-combobox__menu")
-        .find(".portfolios-combobox__option")
-        .first()
-        .click();
-    // eslint-disable-next-line cypress/unsafe-to-chain-command
-    cy.get(".bli-status-combobox__control")
-        .click()
-        .get(".bli-status-combobox__menu")
-        .find(".bli-status-combobox__option")
-        .first()
-        .click();
+        // set a number of filters
+        // get select element by name "project-react-select"
+        // eslint-disable-next-line cypress/unsafe-to-chain-command
+        cy.get(".fiscal-year-combobox__control")
+            .click()
+            .get(".fiscal-year-combobox__menu")
+            .find(".fiscal-year-combobox__option")
+            .first()
+            .click();
+        // eslint-disable-next-line cypress/unsafe-to-chain-command
+        cy.get(".portfolios-combobox__control")
+            .click()
+            .get(".portfolios-combobox__menu")
+            .find(".portfolios-combobox__option")
+            .first()
+            .click();
+        // eslint-disable-next-line cypress/unsafe-to-chain-command
+        cy.get(".bli-status-combobox__control")
+            .click()
+            .get(".bli-status-combobox__menu")
+            .find(".bli-status-combobox__option")
+            .first()
+            .click();
 
-    // click the button that has text Apply
-    cy.get("button").contains("Apply").click();
+        // click the button that has text Apply
+        cy.get("button").contains("Apply").click();
 
-    // check that the correct tags are displayed
-    cy.get("div").contains("FY 2044").should("exist");
-    cy.get("div").contains("Child Welfare Research").should("exist");
-    cy.get("div").contains("Draft").should("exist");
+        // check that the correct tags are displayed
+        cy.get("div").contains("FY 2044").should("exist");
+        cy.get("div").contains("Child Welfare Research").should("exist");
+        cy.get("div").contains("Draft").should("exist");
 
-    // check that the table is filtered correctly
-    cy.get("tbody > [data-testid='agreement-table-row-1']").should("exist");
+        // check that the table is filtered correctly
+        cy.get("tbody > [data-testid='agreement-table-row-1']").should("exist");
 
-    // reset
-    cy.get("button").contains("Filter").click();
-    cy.get("button").contains("Reset").click();
-    cy.get("button").contains("Apply").click();
+        // reset
+        cy.get("button").contains("Filter").click();
+        cy.get("button").contains("Reset").click();
+        cy.get("button").contains("Apply").click();
 
-    // check that no tags are displayed
-    cy.get("div").contains("FY 2044").should("not.exist");
-    cy.get("div").contains("Child Welfare Research").should("not.exist");
-    cy.get("div").contains("Planned").should("not.exist");
+        // check that no tags are displayed
+        cy.get("div").contains("FY 2044").should("not.exist");
+        cy.get("div").contains("Child Welfare Research").should("not.exist");
+        cy.get("div").contains("Planned").should("not.exist");
 
-    // check that the table is filtered correctly
-    cy.get("div[id='agreements-table-zero-results']").should("not.exist");
-});
+        // check that the table is filtered correctly
+        cy.get("div[id='agreements-table-zero-results']").should("not.exist");
+    });
 
-it("clicking the add agreement button takes you to the create agreement page", () => {
-    cy.visit("/agreements?filter=all-agreements");
-    cy.get("a").contains("Add Agreement").click();
-    cy.url().should("include", "/agreements/create");
-});
+    it("clicking the add agreement button takes you to the create agreement page", () => {
+        cy.visit("/agreements?filter=all-agreements");
+        cy.get("a").contains("Add Agreement").click();
+        cy.url().should("include", "/agreements/create");
+    });
 
-it("Change Requests tab works", () => {
-    cy.visit("/agreements?filter=change-requests");
-    cy.wait(1000);
-    cy.get("h2").should("have.text", "For Review");
-    cy.get(".text-center")
-        .invoke("text")
-        .should("match", /no changes/i);
-});
+    it("Change Requests tab works", () => {
+        cy.visit("/agreements?filter=change-requests");
+        cy.wait(1000);
+        cy.get("h2").should("have.text", "For Review");
+        cy.get(".text-center")
+            .invoke("text")
+            .should("match", /no changes/i);
+    });
 
-it("Should allow the user to export table", () => {
-    cy.get('[data-cy="agreement-export"]').should("exist");
-    cy.get("button").contains("Filter").click();
-    // eslint-disable-next-line cypress/unsafe-to-chain-command
-    cy.get(".portfolios-combobox__control")
-        .click()
-        .get(".portfolios-combobox__menu")
-        .find(".portfolios-combobox__option")
-        .contains("Home Visiting")
-        .click();
-    cy.get("button").contains("Apply").click();
-    cy.get('[data-cy="agreement-export"]').should("not.exist");
+    it("Should allow the user to export table", () => {
+        cy.get('[data-cy="agreement-export"]').should("exist");
+        cy.get("button").contains("Filter").click();
+        // eslint-disable-next-line cypress/unsafe-to-chain-command
+        cy.get(".portfolios-combobox__control")
+            .click()
+            .get(".portfolios-combobox__menu")
+            .find(".portfolios-combobox__option")
+            .contains("Home Visiting")
+            .click();
+        cy.get("button").contains("Apply").click();
+        cy.get('[data-cy="agreement-export"]').should("not.exist");
+    });
+
+    it("Should not allow user to edit an agreement that is awarded or not developed", () => {
+        cy.get("[data-testid='agreement-table-row-2']").trigger("mouseover");
+        cy.get("[data-testid='agreement-table-row-2']").find('[data-cy="edit-row"]').should("be.disabled");
+    });
 });

--- a/frontend/cypress/e2e/budgetChangeRequest.cy.js
+++ b/frontend/cypress/e2e/budgetChangeRequest.cy.js
@@ -443,11 +443,9 @@ describe("Budget Change in review", () => {
 
         // request BLIs status change and change all planned BLIs to executing
         cy.get('[data-cy="bli-continue-btn"]').click();
-        cy.wait(2000);
+        cy.wait(3000); // NOTE: add some wait time to ensure the page is loaded
         cy.get('[data-cy="div-change-planned-to-executing"]').click();
-        cy.wait(2000);
         cy.get('[data-cy="check-all-label"]').click();
-        cy.wait(2000);
         cy.get('[type="checkbox"]')
             .should("have.length.greaterThan", 2)
             .each((checkbox) => {

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
@@ -97,6 +97,8 @@ export const AgreementTableRow = ({ agreementId }) => {
     const areAllBudgetLinesInDraftStatus = isSuccess ? areAllBudgetLinesInStatus(agreement, BLI_STATUS.DRAFT) : false;
     const canUserEditAgreement = isSuccess ? agreement?._meta.isEditable : false;
     const areThereAnyBudgetLines = isSuccess ? isThereAnyBudgetLines(agreement) : false;
+    // TODO: add check for agreement is not a contract
+    // TODO: add check for agreement is not awarded
     const isEditable = canUserEditAgreement && !doesAgreementHaveBLIsInReview;
     const canUserDeleteAgreement = canUserEditAgreement && (areAllBudgetLinesInDraftStatus || !areThereAnyBudgetLines);
     // hooks

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
@@ -3,7 +3,7 @@ import { faCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import CurrencyFormat from "react-currency-format";
 import { Link, useSearchParams } from "react-router-dom";
-import { BLI_STATUS } from "../../../helpers/budgetLines.helpers";
+import { BLI_STATUS, hasBlIsObligated } from "../../../helpers/budgetLines.helpers";
 import { getDecimalScale } from "../../../helpers/currencyFormat.helpers";
 import {
     convertCodeForDisplay,
@@ -41,6 +41,7 @@ import { useGetAgreementByIdQuery, useLazyGetUserByIdQuery } from "../../../api/
 import { useState } from "react";
 import React from "react";
 import { NO_DATA } from "../../../constants";
+import { isNotDevelopedYet } from "../../../helpers/agreement.helpers";
 
 /**
  * Renders a row in the agreements table.
@@ -97,9 +98,12 @@ export const AgreementTableRow = ({ agreementId }) => {
     const areAllBudgetLinesInDraftStatus = isSuccess ? areAllBudgetLinesInStatus(agreement, BLI_STATUS.DRAFT) : false;
     const canUserEditAgreement = isSuccess ? agreement?._meta.isEditable : false;
     const areThereAnyBudgetLines = isSuccess ? isThereAnyBudgetLines(agreement) : false;
-    // TODO: add check for agreement is not a contract
-    // TODO: add check for agreement is not awarded
-    const isEditable = canUserEditAgreement && !doesAgreementHaveBLIsInReview;
+    const isAgreementTypeNotDeveloped = isSuccess
+        ? isNotDevelopedYet(agreement?.agreement_type, agreement?.procurement_shop?.abbr)
+        : false;
+    const isAgreementAwarded = isSuccess ? hasBlIsObligated(agreement?.budget_line_items) : false;
+    const isEditable =
+        canUserEditAgreement && !doesAgreementHaveBLIsInReview && !isAgreementTypeNotDeveloped && !isAgreementAwarded;
     const canUserDeleteAgreement = canUserEditAgreement && (areAllBudgetLinesInDraftStatus || !areThereAnyBudgetLines);
     // hooks
     const handleSubmitAgreementForApproval = useNavigateAgreementReview();
@@ -113,6 +117,8 @@ export const AgreementTableRow = ({ agreementId }) => {
         const lockedMessages = {
             inReview: "This agreement cannot be edited because it is currently In Review for a status change",
             notTeamMember: "Only team members on this agreement can edit, delete, or send to approval",
+            notDeveloped:
+                "This agreement cannot be edited because it is not developed yet, \nplease contact the Budget Team.",
             default: "Disabled"
         };
         switch (true) {
@@ -120,6 +126,8 @@ export const AgreementTableRow = ({ agreementId }) => {
                 return lockedMessages.inReview;
             case !canUserEditAgreement:
                 return lockedMessages.notTeamMember;
+            case isAgreementTypeNotDeveloped || isAgreementAwarded:
+                return lockedMessages.notDeveloped;
             default:
                 return lockedMessages.default;
         }

--- a/frontend/src/pages/agreements/details/AgreementDetails.jsx
+++ b/frontend/src/pages/agreements/details/AgreementDetails.jsx
@@ -36,7 +36,7 @@ const AgreementDetails = ({
                 isEditable={isEditable}
             />
 
-            {isEditMode ? (
+            {isEditMode && isEditable ? (
                 <AgreementDetailsEdit
                     agreement={agreement}
                     setHasAgreementChanged={setHasAgreementChanged}


### PR DESCRIPTION
## What Changed

This PR fixes the edit button logic in the Agreement List so that the edit button is disabled when the agreement is either awarded or not developed yet. Key changes include:

- Modifying the AgreementDetails component to render the edit section only when both edit mode and editability conditions are met.
- Updating the AgreementTableRow logic to incorporate additional conditions (agreement type not developed and awarded) when determining editability and locked messages.
- Adjusting Cypress tests to validate the new behavior and adding extra wait time in one test for improved stability.

## Issue

- fixes #3778 

## How to test

1. e2e tests pass or:
2. login as system owner
3. goto agreement list
4. look for agreement DIRECT ALLOCATION 2: African American Child and Family Research Center
5. edit button will be disabled 

## Screenshots

<img width="1083" alt="image" src="https://github.com/user-attachments/assets/5de066fc-7b9e-485f-870f-ddbb3fa55bdf" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
