### PR TITLE
Updating text on temporary banner for awarded agreements

### DIFF
--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -212,7 +212,7 @@ const Agreement = () => {
                     type="warning"
                     heading="This page is in progress"
                     isClosable={true}
-                    message="Contracts that are awarded have not been fully developed yet, but are coming soon. Some data or information might be missing from this view such as CLINs, or other award and modification related data. Please note: any data that is not visible is not lost, its just not displayed in the user interface yet. Thank you for your patience."
+                    message="Contracts that are awarded have not been fully developed yet, but are coming soon. Some data or information might be missing from this view such as CLINs, Contract #, or other award and modification related data. Please note: any data that is not visible is not lost, its just not displayed in the user interface yet. Thank you for your patience."
                     setIsAlertVisible={setIsAwardedAlertVisible}
                 />
             )}


### PR DESCRIPTION
## What changed

Updates the text shown in the temporary `SimpleAlert` shown for awarded agreements to include a new example of data they won't yet see on an awarded agreement

## Issue

#4147 

## How to test

View an awarded agreement

## Screenshots


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

