### PR TITLE
Extend 'in_review' to include agreement change requests.

### DIFF
--- a/backend/models/budget_line_items.py
+++ b/backend/models/budget_line_items.py
@@ -228,21 +228,22 @@ class BudgetLineItem(BaseModel):
 
         agreement_id = self.agreement_id if hasattr(self, 'agreement_id') else None
 
-        bli_stmt = select(BudgetLineItemChangeRequest).where(
-            BudgetLineItemChangeRequest.status == ChangeRequestStatus.IN_REVIEW,
-            BudgetLineItemChangeRequest.change_request_type == ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
-            BudgetLineItemChangeRequest.budget_line_item_id == self.id,
+        bli_stmt = (
+            select(BudgetLineItemChangeRequest)
+            .where(
+                BudgetLineItemChangeRequest.status == ChangeRequestStatus.IN_REVIEW,
+                BudgetLineItemChangeRequest.change_request_type == ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+                BudgetLineItemChangeRequest.budget_line_item_id == self.id,
+            )
         )
 
-        agreement_stmt = select(AgreementChangeRequest).where(
-            AgreementChangeRequest.status == ChangeRequestStatus.IN_REVIEW,
-            AgreementChangeRequest.change_request_type == ChangeRequestType.AGREEMENT_CHANGE_REQUEST,
-            AgreementChangeRequest.agreement_id == agreement_id,
-            # ~AgreementChangeRequest.id.in_(
-            #     select(BudgetLineItemChangeRequest.id).where(
-            #         BudgetLineItemChangeRequest.budget_line_item_id == self.id
-            #     )
-            # ),
+        agreement_stmt = (
+            select(AgreementChangeRequest)
+            .where(
+                AgreementChangeRequest.status == ChangeRequestStatus.IN_REVIEW,
+                AgreementChangeRequest.change_request_type == ChangeRequestType.AGREEMENT_CHANGE_REQUEST,
+                AgreementChangeRequest.agreement_id == agreement_id
+            )
         ) if agreement_id else None
 
         results = session.execute(bli_stmt).all()

--- a/backend/models/budget_line_items.py
+++ b/backend/models/budget_line_items.py
@@ -228,13 +228,29 @@ class BudgetLineItem(BaseModel):
 
         agreement_id = self.agreement_id if hasattr(self, 'agreement_id') else None
 
-        stmt = select(BudgetLineItemChangeRequest).where(
+        bli_stmt = select(BudgetLineItemChangeRequest).where(
             BudgetLineItemChangeRequest.status == ChangeRequestStatus.IN_REVIEW,
             BudgetLineItemChangeRequest.change_request_type == ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
             BudgetLineItemChangeRequest.budget_line_item_id == self.id,
         )
 
-        results = session.execute(stmt).all()
+        agreement_stmt = select(AgreementChangeRequest).where(
+            AgreementChangeRequest.status == ChangeRequestStatus.IN_REVIEW,
+            AgreementChangeRequest.change_request_type == ChangeRequestType.AGREEMENT_CHANGE_REQUEST,
+            AgreementChangeRequest.agreement_id == agreement_id,
+            # ~AgreementChangeRequest.id.in_(
+            #     select(BudgetLineItemChangeRequest.id).where(
+            #         BudgetLineItemChangeRequest.budget_line_item_id == self.id
+            #     )
+            # ),
+        ) if agreement_id else None
+
+        results = session.execute(bli_stmt).all()
+
+        if agreement_stmt is not None:
+            agreement_stmt_results = session.execute(agreement_stmt).all()
+            results.extend(agreement_stmt_results)
+
         change_requests = [row[0] for row in results] if results else None
         return change_requests
 

--- a/backend/models/budget_line_items.py
+++ b/backend/models/budget_line_items.py
@@ -228,21 +228,10 @@ class BudgetLineItem(BaseModel):
 
         agreement_id = self.agreement_id if hasattr(self, 'agreement_id') else None
 
-        stmt = (
-            select(ChangeRequest)
-            .where(
-                ChangeRequest.status == ChangeRequestStatus.IN_REVIEW,
-                or_(
-                    ChangeRequest.change_request_type == ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
-                    ChangeRequest.change_request_type == ChangeRequestType.AGREEMENT_CHANGE_REQUEST
-                )
-            )
-            .where(
-                or_(
-                    BudgetLineItemChangeRequest.budget_line_item_id == self.id,
-                    AgreementChangeRequest.agreement_id == agreement_id
-                )
-            )
+        stmt = select(BudgetLineItemChangeRequest).where(
+            BudgetLineItemChangeRequest.status == ChangeRequestStatus.IN_REVIEW,
+            BudgetLineItemChangeRequest.change_request_type == ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+            BudgetLineItemChangeRequest.budget_line_item_id == self.id,
         )
 
         results = session.execute(stmt).all()

--- a/backend/models/change_requests.py
+++ b/backend/models/change_requests.py
@@ -77,11 +77,11 @@ class AgreementChangeRequest(ChangeRequest):
     proc_shop_field_names = ["awarding_entity_id"]
 
     @hybrid_property
-    def has_proc_shop_field_names_change(self):
+    def has_proc_shop_change(self):
         return any(key in self.requested_change_data for key in self.proc_shop_field_names)
 
-    @has_proc_shop_field_names_change.expression
-    def has_proc_shop_field_names_change(cls):
+    @has_proc_shop_change.expression
+    def has_proc_shop_change(cls):
         return cls.requested_change_data.has_any(cls.proc_shop_field_names)
 
 

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -4230,7 +4230,7 @@ components:
         - $ref: "#/components/schemas/GenericChangeRequest"
         - type: object
           properties:
-            has_proc_shop_field_names_change:
+            has_proc_shop_change:
               type: boolean
 
       AgreementChangeRequests:

--- a/backend/ops_api/ops/schemas/change_requests.py
+++ b/backend/ops_api/ops/schemas/change_requests.py
@@ -16,7 +16,7 @@ class ChangeRequestResponseSchema(Schema):
     created_by_user = fields.Nested(SafeUserSchema(), load_default=None, dump_default=None, allow_none=True)
     created_on = fields.DateTime(required=True)
     reviewed_by = fields.Integer(allow_none=True)
-    reviewed_on = fields.DateTime(allow_none=True)
+    reviewed_on = fields.DateTime(required=True)
     reviewer_notes = fields.String(load_default=None, dump_default=None, allow_none=True)
     updated_by = fields.Integer(allow_none=True)
     updated_on = fields.DateTime(required=True)

--- a/backend/ops_api/ops/schemas/change_requests.py
+++ b/backend/ops_api/ops/schemas/change_requests.py
@@ -16,7 +16,7 @@ class ChangeRequestResponseSchema(Schema):
     created_by_user = fields.Nested(SafeUserSchema(), load_default=None, dump_default=None, allow_none=True)
     created_on = fields.DateTime(required=True)
     reviewed_by = fields.Integer(allow_none=True)
-    reviewed_on = fields.DateTime(required=True)
+    reviewed_on = fields.DateTime(allow_none=True)
     reviewer_notes = fields.String(load_default=None, dump_default=None, allow_none=True)
     updated_by = fields.Integer(allow_none=True)
     updated_on = fields.DateTime(required=True)
@@ -30,7 +30,7 @@ class GenericChangeRequestResponseSchema(ChangeRequestResponseSchema):
 
 
 class AgreementChangeRequestResponseSchema(GenericChangeRequestResponseSchema):
-    has_proc_shop_field_names_change = fields.Bool(required=True)
+    has_proc_shop_change = fields.Bool(required=True)
 
 
 class BudgetLineItemChangeRequestResponseSchema(GenericChangeRequestResponseSchema):

--- a/backend/ops_api/ops/utils/change_requests_helpers.py
+++ b/backend/ops_api/ops/utils/change_requests_helpers.py
@@ -35,7 +35,7 @@ def build_approve_url(change_request: ChangeRequest, agreement_id: int, fe_url: 
         change_type = "status-change"
     elif getattr(change_request, "has_budget_change", False):
         change_type = "budget-change"
-    elif getattr(change_request, "has_proc_shop_field_names_change", False):
+    elif getattr(change_request, "has_proc_shop_change", False):
         change_type = "procurement-shop-change"
     else:
         raise ValueError(f"Unrecognized change request type for ChangeRequest ID {change_request.id}")

--- a/backend/ops_api/tests/ops/agreement/test_agreement_change_requests.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement_change_requests.py
@@ -143,6 +143,10 @@ def test_update_awarding_entity_creates_agreement_change_request(
     assert blis[0].status is BudgetLineItemStatus.PLANNED
     assert blis[0].in_review is True
 
+    # Confirm "has_proc_shop_change" is True
+    change_request = loaded_db.get(AgreementChangeRequest, change_request_id)
+    assert change_request.has_proc_shop_change is True
+
     # Confirm notification created
     notifications = (
         loaded_db.query(ChangeRequestNotification)

--- a/backend/ops_api/tests/ops/agreement/test_agreement_change_requests.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement_change_requests.py
@@ -134,6 +134,15 @@ def test_update_awarding_entity_creates_agreement_change_request(
     assert agreement.change_requests_in_review[0].status == ChangeRequestStatus.IN_REVIEW
     assert agreement.change_requests_in_review[0].id == change_request_id
 
+    # Confirm the Planned BLI on the agreement is in_review
+    blis = (
+        loaded_db.query(GrantBudgetLineItem).filter(GrantBudgetLineItem.agreement_id == test_grant_agreement.id).all()
+    )
+    assert len(blis) == 1
+    assert blis[0].agreement_id is test_grant_agreement.id
+    assert blis[0].status is BudgetLineItemStatus.PLANNED
+    assert blis[0].in_review is True
+
     # Confirm notification created
     notifications = (
         loaded_db.query(ChangeRequestNotification)

--- a/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_change_requests.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_change_requests.py
@@ -16,7 +16,6 @@ from models import (
 @pytest.mark.parametrize(
     "bli_status",
     [
-        BudgetLineItemStatus.DRAFT,
         BudgetLineItemStatus.PLANNED,
         BudgetLineItemStatus.IN_EXECUTION,
         BudgetLineItemStatus.OBLIGATED,

--- a/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_change_requests.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_change_requests.py
@@ -1,0 +1,91 @@
+import pytest
+
+from models import (
+    AgreementChangeRequest,
+    AgreementType,
+    BudgetLineItemChangeRequest,
+    BudgetLineItemStatus,
+    ChangeRequestStatus,
+    ChangeRequestType,
+    ContractAgreement,
+    ContractBudgetLineItem,
+)
+
+
+@pytest.mark.usefixtures("app_ctx", "loaded_db")
+@pytest.mark.parametrize(
+    "bli_status",
+    [
+        BudgetLineItemStatus.DRAFT,
+        BudgetLineItemStatus.PLANNED,
+        BudgetLineItemStatus.IN_EXECUTION,
+        BudgetLineItemStatus.OBLIGATED,
+    ],
+)
+def test_bli_in_review_true_if_agreement_cr_in_review(loaded_db, test_admin_user, bli_status):
+    # Create a test agreement
+    agreement = ContractAgreement(
+        agreement_type=AgreementType.CONTRACT,
+        name=f"{bli_status} BLI Agreement",
+        nick_name=f"{bli_status}",
+        description=f"Agreement with CR for {bli_status} BLI",
+    )
+    loaded_db.add(agreement)
+    loaded_db.flush()
+
+    # Add BLI with the given status
+    bli = ContractBudgetLineItem(
+        line_description=f"{bli_status} BLI",
+        agreement_id=agreement.id,
+        status=bli_status,
+    )
+    loaded_db.add(bli)
+    loaded_db.flush()
+
+    # Check if BLI is in_review before any CR is added
+    assert bli.in_review is False
+    assert bli.change_requests_in_review is None, f"{bli_status} BLI should not have any CR in review initially"
+
+    # Create Agreement-level change request
+    cr = AgreementChangeRequest(
+        agreement_id=agreement.id,
+        change_request_type=ChangeRequestType.AGREEMENT_CHANGE_REQUEST,
+        status=ChangeRequestStatus.IN_REVIEW,
+        requested_change_data={"note": f"CR for {bli_status} BLI"},
+    )
+    loaded_db.add(cr)
+
+    bli_cr = BudgetLineItemChangeRequest(
+        agreement_id=agreement.id,
+        budget_line_item_id=bli.id,
+        change_request_type=ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+        status=ChangeRequestStatus.IN_REVIEW,
+        requested_change_data={"note": f"CR for {bli_status} BLI"},
+    )
+    loaded_db.add(bli_cr)
+
+    bli_cr_2 = BudgetLineItemChangeRequest(
+        agreement_id=agreement.id,
+        budget_line_item_id=bli.id,
+        change_request_type=ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+        status=ChangeRequestStatus.IN_REVIEW,
+        requested_change_data={"note": "Another CR for the same BLI"},
+    )
+    loaded_db.add(bli_cr_2)
+
+    loaded_db.commit()
+    loaded_db.refresh(bli)
+
+    assert bli.in_review is True, f"{bli_status} BLI should be in_review if agreement has IN_REVIEW CR"
+    assert len(bli.change_requests_in_review) == 3, f"{bli_status} BLI should have 3 CR in review"
+
+    # Delete the created objects
+    loaded_db.delete(bli)
+    loaded_db.delete(cr)
+    loaded_db.delete(agreement)
+
+    # Check if the objects are deleted
+    loaded_db.commit()
+    assert loaded_db.get(ContractBudgetLineItem, bli.id) is None
+    assert loaded_db.get(AgreementChangeRequest, cr.id) is None
+    assert loaded_db.get(ContractAgreement, agreement.id) is None, "Agreement should be deleted after test"

--- a/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_change_requests.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_change_requests.py
@@ -9,6 +9,7 @@ from models import (
     ChangeRequestType,
     ContractAgreement,
     ContractBudgetLineItem,
+    GrantAgreement,
 )
 
 
@@ -101,3 +102,51 @@ def test_bli_in_review_true_if_agreement_cr_in_review(loaded_db, test_admin_user
     assert loaded_db.get(BudgetLineItemChangeRequest, bli_cr.id) is None
     assert loaded_db.get(BudgetLineItemChangeRequest, bli_cr_2.id) is None
     assert loaded_db.get(ContractAgreement, agreement.id) is None, "Agreement should be deleted after test"
+
+
+@pytest.mark.usefixtures("app_ctx", "loaded_db")
+def test_bli_in_review_with_no_agreement_crs_should_return_one_bli_cr(loaded_db):
+    # Create a test agreement
+    agreement = GrantAgreement(
+        agreement_type=AgreementType.GRANT,
+        name="BLI Agreement with no agreement CRs",
+        nick_name="No Agreement CRs",
+        description="Agreement with no CRs at the agreement level",
+    )
+    loaded_db.add(agreement)
+    loaded_db.flush()
+
+    # Create a test bli
+    bli = ContractBudgetLineItem(
+        line_description="Test BLI for checking in_review with no agreement CRs",
+        agreement_id=agreement.id,
+        status=BudgetLineItemStatus.PLANNED,
+    )
+    loaded_db.add(bli)
+    loaded_db.flush()
+
+    # Create a bli cr
+    bli_cr = BudgetLineItemChangeRequest(
+        agreement_id=agreement.id,
+        budget_line_item_id=bli.id,
+        change_request_type=ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+        status=ChangeRequestStatus.IN_REVIEW,
+        requested_change_data={"note": "CR for BLI with no agreement CRs"},
+    )
+    loaded_db.add(bli_cr)
+    loaded_db.commit()
+
+    # Refresh the BLI to get the latest state
+    loaded_db.refresh(bli)
+    assert bli.in_review is True, "BLI should be in_review if it has its own IN_REVIEW CR"
+    assert len(bli.change_requests_in_review) == 1, "BLI should have exactly one CR in review"
+    assert bli.change_requests_in_review[0].id == bli_cr.id, "The CR in review should be the one created for the BLI"
+
+    # Clean up test data
+    loaded_db.delete(bli)
+    loaded_db.delete(bli_cr)
+    loaded_db.delete(agreement)
+    loaded_db.commit()
+    assert loaded_db.get(BudgetLineItemChangeRequest, bli_cr.id) is None
+    assert loaded_db.get(ContractBudgetLineItem, bli.id) is None
+    assert loaded_db.get(GrantAgreement, agreement.id) is None

--- a/backend/ops_api/tests/ops/utils/test_change_requests_helpers.py
+++ b/backend/ops_api/tests/ops/utils/test_change_requests_helpers.py
@@ -34,7 +34,7 @@ def test_get_model_class_by_type_invalid():
     [
         ({"has_status_change": True}, "status-change"),
         ({"has_budget_change": True}, "budget-change"),
-        ({"has_proc_shop_field_names_change": True}, "procurement-shop-change"),
+        ({"has_proc_shop_change": True}, "procurement-shop-change"),
     ],
 )
 def test_build_approve_url_change_types(attrs, expected_type):

--- a/backend/ops_api/tests/ops/workflows/test_change_requests.py
+++ b/backend/ops_api/tests/ops/workflows/test_change_requests.py
@@ -196,9 +196,9 @@ def test_budget_line_item_patch_with_budgets_change_requests(
     assert len(ag_bli["change_requests_in_review"]) == 3
     ag_bli_other = next((bli for bli in ag_blis if bli["id"] != bli_id), None)
     assert "in_review" in ag_bli_other
-    assert ag_bli_other["in_review"] is True
+    assert ag_bli_other["in_review"] is False
     assert "change_requests_in_review" in ag_bli
-    assert ag_bli_other["change_requests_in_review"] is not None
+    assert ag_bli_other["change_requests_in_review"] is None
 
     # verify managing_division
     for change_request in change_requests_in_review:
@@ -430,9 +430,9 @@ def test_budget_line_item_patch_with_status_change_requests(
     assert len(ag_bli["change_requests_in_review"]) == 1
     ag_bli_other = next((bli for bli in ag_blis if bli["id"] != bli_id), None)
     assert "in_review" in ag_bli_other
-    assert ag_bli_other["in_review"] is True
+    assert ag_bli_other["in_review"] is False
     assert "change_requests_in_review" in ag_bli
-    assert ag_bli_other["change_requests_in_review"] is not None
+    assert ag_bli_other["change_requests_in_review"] is None
 
     # approve the change request
     data = {"change_request_id": change_request_id, "action": "APPROVE", "reviewer_notes": "Notes from the reviewer"}

--- a/backend/ops_api/tests/ops/workflows/test_change_requests.py
+++ b/backend/ops_api/tests/ops/workflows/test_change_requests.py
@@ -196,9 +196,9 @@ def test_budget_line_item_patch_with_budgets_change_requests(
     assert len(ag_bli["change_requests_in_review"]) == 3
     ag_bli_other = next((bli for bli in ag_blis if bli["id"] != bli_id), None)
     assert "in_review" in ag_bli_other
-    assert ag_bli_other["in_review"] is False
+    assert ag_bli_other["in_review"] is True
     assert "change_requests_in_review" in ag_bli
-    assert ag_bli_other["change_requests_in_review"] is None
+    assert ag_bli_other["change_requests_in_review"] is not None
 
     # verify managing_division
     for change_request in change_requests_in_review:
@@ -430,9 +430,9 @@ def test_budget_line_item_patch_with_status_change_requests(
     assert len(ag_bli["change_requests_in_review"]) == 1
     ag_bli_other = next((bli for bli in ag_blis if bli["id"] != bli_id), None)
     assert "in_review" in ag_bli_other
-    assert ag_bli_other["in_review"] is False
+    assert ag_bli_other["in_review"] is True
     assert "change_requests_in_review" in ag_bli
-    assert ag_bli_other["change_requests_in_review"] is None
+    assert ag_bli_other["change_requests_in_review"] is not None
 
     # approve the change request
     data = {"change_request_id": change_request_id, "action": "APPROVE", "reviewer_notes": "Notes from the reviewer"}


### PR DESCRIPTION
## What changed
- Change the `in_review` attribute on the BLIs to indicate if the BLI or its parent agreement has a change request
- Rename `has_proc_shop_field_names_change`

## Issue
[#4157](https://github.com/HHS/OPRE-OPS/issues/4157)

## How to test
All tests pass successfully.

## Screenshots
N/A

## Definition of Done Checklist
- [X] OESA: Code refactored for clarity
- [X] OESA: Dependency rules followed
- [X] Automated unit tests updated and passed
- [X] Automated integration tests updated and passed
- [X] Automated quality tests updated and passed
- [X] Automated load tests updated and passed
- [X] Automated a11y tests updated and passed
- [X] Automated security tests updated and passed
- [X] 90%+ Code coverage achieved
- [X] Form validations updated


## Links
N/A