### PR TITLE
OPS-3904: agreement list filter by portfolio bug fix

### DIFF
--- a/backend/ops_api/ops/schemas/budget_line_items.py
+++ b/backend/ops_api/ops/schemas/budget_line_items.py
@@ -355,4 +355,4 @@ class BudgetLineItemResponseSchema(Schema):
 class BudgetLineItemListFilterOptionResponseSchema(Schema):
     fiscal_years = fields.List(fields.Int(), required=True)
     statuses = fields.List(fields.String(), required=True)
-    portfolios = fields.List(fields.String(), required=True)
+    portfolios = fields.List(fields.Dict(keys=fields.String(), values=fields.Raw()), required=True)

--- a/backend/ops_api/ops/services/budget_line_items.py
+++ b/backend/ops_api/ops/services/budget_line_items.py
@@ -389,7 +389,15 @@ class BudgetLineItemService:
 
         fiscal_years = {result.fiscal_year for result in results if result.fiscal_year}
         budget_line_statuses = {result.status for result in results if result.status}
-        portfolios = {result.can.portfolio.name for result in results if result.can and result.can.portfolio}
+
+        portfolio_dict = {}
+        for result in results:
+            if result.can and result.can.portfolio:
+                portfolio_id = result.can.portfolio.id
+                if portfolio_id not in portfolio_dict:
+                    portfolio_dict[portfolio_id] = {"id": portfolio_id, "name": result.can.portfolio.name}
+
+        portfolios = list(portfolio_dict.values())
 
         budget_line_statuses_list = [status.name for status in budget_line_statuses]
         status_sort_order = [
@@ -402,7 +410,7 @@ class BudgetLineItemService:
         filters = {
             "fiscal_years": sorted(fiscal_years, reverse=True),
             "statuses": sorted(budget_line_statuses_list, key=status_sort_order.index),
-            "portfolios": sorted(portfolios),
+            "portfolios": sorted(portfolios, key=lambda x: x["name"]),
         }
         filter_response_schema = BudgetLineItemListFilterOptionResponseSchema()
         filter_options = filter_response_schema.dump(filters)

--- a/backend/ops_api/ops/services/budget_line_items.py
+++ b/backend/ops_api/ops/services/budget_line_items.py
@@ -390,12 +390,11 @@ class BudgetLineItemService:
         fiscal_years = {result.fiscal_year for result in results if result.fiscal_year}
         budget_line_statuses = {result.status for result in results if result.status}
 
-        portfolio_dict = {}
-        for result in results:
-            if result.can and result.can.portfolio:
-                portfolio_id = result.can.portfolio.id
-                if portfolio_id not in portfolio_dict:
-                    portfolio_dict[portfolio_id] = {"id": portfolio_id, "name": result.can.portfolio.name}
+        portfolio_dict = {
+            result.can.portfolio.id: {"id": result.can.portfolio.id, "name": result.can.portfolio.name}
+            for result in results
+            if result.can and result.can.portfolio
+        }
 
         portfolios = list(portfolio_dict.values())
 

--- a/backend/ops_api/tests/ops/can/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/can/test_budget_line_item.py
@@ -1501,12 +1501,12 @@ def test_get_budget_line_items_filter_options(system_owner_auth_client):
     assert response.json == {
         "fiscal_years": [2045, 2044, 2043],
         "portfolios": [
-            "Child Care Research",
-            "Child Welfare Research",
-            "Head Start Research",
-            "Healthy Marriage & Responsible Fatherhood Research",
-            "OCDO Portfolio",
-            "OD Portfolio",
+            {"id": 3, "name": "Child Care Research"},
+            {"id": 1, "name": "Child Welfare Research"},
+            {"id": 2, "name": "Head Start Research"},
+            {"id": 6, "name": "Healthy Marriage & Responsible Fatherhood Research"},
+            {"id": 8, "name": "OCDO Portfolio"},
+            {"id": 9, "name": "OD Portfolio"},
         ],
         "statuses": ["DRAFT", "PLANNED", "IN_EXECUTION", "OBLIGATED"],
     }

--- a/frontend/src/components/Portfolios/PortfoliosComboBox/PortfoliosComboBox.jsx
+++ b/frontend/src/components/Portfolios/PortfoliosComboBox/PortfoliosComboBox.jsx
@@ -26,20 +26,20 @@ export const PortfoliosComboBox = ({
     let newPortfolioOptions = [];
 
     if (portfolioOptions.length === 0 && isSuccess) {
-        newPortfolioOptions = data?.map((portfolio, index) => {
+        newPortfolioOptions = data?.map((portfolio) => {
             const portfolioOption = {
-                id: index + 1,
+                id: portfolio.id,
                 title: portfolio.name,
                 name: portfolio.name
             };
             return portfolioOption;
         });
     } else {
-        newPortfolioOptions = portfolioOptions.map((portfolio, index) => {
+        newPortfolioOptions = portfolioOptions.map((portfolio) => {
             const portfolioOption = {
-                id: index + 1,
-                title: portfolio,
-                name: portfolio
+                id: portfolio.id,
+                title: portfolio.name,
+                name: portfolio.name
             };
             return portfolioOption;
         });


### PR DESCRIPTION
## What changed

This PR fixes a mismatch in portfolio IDs between the UI query parameters and the database response, ensuring the agreement list filters correctly by portfolio.

Frontend: Use actual portfolio IDs instead of index-based IDs in the combo box options.
Backend service & schema: Emit portfolios as objects with id and name, sorted by name.
Tests: Update expectations to match the new object format for portfolios.

--Copilot

## Issue

Closes #3904 

## How to test

Agreement list filtering by portfolio should show the correct agreements

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated