### PR TITLE
E2e tests and return stmt

### DIFF
--- a/frontend/cypress/e2e/canList.cy.js
+++ b/frontend/cypress/e2e/canList.cy.js
@@ -117,8 +117,8 @@ describe("CAN List Filtering", () => {
         cy.get("#fiscal-year-select").select("2044");
         // table should not exist and contain one row
         cy.get("tbody").children().should("have.length.above", 0);
-        // table row should contain G996400
-        cy.get("tbody").contains("G996400").should("exist");
+        // table row should contain G99AB14
+        cy.get("tbody").contains("G99AB14").should("exist");
     });
 
     it("the filter button works as expected", () => {

--- a/frontend/cypress/e2e/canList.cy.js
+++ b/frontend/cypress/e2e/canList.cy.js
@@ -32,18 +32,7 @@ describe("CAN List", () => {
         // budget-summary-card-2021 should contain $ 30,200,000
         cy.get("[data-cy='budget-summary-card-2021']").contains("$ 30,200,000");
 
-        const expectedValues = [
-            "$0",
-            "$0",
-            "$0",
-            "$0",
-            "$200,000.00",
-            "$10,000,000.00",
-            "$10,000,000.00",
-            "$10,000,000.00",
-            "$0",
-            "$0"
-        ];
+        const expectedValues = ["$200,000.00", "$10,000,000.00", "$10,000,000.00", "$10,000,000.00"];
 
         cy.get("tbody tr").each(($row, index) => {
             cy.wrap($row)
@@ -115,10 +104,8 @@ describe("CAN List", () => {
 
     it("test cans with no funding budgets", () => {
         cy.get("#fiscal-year-select").select("2044");
-        cy.get("tbody").find("tr").should("have.length.above", 0);
-        cy.get("tbody").contains("G99XXX3").should("exist");
-        cy.get("tbody").contains("G1183CE").should("exist");
-        cy.get("tbody").contains("G996400").should("exist");
+        cy.get("tbody").find("tr").should("have.length", 1);
+        cy.get("tbody").contains("G99AB14").should("exist");
     });
 });
 

--- a/frontend/src/pages/cans/list/CanList.jsx
+++ b/frontend/src/pages/cans/list/CanList.jsx
@@ -50,7 +50,7 @@ const CanList = () => {
     });
 
     const filteredCANsByFiscalYear = React.useMemo(() => {
-        filterCANsByFiscalYear(canList, fiscalYear);
+        return filterCANsByFiscalYear(canList, fiscalYear);
     }, [canList, fiscalYear]);
     const sortedCANs = sortAndFilterCANs(filteredCANsByFiscalYear, myCANsUrl, activeUser, filters, fiscalYear) || [];
     const portfolioOptions = getPortfolioOptions(canList);


### PR DESCRIPTION
- Add `return` statement. 
  -  I believe filterCANsByFiscalYear() runs, but the callback doesn't return anything if we don't include the `return` statement — so filteredCANsByFiscalYear would be undefined.
- Fix CanList e2e tests. 