### PR TITLE
Adding a renovate linter in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,7 @@ repos:
         stages: [commit-msg]
         additional_dependencies: ["@commitlint/config-conventional"]
         language_version: 22.8.0
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 41.23.5
+    hooks:
+      - id: renovate-config-validator


### PR DESCRIPTION
## What changed

Adds a pre-commit hook to lint the renovate bot config file(s) if changed. 

**You'll want to run `pre-commit` locally at the repo root.**

## Issue

No existing issue really, but I do credit the scholar and a gentleman, @tomwillis608 for advertising this discovery and being the change agent he is. 

## How to test

You'll want to run `pre-commit` locally at the repo root. Then try staging a change locally to renovatebot config and watching the output! 

## Screenshots

N/A

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~


## Links

_If relevant, e.g. for a link to a piece of markdown documentation_
