### PR TITLE
Removing specific version of unzip in apt command of frontend dockerfile

### DIFF
--- a/frontend/Dockerfile.azure
+++ b/frontend/Dockerfile.azure
@@ -1,7 +1,8 @@
 # ---- Build Stage ----
 # alpine
 FROM oven/bun@sha256:359bd5872a371d8e08606ac135f17167ba71118b00f6a08308a7a3a9852d7576 as build
-RUN apt-get update && apt-get -y install unzip=latest --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get -y install unzip --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/bun/app
 

--- a/frontend/Dockerfile.azure
+++ b/frontend/Dockerfile.azure
@@ -1,7 +1,7 @@
 # ---- Build Stage ----
 # alpine
 FROM oven/bun@sha256:359bd5872a371d8e08606ac135f17167ba71118b00f6a08308a7a3a9852d7576 as build
-RUN apt-get update && apt-get -y install unzip=6.0-26+deb11u1 --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install unzip=latest --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /home/bun/app
 


### PR DESCRIPTION
## What changed

Removes specific version of unzip specified in frontend azure dockerfile. Renovate nor dependabot will keep it up to date so just not pinning it. 

## Issue

previous specified version is no longer available

## How to test

CI/CD tests

