### PR TITLE
Have renovatebot update pre-commit versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,9 @@
         "automerge": true,
         "platformAutomerge": true
     },
+    "pre-commit": {
+        "enabled": true
+    },
     "packageRules": [
         {
             "matchPackageNames": ["python"],


### PR DESCRIPTION
## What changed

Having renovatebot attempt to update versions of `pre-commit` hooks that we have in use and specified in our `pre-commit` config file so that we avoid stale versions. 

## Issue

N/A

## How to test

Check renovate logs

## Screenshots

N/A

