### PR TITLE
Fix Agreement Total Sort on Agreement Table

### DIFF
--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -579,7 +579,9 @@ def agreement_total_sort(agreement):
     # handle fees if agreement has procurement shop
     if agreement.procurement_shop:
         procurement_shop_subtotal = reduce(
-            lambda aggregate, bli: aggregate + (bli.amount * Decimal(agreement.procurement_shop.fee)), filtered_blis, 0
+            lambda aggregate, bli: aggregate + (bli.amount * Decimal(agreement.procurement_shop.fee_percentage)),
+            filtered_blis,
+            0,
         )
         bli_totals = bli_totals + procurement_shop_subtotal
     return bli_totals

--- a/frontend/cypress/e2e/agreementList.cy.js
+++ b/frontend/cypress/e2e/agreementList.cy.js
@@ -165,34 +165,143 @@ describe("Agreement List", () => {
         cy.get("[data-testid='agreement-table-row-7']").find('[data-cy="edit-row"]').should("not.be.disabled");
     });
 
-    it.only("Should sort the table by clicking on the header", () => {
+    it("Should sort the table by clicking on the header", () => {
         // Sort table by agreement name
         cy.get(`[data-cy=${TABLE_HEADINGS_LIST[0].value}]`).click();
-        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
-            "have.text",
-            "Support Contract #1Support Contract #1"
-        );
-        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should(
-            "have.text",
-            "MIHOPE Long-TermMIHOPE Long-Term"
-        );
-        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should(
-            "have.text",
-            "MIHOPE Check-InMIHOPE Check-In"
-        );
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should("contain", "Support Contract #1");
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should("contain", "MIHOPE Long-Term");
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should("contain", "MIHOPE Check-In");
         // Sort by agreement name ascending
         cy.get(`[data-cy=${TABLE_HEADINGS_LIST[0].value}]`).click();
         cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
-            "have.text",
-            "CONTRACT #2: Fathers and Continuous Learning (FCL)CONTRACT #2: Fathers and Continuous Learning (FCL)"
+            "contain",
+            "CONTRACT #2: Fathers and Continuous Learning (FCL)"
         );
         cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should(
-            "have.text",
-            "Contract #1: African American Child and Family Research CenterContract #1: African American Child and Family Research Center"
+            "contain",
+            "Contract #1: African American Child and Family Research Center"
+        );
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should("contain", "Contract Workflow Test");
+
+        // Sort table by project name descending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[1].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "contain",
+            "Grant #1: Early Care and Education Leadership Study (ExCELS)"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should(
+            "contain",
+            "IAA #1: Early Care and Education Leadership Study (ExCELS)"
+        );
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should("contain", "Support Contract #1");
+        // Sort by project name ascending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[1].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "contain",
+            "CONTRACT #2: Fathers and Continuous Learning (FCL)"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should("contain", "Interoperability Initiatives");
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should(
+            "contain",
+            "IAA-AA #1: Fathers and Continuous Learning (FCL)"
+        );
+
+        // Sort table by project name descending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[2].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "contain",
+            "IAA-AA #1: Fathers and Continuous Learning (FCL)"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should(
+            "contain",
+            "IAA #1: Early Care and Education Leadership Study (ExCELS)"
         );
         cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should(
-            "have.text",
-            "Contract Workflow TestContract Workflow Test"
+            "contain",
+            "Grant #1: Early Care and Education Leadership Study (ExCELS)"
+        );
+        // Sort by project name ascending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[2].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "contain",
+            "CONTRACT #2: Fathers and Continuous Learning (FCL)"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should("contain", "MIHOPE Long-Term");
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should("contain", "Support Contract #1");
+
+        // Sort table by agreement total descending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[3].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "contain",
+            "Contract #1: African American Child and Family Research Center"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should(
+            "contain",
+            "DIRECT ALLOCATION #2: African American Child and Family Research Center"
+        );
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should(
+            "contain",
+            "CONTRACT #2: Fathers and Continuous Learning (FCL)"
+        );
+        // Sort by agreement total ascending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[3].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "contain",
+            "Grant #1: Early Care and Education Leadership Study (ExCELS)"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should(
+            "contain",
+            "IAA #1: Early Care and Education Leadership Study (ExCELS)"
+        );
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should(
+            "contain",
+            "IAA-AA #1: Fathers and Continuous Learning (FCL)"
+        );
+
+        // Sort table by next budget line descending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[4].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "contain",
+            "Contract #1: African American Child and Family Research Center"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should("contain", "Contract Workflow Test");
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should(
+            "contain",
+            "DIRECT ALLOCATION #2: African American Child and Family Research Center"
+        );
+        // Sort by next budget line ascending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[4].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "contain",
+            "CONTRACT #2: Fathers and Continuous Learning (FCL)"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should(
+            "contain",
+            "Grant #1: Early Care and Education Leadership Study (ExCELS)"
+        );
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should(
+            "contain",
+            "IAA #1: Early Care and Education Leadership Study (ExCELS)"
+        );
+
+        // Sort table by next obligate by descending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[5].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should("contain", "Support Contract #1");
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should("contain", "MIHOPE Check-In");
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should("contain", "MIHOPE Long-Term");
+        // Sort by next obligate by ascending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[5].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "contain",
+            "CONTRACT #2: Fathers and Continuous Learning (FCL)"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should(
+            "contain",
+            "Grant #1: Early Care and Education Leadership Study (ExCELS)"
+        );
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should(
+            "contain",
+            "IAA #1: Early Care and Education Leadership Study (ExCELS)"
         );
     });
 });

--- a/frontend/cypress/e2e/agreementList.cy.js
+++ b/frontend/cypress/e2e/agreementList.cy.js
@@ -1,5 +1,6 @@
 /// <reference types="cypress" />
 import { terminalLog, testLogin } from "./utils";
+import { TABLE_HEADINGS_LIST } from "../../src/components/Agreements/AgreementsTable/AgreementsTable.constants";
 
 describe("Agreement List", () => {
     beforeEach(() => {
@@ -162,5 +163,36 @@ describe("Agreement List", () => {
     it("Should allow user to edit an obligated agreement", () => {
         cy.get("[data-testid='agreement-table-row-7']").trigger("mouseover");
         cy.get("[data-testid='agreement-table-row-7']").find('[data-cy="edit-row"]').should("not.be.disabled");
+    });
+
+    it.only("Should sort the table by clicking on the header", () => {
+        // Sort table by agreement name
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[0].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "have.text",
+            "Support Contract #1Support Contract #1"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should(
+            "have.text",
+            "MIHOPE Long-TermMIHOPE Long-Term"
+        );
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should(
+            "have.text",
+            "MIHOPE Check-InMIHOPE Check-In"
+        );
+        // Sort by agreement name ascending
+        cy.get(`[data-cy=${TABLE_HEADINGS_LIST[0].value}]`).click();
+        cy.get("tbody > :nth-child(1) > [data-cy='agreement-name']").should(
+            "have.text",
+            "CONTRACT #2: Fathers and Continuous Learning (FCL)CONTRACT #2: Fathers and Continuous Learning (FCL)"
+        );
+        cy.get("tbody > :nth-child(2) > [data-cy='agreement-name']").should(
+            "have.text",
+            "Contract #1: African American Child and Family Research CenterContract #1: African American Child and Family Research Center"
+        );
+        cy.get("tbody > :nth-child(3) > [data-cy='agreement-name']").should(
+            "have.text",
+            "Contract Workflow TestContract Workflow Test"
+        );
     });
 });

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
@@ -149,6 +149,7 @@ export const AgreementTableRow = ({ agreementId }) => {
             <td
                 className={borderExpandedStyles}
                 style={bgExpandedStyles}
+                data-cy="agreement-name"
             >
                 <Link
                     className="text-ink text-no-underline"
@@ -164,6 +165,7 @@ export const AgreementTableRow = ({ agreementId }) => {
             <td
                 className={borderExpandedStyles}
                 style={bgExpandedStyles}
+                data-cy="research-project-name"
             >
                 <TextClip
                     text={researchProjectName}
@@ -174,12 +176,14 @@ export const AgreementTableRow = ({ agreementId }) => {
             <td
                 className={borderExpandedStyles}
                 style={bgExpandedStyles}
+                data-cy="agreement-type"
             >
                 {agreementType || ""}
             </td>
             <td
                 className={borderExpandedStyles}
                 style={bgExpandedStyles}
+                data-cy="agreement-total"
             >
                 <CurrencyFormat
                     value={agreementTotal}
@@ -194,6 +198,7 @@ export const AgreementTableRow = ({ agreementId }) => {
             <td
                 className={borderExpandedStyles}
                 style={bgExpandedStyles}
+                data-cy="next-bli-amount"
             >
                 <CurrencyFormat
                     value={nextBudgetLineAmount}
@@ -208,6 +213,7 @@ export const AgreementTableRow = ({ agreementId }) => {
             <td
                 className={borderExpandedStyles}
                 style={bgExpandedStyles}
+                data-cy="next-need-by"
             >
                 {isRowActive && !isExpanded ? <div>{changeIcons}</div> : <div>{nextNeedBy}</div>}
             </td>

--- a/frontend/src/components/UI/Table/Table.jsx
+++ b/frontend/src/components/UI/Table/Table.jsx
@@ -19,7 +19,7 @@ import styles from "./table.module.css";
 const Table = ({ children, tableHeadings, firstHeadingSlot, onClickHeader, selectedHeader = "", sortDescending }) => {
     /**
      * Adds a width to the Status column
-     * @param {string} heading - The heading to check
+     * @param {object} heading - The heading to check
      * @returns {object | undefined} - The width to add if the heading is Status
      */
     const addWidthIfStatus = (header) => {
@@ -36,6 +36,7 @@ const Table = ({ children, tableHeadings, firstHeadingSlot, onClickHeader, selec
                     {firstHeadingSlot && firstHeadingSlot}
                     {tableHeadings.map((header, index) => (
                         <th
+                            data-cy={header.value}
                             key={index}
                             scope="col"
                             role="columnheader"


### PR DESCRIPTION
## What changed

Fixed an issue that caused sorting the Agreement Table by agreement total to send the user to an error page. Added additional E2E tests to check for this in the future.

## Issue

OPS-976 

## How to test

1) Run E2E tests
2) Log in
3) Navigate to agreements page
4) Click 'Agreement Total' header and see that the page does not error out

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

