### PR TITLE
docs: update faq.jsx

### DIFF
--- a/frontend/src/pages/help/FAQ.jsx
+++ b/frontend/src/pages/help/FAQ.jsx
@@ -240,7 +240,7 @@ For cross-portfolio or shared work, you would just choose the CANs for each budg
     },
     {
         heading: "Do we still need $0 budget lines in OPS?",
-        ytcontent: `$0 budget lines in OPS might be a result of an admin mod. If you see any remaining $0 budget lines that were migrated from MAPS to OPS, please do not delete them. We are working on a solution and an update will be shared soon.
+        content: `$0 budget lines in OPS might be a result of an admin mod. If you see any remaining $0 budget lines that were migrated from MAPS to OPS, please do not delete them. We are working on a solution and an update will be shared soon.
         `
     },
     {


### PR DESCRIPTION
A fix where extra characters were accidentally added to an FAQs content tag which resulted in the FAQ answer disappearing.
