### PR TITLE
fix: fix budget lines list error when BLI has no amount

### DIFF
--- a/backend/ops_api/ops/services/budget_line_items.py
+++ b/backend/ops_api/ops/services/budget_line_items.py
@@ -371,36 +371,56 @@ def update_data(budget_line_item: BudgetLineItem, data: dict[str, Any]) -> None:
 
 def _get_totals_with_or_without_fees(all_results, include_fees):
     if include_fees and True in include_fees:
-        total_amount = sum([result.amount + result.fees for result in all_results])
+        total_amount = sum([result.amount + result.fees for result in all_results if result.amount])
         total_draft_amount = sum(
-            [result.amount + result.fees for result in all_results if result.status == BudgetLineItemStatus.DRAFT]
+            [
+                result.amount + result.fees
+                for result in all_results
+                if result.amount and result.status == BudgetLineItemStatus.DRAFT
+            ]
         )
         total_planned_amount = sum(
-            [result.amount + result.fees for result in all_results if result.status == BudgetLineItemStatus.PLANNED]
+            [
+                result.amount + result.fees
+                for result in all_results
+                if result.amount and result.status == BudgetLineItemStatus.PLANNED
+            ]
         )
         total_in_execution_amount = sum(
             [
                 result.amount + result.fees
                 for result in all_results
-                if result.status == BudgetLineItemStatus.IN_EXECUTION
+                if result.amount and result.status == BudgetLineItemStatus.IN_EXECUTION
             ]
         )
         total_obligated_amount = sum(
-            [result.amount + result.fees for result in all_results if result.status == BudgetLineItemStatus.OBLIGATED]
+            [
+                result.amount + result.fees
+                for result in all_results
+                if result.amount and result.status == BudgetLineItemStatus.OBLIGATED
+            ]
         )
     else:
-        total_amount = sum([result.amount for result in all_results])
+        total_amount = sum([result.amount for result in all_results if result.amount])
         total_draft_amount = sum(
-            [result.amount for result in all_results if result.status == BudgetLineItemStatus.DRAFT]
+            [result.amount for result in all_results if result.amount and result.status == BudgetLineItemStatus.DRAFT]
         )
         total_planned_amount = sum(
-            [result.amount for result in all_results if result.status == BudgetLineItemStatus.PLANNED]
+            [result.amount for result in all_results if result.amount and result.status == BudgetLineItemStatus.PLANNED]
         )
         total_in_execution_amount = sum(
-            [result.amount for result in all_results if result.status == BudgetLineItemStatus.IN_EXECUTION]
+            [
+                result.amount
+                for result in all_results
+                if result.amount and result.status == BudgetLineItemStatus.IN_EXECUTION
+            ]
         )
         total_obligated_amount = sum(
-            [result.amount for result in all_results if result.status == BudgetLineItemStatus.OBLIGATED]
+            [
+                result.amount
+                for result in all_results
+                if result.amount and result.status == BudgetLineItemStatus.OBLIGATED
+            ]
         )
     return {
         "total_amount": total_amount,

--- a/backend/ops_api/tests/ops/can/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/can/test_budget_line_item.py
@@ -1382,7 +1382,30 @@ def test_budget_line_items_fees(auth_client, loaded_db, test_bli_new):
     assert bli == test_bli_new
 
 
-def test_budget_line_items_fees_querystring(auth_client, loaded_db):
+@pytest.fixture()
+def test_bli_without_amount(loaded_db, test_can):
+    bli = ContractBudgetLineItem(
+        line_description="LI 1",
+        comments="blah blah",
+        agreement_id=1,
+        can_id=test_can.id,
+        amount=None,
+        status=BudgetLineItemStatus.DRAFT,
+        date_needed=datetime.date(2043, 1, 1),
+        proc_shop_fee_percentage=1.23,
+        created_by=1,
+    )
+    loaded_db.add(bli)
+    loaded_db.commit()
+
+    yield bli
+
+    loaded_db.rollback()
+    loaded_db.delete(bli)
+    loaded_db.commit()
+
+
+def test_budget_line_items_fees_querystring(auth_client, loaded_db, test_bli_without_amount):
     # test using a query string
     response = auth_client.get(
         url_for("api.budget-line-items-group"),


### PR DESCRIPTION
## What changed

Fix budget lines list error when BLI has no amount

## Issue

closes #3911

## How to test

1. open budget_line_item table in DB
2. delete amount of BLI 15000
3. visit /budget-lines
4. should not break

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
