### PR TITLE
test: improve perf on components test

### DIFF
--- a/frontend/cypress/e2e/components.cy.js
+++ b/frontend/cypress/e2e/components.cy.js
@@ -12,15 +12,8 @@ afterEach(() => {
 });
 
 describe("DateRangePicker", () => {
-    it("should display date range picker", () => {
-        cy.visit("/agreements/1/budget-lines");
-        cy.get("#edit").click();
-        cy.get("#pop-start-date").should("exist");
-        cy.get("#pop-end-date").should("exist");
-    });
-
     it("should error if end date is not before the start date", () => {
-        cy.visit("/agreements/1/budget-lines");
+        cy.visit("/agreements/9/budget-lines");
         cy.get("#edit").click();
         cy.get("#servicesComponentSelect").select("4");
         cy.get("#pop-start-date").type("01/01/2020");
@@ -31,7 +24,7 @@ describe("DateRangePicker", () => {
         cy.get("h2").contains("Services Component 4").should("not.exist");
     });
     it('should error if date is not in the format "MM/DD/YYYY"', () => {
-        cy.visit("/agreements/1/budget-lines");
+        cy.visit("/agreements/9/budget-lines");
         cy.get("#edit").click();
         cy.get("#servicesComponentSelect").select("4");
         cy.get("#pop-start-date").type("tacocat");

--- a/frontend/cypress/e2e/components.cy.js
+++ b/frontend/cypress/e2e/components.cy.js
@@ -4,6 +4,7 @@ import { terminalLog, testLogin } from "./utils";
 
 beforeEach(() => {
     testLogin("system-owner");
+    cy.visit("/agreements/9/budget-lines");
 });
 
 afterEach(() => {
@@ -13,7 +14,6 @@ afterEach(() => {
 
 describe("DateRangePicker", () => {
     it("should error if end date is not before the start date", () => {
-        cy.visit("/agreements/9/budget-lines");
         cy.get("#edit").click();
         cy.get("#servicesComponentSelect").select("4");
         cy.get("#pop-start-date").type("01/01/2020");
@@ -24,7 +24,6 @@ describe("DateRangePicker", () => {
         cy.get("h2").contains("Services Component 4").should("not.exist");
     });
     it('should error if date is not in the format "MM/DD/YYYY"', () => {
-        cy.visit("/agreements/9/budget-lines");
         cy.get("#edit").click();
         cy.get("#servicesComponentSelect").select("4");
         cy.get("#pop-start-date").type("tacocat");


### PR DESCRIPTION
## What changed

This PR aims to improve performance in the component tests by targeting agreement 9 rather than 1. The key changes include:

- Removing the "should display date range picker" test.
- Updating the URL in the test cases from "/agreements/1/budget-lines" to "/agreements/9/budget-lines".

## How to test

1. e2e tests pass 

## Definition of Done Checklist
- [-] OESA: Code refactored for clarity
- [-] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
