### PR TITLE
Updates disable user script to only look at active users

### DIFF
--- a/backend/data_tools/src/disable_users/disable_users.py
+++ b/backend/data_tools/src/disable_users/disable_users.py
@@ -81,7 +81,7 @@ def update_disabled_users_status(conn: sqlalchemy.engine.Engine):
         all_users = se.execute(select(User)).scalars().all()
         for user in all_users:
             latest_session = get_latest_user_session(user_id=user.id, session=se)
-            if latest_session and latest_session.last_active_at < datetime.now() - timedelta(days=60):
+            if user.status == UserStatus.ACTIVE and latest_session and latest_session.last_active_at < datetime.now() - timedelta(days=60):
                 results.append(user.id)
             elif latest_session is None and user.status == UserStatus.ACTIVE and (user.updated_on < datetime.now() - timedelta(days=60)):
                 results.append(user.id)


### PR DESCRIPTION
## What changed

Updating the first condition and initial check for an inactive user to further only look at currently active users.  Thusly excluding users who are not already active even if they had a prior session.

## Issue

N/A

## How to test

Verify that it's not trying to re-disable users that were previously marked as disabled but that had a previous session

## Screenshots

N/A

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~


## Links
