### PR TITLE
refactor: update prop types and improve default values across components

### DIFF
--- a/frontend/src/components/Agreements/AgreementDetailsCards/AgreementTotalCard/AgreementTotalCard.jsx
+++ b/frontend/src/components/Agreements/AgreementDetailsCards/AgreementTotalCard/AgreementTotalCard.jsx
@@ -1,7 +1,6 @@
-import PropTypes from "prop-types";
-import CurrencyCard from "../../../UI/Cards/CurrencyCard";
 import CurrencyFormat from "react-currency-format";
 import { getDecimalScale } from "../../../../helpers/currencyFormat.helpers";
+import CurrencyCard from "../../../UI/Cards/CurrencyCard";
 
 /**
  * Renders a card displaying the agreement total, subtotal, fees, and procurement shop information.
@@ -9,9 +8,9 @@ import { getDecimalScale } from "../../../../helpers/currencyFormat.helpers";
  * @param {number} props.total - The total amount of the agreement.
  * @param {number} props.subtotal - The subtotal amount of the agreement.
  * @param {number} props.fees - The fees amount of the agreement.
- * @param {string} props.procurementShopAbbr - The abbreviation of the procurement shop.
- * @param {number} props.procurementShopFee - The fee rate of the procurement shop.
- * @returns {React.JSX.Element} - The JSX element representing the agreement total card.
+ * @param {string} [props.procurementShopAbbr] - The abbreviation of the procurement shop.
+ * @param {number} [props.procurementShopFee] - The fee rate of the procurement shop.
+ * @returns {React.ReactElement} - The JSX element representing the agreement total card.
  */
 const AgreementTotalCard = ({ total, subtotal, fees, procurementShopAbbr = "TBD", procurementShopFee = 0 }) => {
     return (
@@ -68,14 +67,6 @@ const AgreementTotalCard = ({ total, subtotal, fees, procurementShopAbbr = "TBD"
             </CurrencyCard>
         </div>
     );
-};
-
-AgreementTotalCard.propTypes = {
-    total: PropTypes.number.isRequired,
-    subtotal: PropTypes.number.isRequired,
-    fees: PropTypes.number.isRequired,
-    procurementShopAbbr: PropTypes.string.isRequired,
-    procurementShopFee: PropTypes.number.isRequired
 };
 
 export default AgreementTotalCard;

--- a/frontend/src/components/Agreements/AgreementMetaAccordion/AgreementMetaAccordion.jsx
+++ b/frontend/src/components/Agreements/AgreementMetaAccordion/AgreementMetaAccordion.jsx
@@ -12,7 +12,7 @@ import Term from "../../UI/Term";
  * @param {Object} [props.cn] - The classnames object.
  * @param {Function} props.convertCodeForDisplay - The function to convert codes for display.
  * @param {string} props.instructions - The instruction text of the agreement.
- * @returns {JSX.Element} - The rendered component.
+ * @returns {React.ReactElement} - The rendered component.
  */
 const AgreementMetaAccordion = ({
     agreement,
@@ -31,7 +31,8 @@ const AgreementMetaAccordion = ({
      * @param {string} name - The name of the input field.
      * @param {string} [label] - The label to display for the input field (optional)..
      * @param {string|number} [value] - The value of the input field (optional).
-     * @returns {JSX.Element} - The rendered input component.
+     * @returns {React.ReactElement} - The rendered Term component.
+     * @private
      */
     const renderTerm = (name, label, value) => (
         <Term

--- a/frontend/src/components/Agreements/ProcurementShopSelect/ProcurementShopSelect.jsx
+++ b/frontend/src/components/Agreements/ProcurementShopSelect/ProcurementShopSelect.jsx
@@ -2,19 +2,11 @@ import { useEffect, useState } from "react";
 import { useGetProcurementShopsQuery } from "../../../api/opsAPI";
 import ErrorPage from "../../../pages/ErrorPage";
 
-/**
- * Object representing a procurement shop.
- * @typedef {Object} selectedProcurementShop - The currently selected procurement shop.
- * @property {string} id - The procurement shop id.
- * @property {number} fee - The procurement shop fee rate.
- * @property {string} name - The procurement shop name.
- * @property {string} abbr - The procurement shop abbreviation.
- */
-
+/**  @typedef {import("../../../types/AgreementTypes").ProcurementShop} ProcurementShop */
 /**
  * A select input for choosing a procurement shop.
  * @param {Object} props - The component props.
- * @param {selectedProcurementShop} props.selectedProcurementShop - The currently selected procurement shop object.
+ * @param {ProcurementShop} props.selectedProcurementShop - The currently selected procurement shop object.
  * @param {Function} props.onChangeSelectedProcurementShop - A function to call when the selected procurement shop changes.
  * @param {string} [props.legendClassname] - Additional CSS classes to apply to the label/legend (optional).
  * @param {string} [props.defaultString] - Initial text to display in select (optional).
@@ -31,7 +23,7 @@ export const ProcurementShopSelect = ({
     isFilter = false
 }) => {
     const [hasSelectedDefault, setHasSelectedDefault] = useState(defaultToGCS);
-
+    /** @type {{data?: ProcurementShop[] | undefined, error?: Object,  isLoading: boolean}} */
     const {
         data: procurementShops,
         error: errorProcurementShops,
@@ -53,6 +45,8 @@ export const ProcurementShopSelect = ({
 
     const handleChange = (e) => {
         const procurementShopId = e.target.value;
+
+        if (!procurementShops) return;
 
         const procurementShop = {
             id: procurementShops[procurementShopId - 1].id,
@@ -84,7 +78,7 @@ export const ProcurementShopSelect = ({
                     required
                 >
                     <option value={0}>{defaultString}</option>
-                    {procurementShops.map((shop) => (
+                    {procurementShops?.map((shop) => (
                         <option
                             key={shop?.id}
                             value={shop?.id}

--- a/frontend/src/components/Agreements/ProcurementShopSelectWithFee/ProcurementShopSelectWithFee.jsx
+++ b/frontend/src/components/Agreements/ProcurementShopSelectWithFee/ProcurementShopSelectWithFee.jsx
@@ -1,21 +1,13 @@
 import ProcurementShopSelect from "../ProcurementShopSelect";
 
-/**
- * Object representing a procurement shop.
- * @typedef {Object} selectedProcurementShop - The currently selected procurement shop.
- * @property {string} id - The procurement shop id.
- * @property {number} fee - The procurement shop fee rate.
- * @property {string} name - The procurement shop name.
- * @property {string} abbr - The procurement shop abbreviation.
- */
-
+/**  @typedef {import("../../../types/AgreementTypes").ProcurementShop} ProcurementShop */
 /**
  * A select input for choosing a procurement shop.
  * @param {Object} props - The component props.
- * @param {selectedProcurementShop} props.selectedProcurementShop - The currently selected procurement shop object.
+ * @param {ProcurementShop} props.selectedProcurementShop - The currently selected procurement shop object.
  * @param {Function} props.onChangeSelectedProcurementShop - A function to call when the selected procurement shop changes.
  * @param {string} [props.legendClassname] - Additional CSS classes to apply to the label/legend (optional).
- * @returns {JSX.Element} - The procurement shop select element.
+ * @returns {React.JSX.Element} - The procurement shop select element with fee display.
  */
 export const ProcurementShopSelectWithFee = ({
     selectedProcurementShop,

--- a/frontend/src/components/Agreements/ProcurementShopSelectWithFee/ProcurementShopSelectWithFee.jsx
+++ b/frontend/src/components/Agreements/ProcurementShopSelectWithFee/ProcurementShopSelectWithFee.jsx
@@ -7,7 +7,7 @@ import ProcurementShopSelect from "../ProcurementShopSelect";
  * @param {ProcurementShop} props.selectedProcurementShop - The currently selected procurement shop object.
  * @param {Function} props.onChangeSelectedProcurementShop - A function to call when the selected procurement shop changes.
  * @param {string} [props.legendClassname] - Additional CSS classes to apply to the label/legend (optional).
- * @returns {React.JSX.Element} - The procurement shop select element with fee display.
+ * @returns {React.ReactElement} - The procurement shop select element with fee display.
  */
 export const ProcurementShopSelectWithFee = ({
     selectedProcurementShop,
@@ -19,6 +19,7 @@ export const ProcurementShopSelectWithFee = ({
      * @param {Object} props - The component props.
      * @param {selectedProcurementShop} props.selectedProcurementShop - The selected procurement shop object.
      * @returns {React.JSX.Element | undefined} - The fee rate element, or null if no procurement shop is selected.
+     * @private
      */
     const FeeRate = ({ selectedProcurementShop }) => {
         if (selectedProcurementShop?.id) {

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
@@ -25,7 +25,7 @@ import useCreateBLIsAndSCs from "./CreateBLIsAndSCs.hooks";
  * @param {number} props.currentStep - The index of the current step in the flow.
  * @param {import("../../../types/ProjectTypes").Project} [props.selectedResearchProject] - The selected research project.
  * @param {import("../../../types/AgreementTypes").Agreement} [props.selectedAgreement] - The selected agreement.
- * @param {import("../../../types/AgreementTypes").ProcurementShop}[ props.selectedProcurementShop] - The selected procurement shop.
+ * @param {import("../../../types/AgreementTypes").ProcurementShop} [props.selectedProcurementShop] - The selected procurement shop.
  * @param {import("../../../types/BudgetLineTypes").BudgetLine[]} props.budgetLines - The selected Agreements budget lines.
  * @param {string} props.continueBtnText - The text to display on the "Continue" button.
  * @param {boolean} props.isEditMode - Whether the form is in edit mode.

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
@@ -23,9 +23,9 @@ import useCreateBLIsAndSCs from "./CreateBLIsAndSCs.hooks";
  * @param {Object} [props.formData] - The form data.
  * @param {string[]} props.wizardSteps - An array of objects representing the steps in the flow.
  * @param {number} props.currentStep - The index of the current step in the flow.
- * @param {import("../../../types/ProjectTypes").Project} props.selectedResearchProject - The selected research project.
- * @param {import("../../../types/AgreementTypes").Agreement} props.selectedAgreement - The selected agreement.
- * @param {import("../../../types/AgreementTypes").ProcurementShop} props.selectedProcurementShop - The selected procurement shop.
+ * @param {import("../../../types/ProjectTypes").Project} [props.selectedResearchProject] - The selected research project.
+ * @param {import("../../../types/AgreementTypes").Agreement} [props.selectedAgreement] - The selected agreement.
+ * @param {import("../../../types/AgreementTypes").ProcurementShop}[ props.selectedProcurementShop] - The selected procurement shop.
  * @param {import("../../../types/BudgetLineTypes").BudgetLine[]} props.budgetLines - The selected Agreements budget lines.
  * @param {string} props.continueBtnText - The text to display on the "Continue" button.
  * @param {boolean} props.isEditMode - Whether the form is in edit mode.

--- a/frontend/src/components/Projects/ProjectAgreementSummaryCard/ProjectAgreementSummaryCard.jsx
+++ b/frontend/src/components/Projects/ProjectAgreementSummaryCard/ProjectAgreementSummaryCard.jsx
@@ -1,14 +1,23 @@
-import PropTypes from "prop-types";
+/**
+ * @typedef {import("../../../types/ProjectTypes").ResearchProject} ResearchProject
+ * @typedef {import("../../../types/AgreementTypes").Agreement} Agreement
+ * @typedef {import("../../../types/AgreementTypes").ProcurementShop} ProcurementShop
+ */
 
+/**
+ * Displays a summary card with project, agreement, and procurement shop details.
+ *
+ * @param {object} props - The component's props.
+ * @param {ResearchProject} props.selectedResearchProject The selected research project object.
+ * @param {Agreement} props.selectedAgreement - The selected agreement object.
+ * @param {ProcurementShop} props.selectedProcurementShop - The selected procurement shop object.
+ * @returns {React.ReactElement} - The rendered summary card component.
+ */
 export const ProjectAgreementSummaryCard = ({
-    selectedResearchProject = {},
-    selectedAgreement = {},
-    selectedProcurementShop = {}
+    selectedResearchProject,
+    selectedAgreement,
+    selectedProcurementShop
 }) => {
-    const { title } = selectedResearchProject;
-    const { name: agreementName } = selectedAgreement;
-    const { fee_percentage, name: procurementShopName } = selectedProcurementShop;
-
     return (
         <div
             className="bg-base-lightest font-family-sans border-1px border-base-light radius-sm margin-y-7"
@@ -20,7 +29,7 @@ export const ProjectAgreementSummaryCard = ({
                     className="margin-0 text-bold margin-top-1"
                     style={{ fontSize: "1.375rem" }}
                 >
-                    {title}
+                    {selectedResearchProject?.title}
                 </dd>
                 {selectedAgreement?.name && (
                     <>
@@ -29,7 +38,7 @@ export const ProjectAgreementSummaryCard = ({
                             className="margin-0 text-bold margin-top-1"
                             style={{ fontSize: "1.375rem" }}
                         >
-                            {agreementName}
+                            {selectedAgreement.name}
                         </dd>
                     </>
                 )}
@@ -37,32 +46,15 @@ export const ProjectAgreementSummaryCard = ({
             <dl className="display-flex margin-top-205 font-12px padding-x-3">
                 <div>
                     <dt className="margin-0 text-base-dark">Procurement Shop</dt>
-                    <dd className="margin-0 text-semibold">{procurementShopName}</dd>
+                    <dd className="margin-0 text-semibold">{selectedProcurementShop?.name}</dd>
                 </div>
                 <div className="margin-left-5">
                     <dt className="margin-0 text-base-dark">Fee Rate</dt>
-                    <dd className="margin-0 text-semibold">{fee_percentage && `${fee_percentage}`}%</dd>
+                    <dd className="margin-0 text-semibold">{selectedProcurementShop?.fee_percentage}%</dd>
                 </div>
             </dl>
         </div>
     );
-};
-
-ProjectAgreementSummaryCard.propTypes = {
-    selectedResearchProject: PropTypes.shape({
-        title: PropTypes.string
-    }),
-    selectedAgreement: PropTypes.oneOfType([
-        PropTypes.shape({
-            name: PropTypes.string
-        }),
-        PropTypes.number
-    ]),
-
-    selectedProcurementShop: PropTypes.shape({
-        name: PropTypes.string,
-        fee: PropTypes.number
-    })
 };
 
 export default ProjectAgreementSummaryCard;

--- a/frontend/src/helpers/budgetLines.helpers.js
+++ b/frontend/src/helpers/budgetLines.helpers.js
@@ -62,7 +62,7 @@ export const getBudgetLineCreatedDate = (budgetLine) => {
  */
 export const budgetLinesTotal = (budgetLines) => {
     handleBLIArrayProp(budgetLines);
-    return budgetLines?.reduce((n, { amount }) => n + (amount || 0), 0);
+    return budgetLines.reduce((n, { amount }) => n + (amount || 0), 0);
 };
 
 /**

--- a/frontend/src/helpers/budgetLines.helpers.js
+++ b/frontend/src/helpers/budgetLines.helpers.js
@@ -1,12 +1,6 @@
 import { getTypesCounts } from "../pages/cans/detail/Can.helpers";
 import { formatDateToMonthDayYear } from "./utils";
-/**
- * @typedef {Object} BudgetLine
- * @property {number} id - The ID of the budget line.
- * @property {string} status - The status of the budget line.
- * @property {number} created_by - The ID of the user who created the budget line.
- * @property {boolean} in_review - Whether the budget line is in review.
- */
+/** @typedef {import("../types/BudgetLineTypes").BudgetLine} BudgetLine */
 
 /**
  * Enum representing the possible statuses of a budget line item.
@@ -36,6 +30,17 @@ const handleBLIProp = (budgetLine) => {
 };
 
 /**
+ * Validates if the given budget lines parameter is an array.
+ * @param {BudgetLine[]} budgetLines - The budget lines array to validate.
+ * @throws {Error} Will throw an error if the budget lines parameter is not an array.
+ */
+const handleBLIArrayProp = (budgetLines) => {
+    if (!Array.isArray(budgetLines)) {
+        throw new Error(`BudgetLines must be an array, but got ${typeof budgetLines}`);
+    }
+};
+
+/**
  * Returns the created date of a budget line in a formatted string.
  * If the budget line does not have a created_on property, returns today's date in a formatted string.
  *
@@ -53,11 +58,11 @@ export const getBudgetLineCreatedDate = (budgetLine) => {
 /**
  * Returns the total amount of a budget line.
  * @param {BudgetLine[]} budgetLines - The budget line to get the total amount from.
- * @returns {Object | null} The total amount of the budget line.
+ * @returns {number} The total amount of the budget line.
  */
 export const budgetLinesTotal = (budgetLines) => {
-    handleBLIProp(budgetLines);
-    return budgetLines?.reduce((n, { amount }) => n + amount, 0);
+    handleBLIArrayProp(budgetLines);
+    return budgetLines?.reduce((n, { amount }) => n + (amount || 0), 0);
 };
 
 /**
@@ -67,7 +72,7 @@ export const budgetLinesTotal = (budgetLines) => {
  * @returns {BudgetLine[]} An array of budget lines filtered by status.
  */
 export const getBudgetByStatus = (budgetLines, status) => {
-    handleBLIProp(budgetLines);
+    handleBLIArrayProp(budgetLines);
     return budgetLines?.filter((bli) => status.includes(bli.status));
 };
 
@@ -77,7 +82,7 @@ export const getBudgetByStatus = (budgetLines, status) => {
  * @returns {BudgetLine[]} An array of budget lines that are not in draft status.
  */
 export const getNonDRAFTBudgetLines = (budgetLines) => {
-    handleBLIProp(budgetLines);
+    handleBLIArrayProp(budgetLines);
     return budgetLines?.filter((bli) => bli.status !== BLI_STATUS.DRAFT);
 };
 
@@ -87,7 +92,7 @@ export const getNonDRAFTBudgetLines = (budgetLines) => {
  * @returns {boolean} Whether any of the budget lines are in review.
  */
 export const hasBlIsInReview = (budgetLines) => {
-    handleBLIProp(budgetLines);
+    handleBLIArrayProp(budgetLines);
     return budgetLines?.some((bli) => bli.in_review);
 };
 
@@ -97,7 +102,7 @@ export const hasBlIsInReview = (budgetLines) => {
  * @returns {boolean} Whether any of the budget lines are obligated.
  */
 export const hasBlIsObligated = (budgetLines) => {
-    handleBLIProp(budgetLines);
+    handleBLIArrayProp(budgetLines);
     return budgetLines?.some((bli) => bli.status === BLI_STATUS.OBLIGATED);
 };
 
@@ -108,7 +113,8 @@ export const hasBlIsObligated = (budgetLines) => {
  */
 export const groupByServicesComponent = (budgetLines) => {
     try {
-        handleBLIProp(budgetLines);
+        handleBLIArrayProp(budgetLines);
+
         return budgetLines
             .reduce((acc, budgetLine) => {
                 const servicesComponentId = budgetLine.services_component_id;

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
@@ -64,7 +64,7 @@ const AgreementBudgetLines = ({
         let month = date_needed.getMonth();
         let year = date_needed.getFullYear();
         let fiscalYear = month > 8 ? year + 1 : year;
-        let amount = bl?.amount;
+        let amount = bl?.amount ?? 0;
         let fee = amount * bl?.proc_shop_fee_percentage;
         let total = amount + fee;
         let status = bl?.status.charAt(0).toUpperCase() + bl?.status.slice(1).toLowerCase();
@@ -89,7 +89,7 @@ const AgreementBudgetLines = ({
     const agreementTotal = totals.Agreement.total;
     const agreementSubtotal = totals.Agreement.subtotal;
     const agreementFees = totals.Agreement.fees;
-    const groupedBudgetLinesByServicesComponent = groupByServicesComponent(agreement?.budget_line_items);
+    const groupedBudgetLinesByServicesComponent = groupByServicesComponent(agreement?.budget_line_items ?? []);
 
     return (
         <>
@@ -126,7 +126,7 @@ const AgreementBudgetLines = ({
             {isEditMode && (
                 <CreateBLIsAndSCs
                     selectedAgreement={agreement}
-                    budgetLines={agreement?.budget_line_items}
+                    budgetLines={agreement?.budget_line_items ?? []}
                     isEditMode={isEditMode}
                     setIsEditMode={setIsEditMode}
                     isReviewMode={false}

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
@@ -65,7 +65,7 @@ const AgreementBudgetLines = ({
         let year = date_needed.getFullYear();
         let fiscalYear = month > 8 ? year + 1 : year;
         let amount = bl?.amount ?? 0;
-        let fee = amount * bl?.proc_shop_fee_percentage;
+        let fee = amount * (bl?.proc_shop_fee_percentage ?? 0);
         let total = amount + fee;
         let status = bl?.status.charAt(0).toUpperCase() + bl?.status.slice(1).toLowerCase();
 


### PR DESCRIPTION
This PR refactors prop-type handling by replacing PropTypes with JSDoc imports, adds nullish defaults for potentially undefined values, and tightens helper validations.

- Use `??` defaults for amounts and arrays to avoid `undefined`
- Swap out PropTypes for imported JSDoc typedefs
- Add runtime checks in helper functions to validate array inputs