### PR TITLE
fix: simplify effect and update prop types

### DIFF
--- a/frontend/src/components/Projects/ProjectSelectWithSummaryCard/ProjectSelectWithSummaryCard.jsx
+++ b/frontend/src/components/Projects/ProjectSelectWithSummaryCard/ProjectSelectWithSummaryCard.jsx
@@ -1,19 +1,38 @@
-import PropTypes from "prop-types";
-import ProjectComboBox from "../ProjectComboBox";
 import { useEffect } from "react";
+import ProjectComboBox from "../ProjectComboBox";
 
-export const ProjectSelectWithSummaryCard = ({
+/**
+ * A component that renders a project selection dropdown with a summary card.
+ * When a project is selected, it displays the project details in a card format.
+ *
+ * @param {Object} props - The component props
+ * @param {import("../../../types/ProjectTypes").ResearchProject[]} props.researchProjects - Array of available research projects to select from
+ * @param {import("../../../types/ProjectTypes").ResearchProject} props.selectedResearchProject - The currently selected research project object
+ * @param {Function} props.setSelectedProject - Callback function to update the selected project
+ * @param {Function} [props.setAgreementProjectId] - Optional callback to set the agreement project ID when selection changes
+ * @returns {React.ReactElement} A flex container with project selection dropdown and summary card
+ */
+const ProjectSelectWithSummaryCard = ({
     researchProjects,
     selectedResearchProject,
     setSelectedProject,
     setAgreementProjectId
 }) => {
     useEffect(() => {
-        if (setAgreementProjectId) {
-            setAgreementProjectId(selectedResearchProject?.id);
-        }
-    }, [selectedResearchProject, setAgreementProjectId]);
+        setAgreementProjectId?.(selectedResearchProject?.id);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedResearchProject]);
 
+    /**
+     * A card component that displays a summary of a selected research project.
+     * Shows the project title and optional description in a styled card layout.
+     *
+     * @component
+     * @param {Object} props - The component props
+     * @param {import("../../../types/ProjectTypes").ResearchProject} props.selectedResearchProject - The research project object to display
+     * @private
+     * @returns {React.ReactElement} A card displaying the project title and description
+     */
     const ProjectSummaryCard = ({ selectedResearchProject }) => {
         const { title, description } = selectedResearchProject;
         return (
@@ -37,12 +56,7 @@ export const ProjectSelectWithSummaryCard = ({
             </div>
         );
     };
-    ProjectSummaryCard.propTypes = {
-        selectedResearchProject: PropTypes.shape({
-            title: PropTypes.string.isRequired,
-            description: PropTypes.string
-        }).isRequired
-    };
+
     return (
         <div className="display-flex flex-justify padding-top-105">
             {/* NOTE: Left side */}
@@ -64,10 +78,3 @@ export const ProjectSelectWithSummaryCard = ({
 };
 
 export default ProjectSelectWithSummaryCard;
-
-ProjectSelectWithSummaryCard.propTypes = {
-    researchProjects: PropTypes.array.isRequired,
-    selectedResearchProject: PropTypes.object.isRequired,
-    setSelectedProject: PropTypes.func.isRequired,
-    setAgreementProjectId: PropTypes.func
-};

--- a/frontend/src/components/Projects/ProjectSelectWithSummaryCard/ProjectSelectWithSummaryCard.jsx
+++ b/frontend/src/components/Projects/ProjectSelectWithSummaryCard/ProjectSelectWithSummaryCard.jsx
@@ -19,7 +19,9 @@ const ProjectSelectWithSummaryCard = ({
     setAgreementProjectId
 }) => {
     useEffect(() => {
-        setAgreementProjectId?.(selectedResearchProject?.id);
+        if (selectedResearchProject?.id) {
+            setAgreementProjectId?.(selectedResearchProject.id);
+        }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [selectedResearchProject]);
 


### PR DESCRIPTION
## What changed


## Pull Request Overview

This PR refactors `ProjectSelectWithSummaryCard` by replacing PropTypes with JSDoc/TypeScript imports and simplifying the side‐effect logic.

- Replaced all `propTypes` usage with JSDoc comments importing TS types.
- Simplified the `useEffect` to call `setAgreementProjectId` via optional chaining.
- Cleaned up import ordering and removed the PropTypes import.
- Dependency array in the component was causing a glitch. I believe this was introduced by #3958.

## Issue

#3958

## How to test

1. goto create an Agreement wizard
2. look in the console
3. do not see any useEffect errors

## Screenshots

![SCR-20250530-itkx](https://github.com/user-attachments/assets/3221e408-9b1d-4326-94d0-ed17a6d7e77d)

## Definition of Done Checklist
- [-] OESA: Code refactored for clarity
- [-] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
