### PR TITLE
fix: add calculation for received percentage and update graph data

### DIFF
--- a/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.jsx
+++ b/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.jsx
@@ -65,7 +65,7 @@ const ReceivedFundingCard = ({ title, totalReceived, totalFunding }) => {
                 </div>
             )}
             <div className="font-12px margin-top-2 display-flex flex-justify-end">
-                <div>
+                <div data-testid="received-funding-card-text">
                     Received{" "}
                     <CurrencyFormat
                         value={totalReceived ?? 0}

--- a/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.jsx
+++ b/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.jsx
@@ -3,6 +3,7 @@ import CurrencyWithSmallCents from "../../CurrencyWithSmallCents/CurrencyWithSma
 import ReverseLineGraph from "../../DataViz/LineGraph/ReverseLineGraph";
 import RoundedBox from "../../RoundedBox";
 import Tag from "../../Tag";
+import { calculatePercent } from "../../../../helpers/utils";
 
 /**
  * @typedef {Object} BudgetCardProps
@@ -19,16 +20,19 @@ import Tag from "../../Tag";
  * @returns {JSX.Element} - The BudgetSummaryCard component.
  */
 const ReceivedFundingCard = ({ title, totalReceived, totalFunding }) => {
+    const receivedPercent = calculatePercent(totalReceived, totalFunding);
     const graphData = [
         {
             id: 1,
             value: totalReceived,
-            color: "var(--data-viz-budget-graph-1)"
+            color: "var(--data-viz-budget-graph-1)",
+            percent: receivedPercent
         },
         {
             id: 2,
             value: totalFunding,
-            color: "var(--data-viz-budget-graph-2)"
+            color: "var(--data-viz-budget-graph-2)",
+            percent: 100 - receivedPercent
         }
     ];
 

--- a/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.test.jsx
+++ b/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import ReceivedFundingCard from "./ReceivedFundingCard";
+import { describe, it, expect } from "vitest";
+
+describe("ReceivedFundingCard", () => {
+    it("renders the title correctly", () => {
+        render(<ReceivedFundingCard title="Test Title" totalReceived={1000} totalFunding={5000} />);
+        expect(screen.getByText("Test Title")).toBeInTheDocument();
+    });
+
+    it("displays the total received amount correctly", () => {
+        render(<ReceivedFundingCard title="Test" totalReceived={1234.56} totalFunding={5000} />);
+        expect(screen.getByText("$1,234.56")).toBeInTheDocument();
+    });
+
+    it("displays the total funding amount correctly", () => {
+        render(<ReceivedFundingCard title="Test" totalReceived={1234.56} totalFunding={5000} />);
+        expect(screen.getByText("of $5,000.00")).toBeInTheDocument();
+    });
+
+    it("renders the 'Received' tag when totalFunding is greater than 0", () => {
+        render(<ReceivedFundingCard title="Test" totalReceived={1000} totalFunding={5000} />);
+        expect(screen.getByText("Received")).toBeInTheDocument();
+    });
+
+    it("does not render the 'Received' tag when totalFunding is 0", () => {
+        render(<ReceivedFundingCard title="Test" totalReceived={1000} totalFunding={0} />);
+        expect(screen.queryByText("Received")).not.toBeInTheDocument();
+    });
+
+    it("renders the ReverseLineGraph when totalFunding is greater than 0", () => {
+        render(<ReceivedFundingCard title="Test" totalReceived={1000} totalFunding={5000} />);
+        screen.debug();
+        expect(screen.getByRole("img", { hidden: true })).toBeInTheDocument(); // Assuming the graph renders an SVG or similar
+    });
+
+    it("does not render the ReverseLineGraph when totalFunding is 0", () => {
+        render(<ReceivedFundingCard title="Test" totalReceived={1000} totalFunding={0} />);
+        expect(screen.queryByRole("img", { hidden: true })).not.toBeInTheDocument();
+    });
+
+    it("handles zero totalReceived and totalFunding gracefully", () => {
+        render(<ReceivedFundingCard title="Test" totalReceived={0} totalFunding={0} />);
+        expect(screen.getByText("$0")).toBeInTheDocument();
+        expect(screen.getByText("of $0")).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.test.jsx
+++ b/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.test.jsx
@@ -4,44 +4,90 @@ import { describe, it, expect } from "vitest";
 
 describe("ReceivedFundingCard", () => {
     it("renders the title correctly", () => {
-        render(<ReceivedFundingCard title="Test Title" totalReceived={1000} totalFunding={5000} />);
+        render(
+            <ReceivedFundingCard
+                title="Test Title"
+                totalReceived={1000}
+                totalFunding={5000}
+            />
+        );
         expect(screen.getByText("Test Title")).toBeInTheDocument();
     });
 
     it("displays the total received amount correctly", () => {
-        render(<ReceivedFundingCard title="Test" totalReceived={1234.56} totalFunding={5000} />);
+        render(
+            <ReceivedFundingCard
+                title="Test"
+                totalReceived={1234.56}
+                totalFunding={5000}
+            />
+        );
         expect(screen.getByText("$1,234.56")).toBeInTheDocument();
     });
 
     it("displays the total funding amount correctly", () => {
-        render(<ReceivedFundingCard title="Test" totalReceived={1234.56} totalFunding={5000} />);
-        expect(screen.getByText("of $5,000.00")).toBeInTheDocument();
+        render(
+            <ReceivedFundingCard
+                title="Test"
+                totalReceived={1234.5678}
+                totalFunding={5000.2345}
+            />
+        );
+        expect(screen.getByTestId("received-funding-card-text")).toHaveTextContent("Received $1,234.57 of $5,000.23");
     });
 
     it("renders the 'Received' tag when totalFunding is greater than 0", () => {
-        render(<ReceivedFundingCard title="Test" totalReceived={1000} totalFunding={5000} />);
+        render(
+            <ReceivedFundingCard
+                title="Test"
+                totalReceived={1000}
+                totalFunding={5000}
+            />
+        );
         expect(screen.getByText("Received")).toBeInTheDocument();
     });
 
     it("does not render the 'Received' tag when totalFunding is 0", () => {
-        render(<ReceivedFundingCard title="Test" totalReceived={1000} totalFunding={0} />);
+        render(
+            <ReceivedFundingCard
+                title="Test"
+                totalReceived={1000}
+                totalFunding={0}
+            />
+        );
         expect(screen.queryByText("Received")).not.toBeInTheDocument();
     });
 
     it("renders the ReverseLineGraph when totalFunding is greater than 0", () => {
-        render(<ReceivedFundingCard title="Test" totalReceived={1000} totalFunding={5000} />);
-        screen.debug();
-        expect(screen.getByRole("img", { hidden: true })).toBeInTheDocument(); // Assuming the graph renders an SVG or similar
+        render(
+            <ReceivedFundingCard
+                title="Test"
+                totalReceived={1000}
+                totalFunding={5000}
+            />
+        );
+        expect(screen.getByTestId("line-graph-left-bar")).toHaveStyle("flex: 0 1 20%");
     });
 
     it("does not render the ReverseLineGraph when totalFunding is 0", () => {
-        render(<ReceivedFundingCard title="Test" totalReceived={1000} totalFunding={0} />);
+        render(
+            <ReceivedFundingCard
+                title="Test"
+                totalReceived={1000}
+                totalFunding={0}
+            />
+        );
         expect(screen.queryByRole("img", { hidden: true })).not.toBeInTheDocument();
     });
 
     it("handles zero totalReceived and totalFunding gracefully", () => {
-        render(<ReceivedFundingCard title="Test" totalReceived={0} totalFunding={0} />);
-        expect(screen.getByText("$0")).toBeInTheDocument();
-        expect(screen.getByText("of $0")).toBeInTheDocument();
+        render(
+            <ReceivedFundingCard
+                title="Test"
+                totalReceived={0}
+                totalFunding={0}
+            />
+        );
+        expect(screen.getByTestId("received-funding-card-text")).toHaveTextContent("Received $0 of $0");
     });
 });

--- a/frontend/src/components/UI/DataViz/LineGraph/ReverseLineGraph.jsx
+++ b/frontend/src/components/UI/DataViz/LineGraph/ReverseLineGraph.jsx
@@ -36,7 +36,7 @@ const ReverseLineGraph = ({ data = [], setActiveId = () => {} }) => {
     return (
         <div className={styles.barBox}>
             {leftValue > 0 && (
-                <div
+                <div data-testid="line-graph-left-bar"
                     className={`${styles.leftBar} ${leftPercent >= 100 ? styles.leftBarFull : ""}`}
                     style={{
                         flex: `0  1 ${leftPercent}%`,


### PR DESCRIPTION
## What changed

This PR fixes the calculation for the received percentage in the budgeting cards and updates the relevant graph and tests accordingly.

- Introduces a calculation for the received percentage using the calculatePercent helper.
- Updates the ReverseLineGraph component to add a test identifier.
- Adds comprehensive tests for the ReceivedFundingCard component.

## Issue

- closes #3787 

## How to test

1. unit test pass
2. visit `/cans/515/funding` select FY 2023
3. check the Funding Received YTD card

## Screenshots

![Screenshot 2025-04-30 at 10 57 42 AM](https://github.com/user-attachments/assets/df55ba0e-b58b-4fe8-afb7-2988c858014a)


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
