### PR TITLE
Ops 3930/can funding summary bug

### DIFF
--- a/backend/ops_api/ops/resources/agreements.py
+++ b/backend/ops_api/ops/resources/agreements.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
-from functools import reduce
 from typing import Any, Optional, Sequence, Type
 
 from flask import Response, current_app, request
@@ -573,15 +572,20 @@ def agreement_type_sort(agreement):
 
 
 def agreement_total_sort(agreement):
+    # Filter out DRAFT budget line items
     filtered_blis = list(filter(lambda bli: bli.status != BudgetLineItemStatus.DRAFT, agreement.budget_line_items))
-    # bli totals before fees
-    bli_totals = reduce(lambda aggregate, bli: aggregate + bli.amount, filtered_blis, 0)
-    # handle fees if agreement has procurement shop
+
+    # Calculate sum of amounts, skipping None values by using 0 instead
+    bli_totals = Decimal("0")
+    for bli in filtered_blis:
+        if bli.amount is not None:
+            bli_totals += bli.amount
+
+    # Handle fees if agreement has procurement shop
     if agreement.procurement_shop:
-        procurement_shop_subtotal = reduce(
-            lambda aggregate, bli: aggregate + (bli.amount * Decimal(agreement.procurement_shop.fee)), filtered_blis, 0
-        )
-        bli_totals = bli_totals + procurement_shop_subtotal
+        fee = Decimal(agreement.procurement_shop.fee)
+        bli_totals += bli_totals * fee
+
     return bli_totals
 
 
@@ -589,14 +593,16 @@ def next_budget_line_sort(agreement):
     next_bli = _get_next_obligated_bli(agreement.budget_line_items)
 
     if next_bli:
-        total = (
-            next_bli.amount + (next_bli.amount * Decimal(next_bli.proc_shop_fee_percentage))
-            if next_bli.proc_shop_fee_percentage
-            else next_bli.amount
-        )
+        amount = next_bli.amount if next_bli.amount is not None else Decimal("0")
+
+        fee = Decimal("0")
+        if next_bli.proc_shop_fee_percentage:
+            fee = amount * Decimal(next_bli.proc_shop_fee_percentage)
+
+        total = amount + fee
         return total
     else:
-        return 0
+        return Decimal("0")
 
 
 def next_obligate_by_sort(agreement):

--- a/backend/ops_api/ops/services/cans.py
+++ b/backend/ops_api/ops/services/cans.py
@@ -105,7 +105,8 @@ class CANService:
                 decorated_results.sort(reverse=sort_descending)
                 return [can for _, _, can in decorated_results]
             case CANSortCondition.FUNDING_RECEIVED:
-                # We need to sort by funding received for the provided year so we're going to use the decorate-sort-undecorate idiom to accomplish it
+                # We need to sort by funding received for the provided year so we're going to use the
+                # decorate-sort-undecorate idiom to accomplish it
                 decorated_results = [
                     (CANService.get_can_funding_received(can, fiscal_year=fiscal_year), i, can)
                     for i, can in enumerate(results)

--- a/backend/ops_api/ops/utils/cans.py
+++ b/backend/ops_api/ops/utils/cans.py
@@ -35,12 +35,16 @@ def get_funding_by_budget_line_item_status(
     if fiscal_year:
         return (
             sum(
-                [bli.amount for bli in can.budget_line_items if bli.status == status and bli.fiscal_year == fiscal_year]
+                [
+                    bli.amount
+                    for bli in can.budget_line_items
+                    if bli.amount and bli.status == status and bli.fiscal_year == fiscal_year
+                ]
             )
             or 0
         )
     else:
-        return sum([bli.amount for bli in can.budget_line_items if bli.status == status]) or 0
+        return sum([bli.amount for bli in can.budget_line_items if bli.amount and bli.status == status]) or 0
 
 
 def get_can_funding_summary(can: CAN, fiscal_year: Optional[int] = None) -> CanFundingSummary:

--- a/backend/ops_api/tests/ops/agreement/test_agreement_sort.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement_sort.py
@@ -1,0 +1,294 @@
+from datetime import date, timedelta
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from models import BudgetLineItemStatus
+from ops_api.ops.resources.agreements import agreement_total_sort, next_budget_line_sort
+
+
+def test_agreement_total_no_budget_lines():
+    # Setup an agreement with no budget lines
+    agreement = MagicMock()
+    agreement.budget_line_items = []
+    agreement.procurement_shop = None
+
+    # Test
+    result = agreement_total_sort(agreement)
+
+    # Assert
+    assert result == 0
+
+
+def test_agreement_total_with_draft_budget_lines_only():
+    # Setup budget line items with DRAFT status only
+    bli1 = MagicMock()
+    bli1.status = BudgetLineItemStatus.DRAFT
+    bli1.amount = Decimal("50000.00")
+
+    bli2 = MagicMock()
+    bli2.status = BudgetLineItemStatus.DRAFT
+    bli2.amount = Decimal("75000.00")
+
+    agreement = MagicMock()
+    agreement.budget_line_items = [bli1, bli2]
+    agreement.procurement_shop = None
+
+    # Test
+    result = agreement_total_sort(agreement)
+
+    # Assert - total should be zero as all BLIs are DRAFT
+    assert result == 0
+
+
+def test_agreement_total_with_multiple_budget_lines():
+    # Setup budget line items with mixed statuses
+    bli1 = MagicMock()
+    bli1.status = BudgetLineItemStatus.PLANNED
+    bli1.amount = Decimal("100000.00")
+
+    bli2 = MagicMock()
+    bli2.status = BudgetLineItemStatus.IN_EXECUTION
+    bli2.amount = Decimal("200000.00")
+
+    bli3 = MagicMock()
+    bli3.status = BudgetLineItemStatus.DRAFT
+    bli3.amount = Decimal("50000.00")
+
+    bli4 = MagicMock()
+    bli4.status = BudgetLineItemStatus.OBLIGATED
+    bli4.amount = Decimal("150000.00")
+
+    agreement = MagicMock()
+    agreement.budget_line_items = [bli1, bli2, bli3, bli4]
+    agreement.procurement_shop = None
+
+    # Test
+    result = agreement_total_sort(agreement)
+
+    # Assert - total should be sum of non-draft BLIs
+    expected = Decimal("100000.00") + Decimal("200000.00") + Decimal("150000.00")
+    assert result == expected
+
+
+def test_agreement_total_with_procurement_shop_fees():
+    # Setup budget line items with procurement shop fees
+    bli1 = MagicMock()
+    bli1.status = BudgetLineItemStatus.PLANNED
+    bli1.amount = Decimal("100000.00")
+
+    bli2 = MagicMock()
+    bli2.status = BudgetLineItemStatus.IN_EXECUTION
+    bli2.amount = Decimal("200000.00")
+
+    # Setup procurement shop with fee
+    procurement_shop = MagicMock()
+    procurement_shop.fee = "0.05"  # 5% fee
+
+    agreement = MagicMock()
+    agreement.budget_line_items = [bli1, bli2]
+    agreement.procurement_shop = procurement_shop
+
+    # Test
+    result = agreement_total_sort(agreement)
+
+    # Assert - total should include base amounts plus fees
+    base_amount = Decimal("100000.00") + Decimal("200000.00")
+    fee_amount = base_amount * Decimal("0.05")
+    expected = base_amount + fee_amount
+    assert result == expected
+
+
+def test_agreement_total_with_zero_amount_budget_lines():
+    # Setup budget line items with zero amounts
+    bli1 = MagicMock()
+    bli1.status = BudgetLineItemStatus.PLANNED
+    bli1.amount = Decimal("0.00")
+
+    bli2 = MagicMock()
+    bli2.status = BudgetLineItemStatus.IN_EXECUTION
+    bli2.amount = Decimal("0.00")
+
+    agreement = MagicMock()
+    agreement.budget_line_items = [bli1, bli2]
+    agreement.procurement_shop = None
+
+    # Test
+    result = agreement_total_sort(agreement)
+
+    # Assert
+    assert result == 0
+
+
+def test_agreement_total_with_decimal_precision():
+    # Setup budget line items with precise decimals
+    bli1 = MagicMock()
+    bli1.status = BudgetLineItemStatus.PLANNED
+    bli1.amount = Decimal("100000.50")
+
+    bli2 = MagicMock()
+    bli2.status = BudgetLineItemStatus.IN_EXECUTION
+    bli2.amount = Decimal("200000.75")
+
+    agreement = MagicMock()
+    agreement.budget_line_items = [bli1, bli2]
+    agreement.procurement_shop = None
+
+    # Test
+    result = agreement_total_sort(agreement)
+
+    # Assert - total should preserve decimal precision
+    expected = Decimal("100000.50") + Decimal("200000.75")
+    assert result == expected
+
+
+def test_agreement_total_with_mixed_statuses_and_fees():
+    # Setup a mix of BLI statuses with procurement shop fee
+    bli1 = MagicMock()
+    bli1.status = BudgetLineItemStatus.PLANNED
+    bli1.amount = Decimal("100000.00")
+
+    bli2 = MagicMock()
+    bli2.status = BudgetLineItemStatus.DRAFT
+    bli2.amount = Decimal("50000.00")
+
+    bli3 = MagicMock()
+    bli3.status = BudgetLineItemStatus.IN_EXECUTION
+    bli3.amount = Decimal("200000.00")
+
+    # Setup procurement shop with fee
+    procurement_shop = MagicMock()
+    procurement_shop.fee = "0.035"  # 3.5% fee
+
+    agreement = MagicMock()
+    agreement.budget_line_items = [bli1, bli2, bli3]
+    agreement.procurement_shop = procurement_shop
+
+    # Test
+    result = agreement_total_sort(agreement)
+
+    # Assert - only non-draft BLIs should be counted, with fees applied
+    base_amount = Decimal("100000.00") + Decimal("200000.00")
+    fee_amount = base_amount * Decimal("0.035")
+    expected = base_amount + fee_amount
+    assert result == expected
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_agreement_total_sort_with_none_amount():
+    # Create mock BLIs with one having None amount
+    bli_1 = MagicMock(status=BudgetLineItemStatus.PLANNED, amount=Decimal("100.00"))
+    bli_2 = MagicMock(status=BudgetLineItemStatus.IN_EXECUTION, amount=None)  # None amount
+    bli_3 = MagicMock(status=BudgetLineItemStatus.OBLIGATED, amount=Decimal("300.00"))
+    bli_4 = MagicMock(status=BudgetLineItemStatus.DRAFT, amount=Decimal("400.00"))  # Should be excluded
+
+    # Create mock agreement with procurement shop fee
+    agreement = MagicMock(
+        budget_line_items=[bli_1, bli_2, bli_3, bli_4], procurement_shop=MagicMock(fee=Decimal("0.05"))
+    )
+
+    # Test the sort function - should skip the None amount
+    result = agreement_total_sort(agreement)
+
+    # Expected: 100 + 300 + (100 * 0.05) + (300 * 0.05) = 400 + 20 = 420
+    expected = Decimal("420.00")
+
+    assert result == expected
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_next_budget_line_sort_with_none_amount():
+    # Create mock BLIs with the 'next' one having None amount
+    today = date.today()
+    tomorrow = today + timedelta(days=1)
+    next_week = today + timedelta(days=7)
+
+    # Create BLIs with different dates and statuses
+    bli_1 = MagicMock(
+        status=BudgetLineItemStatus.PLANNED,
+        amount=Decimal("100.00"),
+        date_needed=next_week,
+        proc_shop_fee_percentage=None,
+    )
+
+    bli_2 = MagicMock(
+        status=BudgetLineItemStatus.PLANNED,
+        amount=None,  # None amount
+        date_needed=tomorrow,  # This is the next one chronologically
+        proc_shop_fee_percentage=Decimal("0.05"),
+    )
+
+    # Create mock agreement
+    agreement = MagicMock(budget_line_items=[bli_1, bli_2])
+
+    # Test the sort function - should handle None amount
+    result = next_budget_line_sort(agreement)
+
+    # Expected: 0 (since the amount is None)
+    expected = Decimal("0")
+
+    assert result == expected
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_next_budget_line_sort_with_fee_and_none_amount():
+    # Create mock BLIs with the 'next' one having None amount but has fee
+    today = date.today()
+    tomorrow = today + timedelta(days=1)
+
+    # Create BLI with None amount
+    bli = MagicMock(
+        status=BudgetLineItemStatus.PLANNED,
+        amount=None,  # None amount
+        date_needed=tomorrow,
+        proc_shop_fee_percentage=Decimal("0.05"),  # Has fee
+    )
+
+    # Create mock agreement
+    agreement = MagicMock(budget_line_items=[bli])
+
+    # Test the sort function
+    result = next_budget_line_sort(agreement)
+
+    # Expected: 0 (since multiplication with None should be handled gracefully)
+    expected = Decimal("0")
+
+    assert result == expected
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_agreement_total_sort_with_multiple_none_amounts():
+    # Create mock BLIs with multiple None amounts
+    bli_1 = MagicMock(status=BudgetLineItemStatus.PLANNED, amount=None)
+    bli_2 = MagicMock(status=BudgetLineItemStatus.IN_EXECUTION, amount=None)
+    bli_3 = MagicMock(status=BudgetLineItemStatus.OBLIGATED, amount=Decimal("300.00"))
+
+    # Create mock agreement with procurement shop fee
+    agreement = MagicMock(budget_line_items=[bli_1, bli_2, bli_3], procurement_shop=MagicMock(fee=Decimal("0.05")))
+
+    # Test the sort function - should skip the None amounts
+    result = agreement_total_sort(agreement)
+
+    # Expected: 300 + (300 * 0.05) = 300 + 15 = 315
+    expected = Decimal("315.00")
+
+    assert result == expected
+
+
+@pytest.mark.usefixtures("app_ctx")
+def test_agreement_total_sort_with_all_none_amounts():
+    # Create mock BLIs with all None amounts
+    bli_1 = MagicMock(status=BudgetLineItemStatus.PLANNED, amount=None)
+    bli_2 = MagicMock(status=BudgetLineItemStatus.IN_EXECUTION, amount=None)
+
+    # Create mock agreement with procurement shop fee
+    agreement = MagicMock(budget_line_items=[bli_1, bli_2], procurement_shop=MagicMock(fee=Decimal("0.05")))
+
+    # Test the sort function - all amounts are None
+    result = agreement_total_sort(agreement)
+
+    # Expected: 0 (since all amounts are None)
+    expected = Decimal("0")
+
+    assert result == expected


### PR DESCRIPTION
## What changed

Fixes for production bug for when a budget line has a `NULL` amount.

## Issue

https://github.com/HHS/OPRE-OPS/issues/3930

## How to test

Automated tests pass and table sorting still works.

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated
