### PR TITLE
fix: procurement shop default option handling

### DIFF
--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -151,11 +151,7 @@ const AgreementEditForm = ({
     let res = suite.get();
 
     const vendorDisabled = agreementReason === "NEW_REQ" || agreementReason === null || agreementReason === "0";
-    const shouldDisableBtn =
-        !agreementTitle ||
-        !agreementType ||
-        res.hasErrors() ||
-        (isCreatingAgreement && selectedProcurementShop.id !== 2);
+    const shouldDisableBtn = !agreementTitle || !agreementType || res.hasErrors();
 
     const cn = classnames(suite.get(), {
         invalid: "usa-form-group--error",
@@ -325,7 +321,7 @@ const AgreementEditForm = ({
 
     const handleOnChangeSelectedProcurementShop = (procurementShop) => {
         setSelectedProcurementShop(procurementShop);
-        setAgreementProcurementShopId(procurementShop.id);
+        setAgreementProcurementShopId(procurementShop?.id);
     };
 
     const runValidate = (name, value) => {

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditorContext.hooks.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditorContext.hooks.js
@@ -23,7 +23,7 @@ export const defaultState = {
         team_members: [],
         notes: "",
         project_id: undefined,
-        awarding_entity_id: undefined,
+        awarding_entity_id: defaultProcurementShop.id,
         contract_type: undefined,
         service_requirement_type: SERVICE_REQ_TYPES.NON_SEVERABLE
     },

--- a/frontend/src/components/Agreements/ProcurementShopSelect/ProcurementShopSelect.jsx
+++ b/frontend/src/components/Agreements/ProcurementShopSelect/ProcurementShopSelect.jsx
@@ -39,10 +39,13 @@ const ProcurementShopSelect = ({
 
     const handleChange = (e) => {
         const procurementShopId = e.target.value;
+        console.log({ procurementShopId });
 
         if (!procurementShops) return;
 
-        onChangeSelectedProcurementShop(procurementShops[procurementShopId - 1]);
+        onChangeSelectedProcurementShop(
+            procurementShopId === "0" ? undefined : procurementShops[procurementShopId - 1]
+        );
     };
 
     return (
@@ -82,7 +85,7 @@ const ProcurementShopSelect = ({
                             id="procurement-shop-select"
                             onChange={handleChange}
                             value={selectedProcurementShop?.id || 0}
-                            required
+                            // required
                         >
                             <option value={0}>{defaultString}</option>
                             {procurementShops?.map((shop) => (

--- a/frontend/src/components/Agreements/ProcurementShopSelect/ProcurementShopSelect.jsx
+++ b/frontend/src/components/Agreements/ProcurementShopSelect/ProcurementShopSelect.jsx
@@ -39,7 +39,6 @@ const ProcurementShopSelect = ({
 
     const handleChange = (e) => {
         const procurementShopId = e.target.value;
-        console.log({ procurementShopId });
 
         if (!procurementShops) return;
 

--- a/frontend/src/components/Agreements/ProcurementShopSelect/ProcurementShopSelect.jsx
+++ b/frontend/src/components/Agreements/ProcurementShopSelect/ProcurementShopSelect.jsx
@@ -84,7 +84,6 @@ const ProcurementShopSelect = ({
                             id="procurement-shop-select"
                             onChange={handleChange}
                             value={selectedProcurementShop?.id || 0}
-                            // required
                         >
                             <option value={0}>{defaultString}</option>
                             {procurementShops?.map((shop) => (

--- a/frontend/src/components/Projects/ProjectAgreementSummaryCard/ProjectAgreementSummaryCard.jsx
+++ b/frontend/src/components/Projects/ProjectAgreementSummaryCard/ProjectAgreementSummaryCard.jsx
@@ -4,6 +4,8 @@
  * @typedef {import("../../../types/AgreementTypes").ProcurementShop} ProcurementShop
  */
 
+import { NO_DATA } from "../../../constants";
+
 /**
  * Displays a summary card with project, agreement, and procurement shop details.
  *
@@ -46,12 +48,14 @@ export const ProjectAgreementSummaryCard = ({
             <dl className="display-flex margin-top-205 font-12px padding-x-3">
                 <div>
                     <dt className="margin-0 text-base-dark">Procurement Shop</dt>
-                    <dd className="margin-0 text-semibold">{selectedProcurementShop?.abbr}</dd>
+                    <dd className="margin-0 text-semibold">{selectedProcurementShop?.abbr ?? NO_DATA}</dd>
                 </div>
                 <div className="margin-left-5">
                     <dt className="margin-0 text-base-dark">Current Fee Rate</dt>
                     <dd className="margin-0 text-semibold">
-                        {selectedProcurementShop?.fee_percentage ?? selectedProcurementShop?.fee}%
+                        {selectedProcurementShop?.fee_percentage
+                            ? `${selectedProcurementShop?.fee_percentage}%`
+                            : NO_DATA}
                     </dd>
                 </div>
             </dl>

--- a/frontend/src/pages/agreements/details/AgreementDetailsView.jsx
+++ b/frontend/src/pages/agreements/details/AgreementDetailsView.jsx
@@ -147,7 +147,7 @@ const AgreementDetailsView = ({ agreement, projectOfficer, alternateProjectOffic
                                 <Tag
                                     dataCy="procurement-shop-tag"
                                     tagStyle="primaryDarkTextLightBackground"
-                                    text={agreement?.procurement_shop?.abbr}
+                                    text={agreement?.procurement_shop?.abbr ?? NO_DATA}
                                 />
                             </dd>
                         </dl>


### PR DESCRIPTION
## What changed

This PR updates how the procurement shop default option is handled throughout the agreement creating wizard, ensuring that both the “default” and “no proc shop” cases display correctly and allow agreement creation.

## How to test

1. go through the creating agreement wizard
2. use default proc shop 
3. should allow creating an agreement.
4. go through the creating agreement wizard
5. use no proc shop
6. should allow creating an agreement.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated
