### PR TITLE
Removes prohibition on renovate updating marshmallow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,12 +41,11 @@
     },
     "packageRules": [
         {
-            "matchPackageNames": ["python", "marshmallow"],
+            "matchPackageNames": ["python"],
             "enabled": false
         },
         {
             "matchPackageNames": [
-                "marshmallow",
                 "python"
             ],
             "enabled": false,


### PR DESCRIPTION
## What changed

Given @rajohnson90's great work to alleviate the breaking changes from Marshmallow 4, we no longer need to have renovate artificially ignoring any updates to marshmallow. This essentially reverses part of #3909

## Issue

#3898

## How to test

Let renovate run according to its schedule or force a manual run and note the logs

## Screenshots

N/A

## Definition of Done Checklist
~- [ ] OESA: Code refactored for clarity~
~- [ ] OESA: Dependency rules followed~
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~
