### PR TITLE
fix: update agreement type label to AA for non contract agreement

### DIFF
--- a/frontend/cypress/e2e/agreementDetails.cy.js
+++ b/frontend/cypress/e2e/agreementDetails.cy.js
@@ -54,7 +54,7 @@ it("Non contract type agreement loads with details", () => {
     cy.get("h2").first().contains("Support Project #1");
     cy.get("h2").eq(1).contains("Agreement Details");
     cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(1)').contains("Agreement Type");
-    cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(2) > .font-12px').contains("Contract");
+    cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(2) > .font-12px').contains("AA");
     cy.get('[data-cy="details-right-col"] > :nth-child(2) > :nth-child(1)').contains("COR");
     cy.get("span").contains("Amelia Popham");
     cy.get('[data-cy="details-right-col"] > :nth-child(2) > :nth-child(2)').contains("Alternate COR");

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
@@ -41,7 +41,7 @@ import { useGetAgreementByIdQuery, useLazyGetUserByIdQuery } from "../../../api/
 import { useState } from "react";
 import React from "react";
 import { NO_DATA } from "../../../constants";
-import { isNotDevelopedYet } from "../../../helpers/agreement.helpers";
+import { getAgreementType, isNotDevelopedYet } from "../../../helpers/agreement.helpers";
 
 /**
  * Renders a row in the agreements table.
@@ -56,7 +56,7 @@ export const AgreementTableRow = ({ agreementId }) => {
     const { data: agreement, isLoading, isSuccess } = useGetAgreementByIdQuery(agreementId);
     const agreementName = isSuccess ? getAgreementName(agreement) : NO_DATA;
     const researchProjectName = isSuccess ? getResearchProjectName(agreement) : NO_DATA;
-    const agreementType = isSuccess ? convertCodeForDisplay("agreementType", agreement?.agreement_type || "") : NO_DATA;
+    const agreementType = isSuccess ? getAgreementType(agreement) : NO_DATA;
     const agreementSubTotal = isSuccess ? getAgreementSubTotal(agreement) : 0;
     const procurementShopSubTotal = isSuccess ? getProcurementShopSubTotal(agreement) : 0;
     const agreementTotal = agreementSubTotal + procurementShopSubTotal;

--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -89,7 +89,7 @@ export const isNotDevelopedYet = (agreementType, procurementShop) => {
  * @returns {string} - The label for the agreement type.
  */
 
-export const getAgreementType = (agreement) => {
+export const getAgreementType = (agreement, abbr = true) => {
     if (!agreement) {
         console.error("Agreement is undefined or null");
         return NO_DATA;
@@ -102,7 +102,7 @@ export const getAgreementType = (agreement) => {
         procurementShop !== ProcurementShopType.GCS &&
         agreement.agreement_type === AgreementType.CONTRACT
     ) {
-        agreementTypeLabel = "AA";
+        agreementTypeLabel = abbr ? "AA" : "Assisted Acquisition (AA)";
     }
 
     return agreementTypeLabel;

--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -1,5 +1,7 @@
+import { NO_DATA } from "../constants";
 import { AgreementType, ProcurementShopType } from "../pages/agreements/agreements.constants";
 import { BLI_STATUS } from "./budgetLines.helpers";
+import { convertCodeForDisplay } from "./utils";
 
 /**
  * Validates if the given budget line is an object.
@@ -80,4 +82,28 @@ export const isNotDevelopedYet = (agreementType, procurementShop) => {
         return true;
     }
     return false;
+};
+
+/**
+ * @param {import("../components/Agreements/AgreementTypes").Agreement} agreement
+ * @returns {string} - The label for the agreement type.
+ */
+
+export const getAgreementType = (agreement) => {
+    if (!agreement) {
+        console.error("Agreement is undefined or null");
+        return NO_DATA;
+    }
+
+    let agreementTypeLabel = convertCodeForDisplay("agreementType", agreement?.agreement_type);
+    const procurementShop = agreement?.procurement_shop?.abbr;
+    if (
+        procurementShop &&
+        procurementShop !== ProcurementShopType.GCS &&
+        agreement.agreement_type === AgreementType.CONTRACT
+    ) {
+        agreementTypeLabel = "AA";
+    }
+
+    return agreementTypeLabel;
 };

--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -105,5 +105,9 @@ export const getAgreementType = (agreement, abbr = true) => {
         agreementTypeLabel = abbr ? "AA" : "Assisted Acquisition (AA)";
     }
 
+    if (agreementTypeLabel === "IAA" && abbr === false) {
+        agreementTypeLabel = "Inter-Agency Agreements (IAA)";
+    }
+
     return agreementTypeLabel;
 };

--- a/frontend/src/pages/agreements/details/AgreementDetails.test.js
+++ b/frontend/src/pages/agreements/details/AgreementDetails.test.js
@@ -411,7 +411,7 @@ describe("AgreementDetails", () => {
         id: 500
     };
 
-    test("renders correctly", () => {
+    test("renders AA type agreement correctly", () => {
         TestApplicationContext.helpers().callBackend.mockImplementation(async () => {
             return agreementHistoryData;
         });
@@ -444,13 +444,71 @@ describe("AgreementDetails", () => {
 
         expect(screen.getByText("Test Description")).toBeInTheDocument();
         expect(screen.getByText("Agreement Type")).toBeInTheDocument();
-        expect(screen.getByText("Contract")).toBeInTheDocument();
+        expect(screen.getByText("AA")).toBeInTheDocument();
         expect(screen.getByText("Product Service Code")).toBeInTheDocument();
         expect(screen.getByText("Test PSC")).toBeInTheDocument();
         expect(screen.getByText("NAICS Code")).toBeInTheDocument();
         expect(screen.getByText("Test NAICS")).toBeInTheDocument();
         expect(screen.getByText("Procurement Shop")).toBeInTheDocument();
         expect(screen.getByText("NIH - Fee Rate: 0.5%")).toBeInTheDocument();
+        expect(screen.getByText("Agreement Reason")).toBeInTheDocument();
+        expect(screen.getByText("Recompete")).toBeInTheDocument();
+        expect(screen.getByText("Vendor")).toBeInTheDocument();
+        expect(screen.getByText("Test Vendor")).toBeInTheDocument();
+        expect(screen.getByText("COR")).toBeInTheDocument();
+        expect(screen.getAllByText("Chris Fortunato")[0]).toBeInTheDocument();
+        expect(screen.getByText("Team Members")).toBeInTheDocument();
+        expect(screen.getByText("Amy Madigan")).toBeInTheDocument();
+        expect(screen.getByText("Ivelisse Martinez-Beck")).toBeInTheDocument();
+    });
+    test("renders contract type agreement correctly", () => {
+        TestApplicationContext.helpers().callBackend.mockImplementation(async () => {
+            return agreementHistoryData;
+        });
+
+        // IntersectionObserver isn't available in test environment
+        const mockIntersectionObserver = mockFn;
+        mockIntersectionObserver.mockReturnValue({
+            observe: () => null,
+            unobserve: () => null,
+            disconnect: () => null
+        });
+        window.IntersectionObserver = mockIntersectionObserver;
+
+        render(
+            <Provider store={store}>
+                <Router
+                    location={history.location}
+                    navigator={history}
+                >
+                    <AgreementDetails
+                        agreement={{
+                            ...agreement,
+                            procurement_shop: {
+                                id: 2,
+                                abbr: "GCS",
+                                fee: 0,
+                                name: "GCS"
+                            }
+                        }}
+                        projectOfficer={projectOfficer}
+                        isEditMode={false}
+                        setIsEditMode={mockFn}
+                        setHasAgreementChanged={mockFn}
+                    />
+                </Router>
+            </Provider>
+        );
+
+        expect(screen.getByText("Test Description")).toBeInTheDocument();
+        expect(screen.getByText("Agreement Type")).toBeInTheDocument();
+        expect(screen.getByText("Contract")).toBeInTheDocument();
+        expect(screen.getByText("Product Service Code")).toBeInTheDocument();
+        expect(screen.getByText("Test PSC")).toBeInTheDocument();
+        expect(screen.getByText("NAICS Code")).toBeInTheDocument();
+        expect(screen.getByText("Test NAICS")).toBeInTheDocument();
+        expect(screen.getByText("Procurement Shop")).toBeInTheDocument();
+        expect(screen.getByText("GCS - Fee Rate: 0%")).toBeInTheDocument();
         expect(screen.getByText("Agreement Reason")).toBeInTheDocument();
         expect(screen.getByText("Recompete")).toBeInTheDocument();
         expect(screen.getByText("Vendor")).toBeInTheDocument();

--- a/frontend/src/pages/agreements/details/AgreementDetails.test.js
+++ b/frontend/src/pages/agreements/details/AgreementDetails.test.js
@@ -444,7 +444,7 @@ describe("AgreementDetails", () => {
 
         expect(screen.getByText("Test Description")).toBeInTheDocument();
         expect(screen.getByText("Agreement Type")).toBeInTheDocument();
-        expect(screen.getByText("AA")).toBeInTheDocument();
+        expect(screen.getByText("Assisted Acquisition (AA)")).toBeInTheDocument();
         expect(screen.getByText("Product Service Code")).toBeInTheDocument();
         expect(screen.getByText("Test PSC")).toBeInTheDocument();
         expect(screen.getByText("NAICS Code")).toBeInTheDocument();

--- a/frontend/src/pages/agreements/details/AgreementDetailsView.jsx
+++ b/frontend/src/pages/agreements/details/AgreementDetailsView.jsx
@@ -75,7 +75,7 @@ const AgreementDetailsView = ({ agreement, projectOfficer, alternateProjectOffic
                             <Tag
                                 dataCy="agreement-type-tag"
                                 tagStyle="primaryDarkTextLightBackground"
-                                text={getAgreementType(agreement)}
+                                text={getAgreementType(agreement, false)}
                             />
                         </dd>
 

--- a/frontend/src/pages/agreements/details/AgreementDetailsView.jsx
+++ b/frontend/src/pages/agreements/details/AgreementDetailsView.jsx
@@ -1,6 +1,7 @@
 import AgreementHistoryPanel from "../../../components/Agreements/AgreementDetails/AgreementHistoryPanel";
 import Tag from "../../../components/UI/Tag/Tag";
 import { NO_DATA } from "../../../constants";
+import { getAgreementType } from "../../../helpers/agreement.helpers";
 import { convertCodeForDisplay } from "../../../helpers/utils";
 
 /**
@@ -74,7 +75,7 @@ const AgreementDetailsView = ({ agreement, projectOfficer, alternateProjectOffic
                             <Tag
                                 dataCy="agreement-type-tag"
                                 tagStyle="primaryDarkTextLightBackground"
-                                text={convertCodeForDisplay("agreementType", agreement?.agreement_type)}
+                                text={getAgreementType(agreement)}
                             />
                         </dd>
 


### PR DESCRIPTION
## What changed

> This PR updates the agreement type label logic so that non-GCS contract agreements are shown as "AA" rather than "Contract". The changes update the helper function used for label generation, adjust the details view to use the new helper, and update tests (unit, integration, and e2e) to verify the new behavior.
>
> Updated AgreementDetailsView to use getAgreementType from agreement.helpers.
Revised tests in AgreementDetails.test.js and agreementDetails.cy.js to reflect the "AA" label when applicable.
Updated AgreementTableRow and the agreement.helpers.js to centralize the agreement type logic.

Update the agreement type label to AA if a contract with procurement shop that is not GCS. fixed #3778 AC 2

## Issue

#3778 

## How to test

1. all e2e test pass
2. go to agreement list and check AA agreement type
3. click on an AA type agreement, the agreement type should AA on agreement details page.

## Screenshot

### list view
<img width="879" alt="image" src="https://github.com/user-attachments/assets/769a000a-7bac-4cea-996b-39cb23881091" />

###  detail view
<img width="840" alt="image" src="https://github.com/user-attachments/assets/96e03714-a499-41cc-8c0d-51b86a112ae6" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated

