### PR TITLE
fix: ♻️ display 'TBD' when totalFunding or totalReceived is 0

### DIFF
--- a/frontend/src/components/CANs/CANTable/CANTableRow.jsx
+++ b/frontend/src/components/CANs/CANTable/CANTableRow.jsx
@@ -4,6 +4,7 @@ import { useGetCanFundingSummaryQuery } from "../../../api/opsAPI";
 import { getDecimalScale } from "../../../helpers/currencyFormat.helpers";
 import Tooltip from "../../UI/USWDS/Tooltip";
 import { displayActivePeriod } from "./CANTableRow.helpers";
+import { NO_DATA } from "../../../constants";
 
 /**
  * CanTableRow component of CANTable
@@ -60,6 +61,7 @@ const CANTableRow = ({ activePeriod, canId, fiscalYear, name, nickname, obligate
             <td>{displayActivePeriod(activePeriod)}</td>
             <td>{obligateBy}</td>
             <td>
+                {totalFunding > 0 ? (
                 <CurrencyFormat
                     value={totalFunding}
                     displayType={"text"}
@@ -68,6 +70,9 @@ const CANTableRow = ({ activePeriod, canId, fiscalYear, name, nickname, obligate
                     decimalScale={getDecimalScale(totalFunding)}
                     fixedDecimalScale={true}
                 />
+                ) : (
+                    <span className="text-ink">{NO_DATA}</span>
+                )}
             </td>
             {fundingReceived === 0 ? (
                 <td>TBD</td>

--- a/frontend/src/components/CANs/CANTable/CANTableRow.test.jsx
+++ b/frontend/src/components/CANs/CANTable/CANTableRow.test.jsx
@@ -121,4 +121,45 @@ describe("CANTableRow", () => {
         expect(screen.getByTestId("tooltip")).toBeInTheDocument();
         expect(screen.getByText("Test CAN")).toBeInTheDocument();
     });
+
+    it("renders TBD when totalFunding is 0", () => {
+        useGetCanFundingSummaryQuery.mockReturnValue({
+            data: { available_funding: 100_000, received_funding: 50_000, total_funding: 0 },
+            isLoading: false,
+            isError: false
+        });
+
+        render(
+            <MemoryRouter>
+                <table>
+                    <tbody>
+                        <CANTableRow {...mockProps} />
+
+                    </tbody>
+                </table>
+            </MemoryRouter>
+        );
+        expect(screen.getByText("TBD")).toBeInTheDocument();
+    });
+
+    it("renders TBD when totalReceived is 0", () => {
+        useGetCanFundingSummaryQuery.mockReturnValue({
+            data: { available_funding: 100_000, received_funding: 0, total_funding: 100_000 },
+            isLoading: false,
+            isError: false
+        });
+
+        render(
+            <MemoryRouter>
+                <table>
+                    <tbody>
+                        <CANTableRow {...mockProps} />
+
+                    </tbody>
+                </table>
+            </MemoryRouter>
+        );
+        expect(screen.getByText("TBD")).toBeInTheDocument();
+    });
+
 });


### PR DESCRIPTION
## What changed

Fix UI display to show 'TBD' when total funding or funding received is zero; adds NO_DATA constant usage and unit tests for these scenarios.

- Import and use NO_DATA for zero total funding in the table row.
- Add tests to verify "TBD" shows when total_funding or received_funding is 0.
- Retain existing conditional rendering for funding received.

## Issue

- closes #3862 

## How to test

1. tests pass or
1. look over steps in 3862

## Screenshots

<img width="2244" alt="image" src="https://github.com/user-attachments/assets/aa98c4ed-775f-42c3-bda1-567575229c28" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
