### PR TITLE
fix: fixes Vite domain comparison

### DIFF
--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -20,7 +20,8 @@ export default defineConfig(({ mode }) => {
             strictPort: true,
             cors: {
                 origin: function (origin, callback) {
-                    if (origin === JSON.stringify(VITE_BACKEND_DOMAIN)) {
+                    // Remove JSON.stringify - it was wrapping the domain in quotes
+                    if (origin === VITE_BACKEND_DOMAIN) {
                         callback(null, false); // disable CORS for backend domain
                     } else {
                         callback(null, true); // enable CORS for other origins


### PR DESCRIPTION
## What changed

The `JSON.stringify(VITE_BACKEND_DOMAIN)` was incorrect and would cause the domain comparison to fail.

## How to test

- e2e tests pass

## Screenshots

![SCR-20250708-hnfm](https://github.com/user-attachments/assets/f3ef0117-d165-4834-b8ff-b659087beb5b)


## Definition of Done Checklist
- [-] OESA: Code refactored for clarity
- [-] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [-] Form validations updated