### PR TITLE
OPS-4131: revert AA agreement type from temporary UI

### DIFF
--- a/frontend/cypress/e2e/agreementDetails.cy.js
+++ b/frontend/cypress/e2e/agreementDetails.cy.js
@@ -60,11 +60,11 @@ describe("agreement details", () => {
     });
 
     it("Contract type agreement loads with budget lines", () => {
-        cy.visit("/agreements/10");
-        cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
+        cy.visit("/agreements/10/budget-lines");
+        cy.get("h1").contains("Contract Workflow Test");
         cy.get('[data-cy="currency-summary-card"]')
             .should("contain", "Agreement Total")
-            // .and("contain", "$ 1,000,000") // total
+            .and("contain", "$ 1,000,000") // total
             .and("contain", "$1,000,000") // sub-total
             .and("contain", "$0") // fees
             .and("contain", "GCS"); // fee rate
@@ -73,8 +73,9 @@ describe("agreement details", () => {
         // toggle on Draft BLIs
         cy.get("#toggleDraftBLIs").should("exist");
         cy.get("#toggleDraftBLIs").click();
+        cy.get("h1").contains("Contract Workflow Test");
         cy.get('[data-cy="currency-summary-card"]')
-            // .should("contain", "$ 2,000,000.00")
+            .should("contain", "$ 2,000,000.00")
             .and("contain", "$2,000,000.00")
             .and("contain", "$0")
             .and("contain", "GCS");

--- a/frontend/cypress/e2e/agreementDetails.cy.js
+++ b/frontend/cypress/e2e/agreementDetails.cy.js
@@ -99,6 +99,7 @@ describe("agreement details", () => {
         cy.get('[data-cy="alert"]').contains(
             "Agreements that are grants, inter-agency agreements (IAAs), assisted acquisitions (AAs) or direct obligations have not been developed yet, but are coming soon."
         );
+        cy.get('[data-cy="close-alert"]').click();
         cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
         cy.get("#edit").should("not.exist");
         cy.get('[data-cy="bli-continue-btn-disabled"]').should("exist");
@@ -114,6 +115,7 @@ describe("agreement details", () => {
         cy.get('[data-cy="alert"]').contains(
             "Agreements that are grants, inter-agency agreements (IAAs), assisted acquisitions (AAs) or direct obligations have not been developed yet, but are coming soon."
         );
+        cy.get('[data-cy="close-alert"]').click();
         cy.get("#edit").should("not.exist");
     });
 
@@ -122,6 +124,7 @@ describe("agreement details", () => {
         cy.get('[data-cy="alert"]').contains(
             "Agreements that are grants, inter-agency agreements (IAAs), assisted acquisitions (AAs) or direct obligations have not been developed yet, but are coming soon."
         );
+        cy.get('[data-cy="close-alert"]').click();
         cy.get("#edit").should("not.exist");
     });
 
@@ -130,6 +133,7 @@ describe("agreement details", () => {
         cy.get('[data-cy="alert"]').contains(
             "Agreements that are grants, inter-agency agreements (IAAs), assisted acquisitions (AAs) or direct obligations have not been developed yet, but are coming soon."
         );
+        cy.get('[data-cy="close-alert"]').click();
         cy.get("#edit").should("not.exist");
     });
 

--- a/frontend/cypress/e2e/agreementDetails.cy.js
+++ b/frontend/cypress/e2e/agreementDetails.cy.js
@@ -64,7 +64,7 @@ describe("agreement details", () => {
         cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
         cy.get('[data-cy="currency-summary-card"]')
             .should("contain", "Agreement Total")
-            .and("contain", "$ 1,000,000") // total
+            // .and("contain", "$ 1,000,000") // total
             .and("contain", "$1,000,000") // sub-total
             .and("contain", "$0") // fees
             .and("contain", "GCS"); // fee rate
@@ -74,7 +74,7 @@ describe("agreement details", () => {
         cy.get("#toggleDraftBLIs").should("exist");
         cy.get("#toggleDraftBLIs").click();
         cy.get('[data-cy="currency-summary-card"]')
-            .should("contain", "$ 2,000,000.00")
+            // .should("contain", "$ 2,000,000.00")
             .and("contain", "$2,000,000.00")
             .and("contain", "$0")
             .and("contain", "GCS");
@@ -82,7 +82,7 @@ describe("agreement details", () => {
         cy.get(".usa-table").should("exist");
     });
 
-    it("should not allow editing Obligated BLIs", () => {
+    it.skip("should not allow editing Obligated BLIs", () => {
         cy.visit("/agreements/7/budget-lines");
         cy.get("#edit").click();
         cy.get("[data-testid='budget-line-row-15005']").trigger("mouseover");

--- a/frontend/cypress/e2e/agreementDetails.cy.js
+++ b/frontend/cypress/e2e/agreementDetails.cy.js
@@ -60,8 +60,8 @@ describe("agreement details", () => {
     });
 
     it("Contract type agreement loads with budget lines", () => {
-        cy.visit("/agreements/10/budget-lines");
-        cy.get("h1").contains("Contract Workflow Test");
+        cy.visit("/agreements/9/budget-lines");
+        cy.get("h1").contains("Interoperability Initiatives");
         cy.get('[data-cy="currency-summary-card"]')
             .should("contain", "Agreement Total")
             .and("contain", "$ 1,000,000") // total
@@ -73,13 +73,14 @@ describe("agreement details", () => {
         // toggle on Draft BLIs
         cy.get("#toggleDraftBLIs").should("exist");
         cy.get("#toggleDraftBLIs").click();
-        cy.get("h1").contains("Contract Workflow Test");
+        cy.get("h1").contains("Interoperability Initiatives");
         cy.get('[data-cy="currency-summary-card"]')
-            .should("contain", "$ 2,000,000.00")
-            .and("contain", "$2,000,000.00")
+            .should("contain", "$ 1,000,000.00")
+            .and("contain", "1,000,000.00")
             .and("contain", "$0")
             .and("contain", "GCS");
-        cy.get('[data-cy="blis-by-fy-card"]').should("contain", "$2,000,000.00");
+        cy.get('[data-cy="blis-by-fy-card"]').should("contain", "$301,500.00");
+        cy.get('[data-cy="blis-by-fy-card"]').should("contain", "$703,500.00");
         cy.get(".usa-table").should("exist");
     });
 

--- a/frontend/cypress/e2e/agreementDetails.cy.js
+++ b/frontend/cypress/e2e/agreementDetails.cy.js
@@ -10,128 +10,161 @@ afterEach(() => {
     cy.checkA11y(null, null, terminalLog);
 });
 
-it("Awarded Contract type agreement loads with details", () => {
-    cy.visit("/agreements/10");
-    cy.get('[data-cy="alert"]').contains(
-        "Contracts that are awarded have not been fully developed yet, but are coming soon."
-    );
-    cy.get('[data-cy="close-alert"]').click();
-    cy.get("h1").contains("Contract Workflow Test");
-    cy.get("h2").first().contains("Human Services Interoperability Support");
-    cy.get('[data-cy="details-tab-Award & Modifications"]').should("be.disabled");
-    cy.get('[data-cy="details-tab-Procurement Tracker"]').should("be.disabled");
-    cy.get('[data-cy="details-tab-Documents"]').should("be.disabled");
-    cy.get("h2").eq(1).contains("Agreement Details");
-    cy.get('[data-cy="agreement-description"]').contains("Test description");
-    cy.get('[data-cy="agreement-type-tag"]').contains("Contract");
-    cy.get('[data-cy="contract-type-tag"]').contains("Firm Fixed Price (FFP)");
-    cy.get('[data-cy="product-service-code-tag"]').contains("Other Scientific and Technical Consulting Services");
-    cy.get('[data-cy="naics-code-tag"]').contains("541690");
-    cy.get('[data-cy="program-support-code-tag"]').contains("R410 - Research");
-    cy.get('[data-cy="procurement-shop-tag"]').contains("GCS");
-    cy.get('[data-cy="agreement-reason-tag"]').contains("Recompete");
-    cy.get('[data-cy="vendor-tag"]').contains("Vendor 1");
-    cy.get('[data-cy="division-director-tag"]').should("contain", "Dave Director");
-    cy.get('[data-cy="team-leader-tag"]').should("contain", "Amy Madigan");
-    cy.get('[data-cy="project-officer-tag"]').contains("Chris Fortunato");
-    cy.get('[data-cy="alternate-project-officer-tag"]').contains("TBD");
-    cy.get('[data-cy="team-member-tag-503"]').contains("Amelia Popham");
-    cy.get("h3").contains("Notes");
-    cy.get("p.font-12px").contains("There are currently no notes for this agreement.");
-});
+describe("agreement details", () => {
+    it("Awarded Contract type agreement loads with details", () => {
+        cy.visit("/agreements/7");
+        cy.get('[data-cy="alert"]').contains(
+            "Contracts that are awarded have not been fully developed yet, but are coming soon."
+        );
+        cy.get('[data-cy="close-alert"]').click();
+        cy.get("h1").contains("MIHOPE Check-In");
+        cy.get("h2").first().contains("Mother and Infant Home Visiting Program Evaluation 2");
+        cy.get('[data-cy="details-tab-Award & Modifications"]').should("be.disabled");
+        cy.get('[data-cy="details-tab-Procurement Tracker"]').should("be.disabled");
+        cy.get('[data-cy="details-tab-Documents"]').should("be.disabled");
+        cy.get("h2").eq(1).contains("Agreement Details");
+        cy.get('[data-cy="agreement-description"]').contains("Test description");
+        cy.get('[data-cy="agreement-type-tag"]').contains("Contract");
+        cy.get('[data-cy="contract-type-tag"]').contains("Time & Materials (T&M)");
+        cy.get('[data-cy="product-service-code-tag"]').contains("Other Scientific and Technical Consulting Services");
+        cy.get('[data-cy="naics-code-tag"]').contains("541690");
+        cy.get('[data-cy="program-support-code-tag"]').contains("R410 - Research");
+        cy.get('[data-cy="procurement-shop-tag"]').contains("GCS");
+        cy.get('[data-cy="agreement-reason-tag"]').contains("New Requirement");
+        cy.get('[data-cy="vendor-tag"]').contains("Vendor 2");
+        cy.get('[data-cy="division-director-tag"]').should("contain", "Dave Director");
+        cy.get('[data-cy="team-leader-tag"]').should("contain", "Ivelisse Martinez-Beck");
+        cy.get('[data-cy="project-officer-tag"]').contains("System Owner");
+        cy.get('[data-cy="alternate-project-officer-tag"]').contains("Dave Director");
+        cy.get("h3").contains("Notes");
+        cy.get("p.font-12px").contains("There are currently no notes for this agreement.");
+    });
 
-it("Non contract type agreement loads with details", () => {
-    cy.visit("/agreements/11");
-    cy.get('[data-cy="alert"]').contains(
-        "Agreements that are grants, inter-agency agreements (IAAs), assisted acquisitions (AAs) or direct obligations have not been developed yet, but are coming soon."
-    );
-    cy.get('[data-cy="close-alert"]').click();
-    cy.get("h1").contains("Support Contract #1");
-    cy.get("h2").first().contains("Support Project #1");
-    cy.get("h2").eq(1).contains("Agreement Details");
-    cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(1)').contains("Agreement Type");
-    cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(2) > .font-12px').contains("AA");
-    cy.get('[data-cy="details-right-col"] > :nth-child(2) > :nth-child(1)').contains("COR");
-    cy.get("span").contains("Amelia Popham");
-    cy.get('[data-cy="details-right-col"] > :nth-child(2) > :nth-child(2)').contains("Alternate COR");
-    cy.get("span").contains("TBD");
-    cy.get('[data-cy="details-right-col"] > :nth-child(3) > :nth-child(1)').contains("Team Members");
-    cy.get("span").contains("Niki Denmark");
-    cy.get("span").contains("System Owner");
-});
+    it("AA type agreement loads with details", () => {
+        cy.visit("/agreements/5");
+        cy.get('[data-cy="alert"]').contains(
+            "Agreements that are grants, inter-agency agreements (IAAs), assisted acquisitions (AAs) or direct obligations have not been developed yet, but are coming soon."
+        );
+        cy.get('[data-cy="close-alert"]').click();
+        cy.get("h1").contains("AA #1: Fathers and Continuous Learning (FCL)");
+        cy.get("h2").first().contains("Annual Performance Plans and Reports");
+        cy.get("h2").eq(1).contains("Agreement Details");
+        cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(1)').contains("Agreement Type");
+        cy.get('[data-cy="details-right-col"] > :nth-child(1) > :nth-child(2) > .font-12px').contains(
+            "Assisted Acquisition (AA)"
+        );
+        cy.get('[data-cy="details-right-col"] > :nth-child(2) > :nth-child(1)').contains("COR");
+        cy.get("span").contains("Chris Fortunato");
+        cy.get('[data-cy="details-right-col"] > :nth-child(2) > :nth-child(2)').contains("Alternate COR");
+        cy.get("span").contains("TBD");
+    });
 
-it("Contract type agreement loads with budget lines", () => {
-    cy.visit("/agreements/10");
-    cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
-    cy.get('[data-cy="currency-summary-card"]')
-        .should("contain", "Agreement Total")
-        .and("contain", "$ 3,000,000") // total
-        .and("contain", "$3,000,000") // sub-total
-        .and("contain", "$0") // fees
-        .and("contain", "GCS"); // fee rate
-    cy.get('[data-cy="blis-by-fy-card"]').should("exist");
-    cy.get("tbody").children().as("table-rows").should("have.length.greaterThan", 0);
-    // toggle on Draft BLIs
-    cy.get("#toggleDraftBLIs").should("exist");
-    cy.get("#toggleDraftBLIs").click();
-    cy.get('[data-cy="currency-summary-card"]')
-        .should("contain", "$ 4,000,000.00")
-        .and("contain", "$4,000,000.00")
-        .and("contain", "$0")
-        .and("contain", "GCS");
-    cy.get('[data-cy="blis-by-fy-card"]').should("contain", "$4,000,000.00");
-    cy.get("#edit").click();
-    cy.get("[data-testid='budget-line-row-15004']").trigger("mouseover");
-    cy.get("[data-testid='budget-line-row-15004'] .usa-tooltip .usa-tooltip__body").should(
-        "contain",
-        "If you need to edit a budget line in Executing Status, please contact the budget team"
-    );
-    cy.get("[data-testid='budget-line-row-15005']").trigger("mouseover");
-    cy.get("[data-testid='budget-line-row-15005'] .usa-tooltip .usa-tooltip__body").should(
-        "contain",
-        "Obligated budget lines cannot be edited"
-    );
-});
+    it("Contract type agreement loads with budget lines", () => {
+        cy.visit("/agreements/10");
+        cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
+        cy.get('[data-cy="currency-summary-card"]')
+            .should("contain", "Agreement Total")
+            .and("contain", "$ 1,000,000") // total
+            .and("contain", "$1,000,000") // sub-total
+            .and("contain", "$0") // fees
+            .and("contain", "GCS"); // fee rate
+        cy.get('[data-cy="blis-by-fy-card"]').should("exist");
+        cy.get("tbody").children().as("table-rows").should("have.length.greaterThan", 0);
+        // toggle on Draft BLIs
+        cy.get("#toggleDraftBLIs").should("exist");
+        cy.get("#toggleDraftBLIs").click();
+        cy.get('[data-cy="currency-summary-card"]')
+            .should("contain", "$ 2,000,000.00")
+            .and("contain", "$2,000,000.00")
+            .and("contain", "$0")
+            .and("contain", "GCS");
+        cy.get('[data-cy="blis-by-fy-card"]').should("contain", "$2,000,000.00");
+        cy.get(".usa-table").should("exist");
+    });
 
-it("Non contract type agreement loads with budget lines", () => {
-    cy.visit("/agreements/11");
-    cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
-    cy.get("#edit").should("not.exist");
-    cy.get('[data-cy="bli-continue-btn-disabled"]').should("exist");
-    cy.get('[data-cy="currency-summary-card"]').contains("Agreement Total");
-    cy.get('[data-cy="currency-summary-card"]').contains("$ 301,500.00");
-    cy.get('[data-cy="blis-by-fy-card"]').should("exist");
-    cy.get("tbody").children().as("table-rows").should("have.length.greaterThan", 0);
-    cy.get("#toggleDraftBLIs").should("exist");
-});
+    it("should not allow editing Obligated BLIs", () => {
+        cy.visit("/agreements/7/budget-lines");
+        cy.get("#edit").click();
+        cy.get("[data-testid='budget-line-row-15005']").trigger("mouseover");
+        cy.get("[data-testid='budget-line-row-15005'] .usa-tooltip .usa-tooltip__body").should(
+            "contain",
+            "Obligated budget lines cannot be edited"
+        );
+    });
+    //TODO: add a test for this
+    it.skip("should not allow editing Executing BLIs", () => {});
 
-it("should not warn when not making changes to agreement and tabbing to BLI tab", () => {
-    cy.visit("/agreements/9");
-    cy.get("#edit").click();
-    cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
-    cy.get("#ops-modal").should("not.exist");
-});
+    it("Direct Obligation type agreement loads with budget lines and temp banner", () => {
+        cy.visit("/agreements/2");
+        cy.get('[data-cy="alert"]').contains(
+            "Agreements that are grants, inter-agency agreements (IAAs), assisted acquisitions (AAs) or direct obligations have not been developed yet, but are coming soon."
+        );
+        cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
+        cy.get("#edit").should("not.exist");
+        cy.get('[data-cy="bli-continue-btn-disabled"]').should("exist");
+        cy.get('[data-cy="currency-summary-card"]').contains("Agreement Total");
+        cy.get('[data-cy="currency-summary-card"]').contains("$ 246,354,000");
+        cy.get('[data-cy="blis-by-fy-card"]').should("exist");
+        cy.get("tbody").children().as("table-rows").should("have.length.greaterThan", 0);
+        cy.get("#toggleDraftBLIs").should("exist");
+    });
 
-it("should warn when making changes to agreement and tabbing out", () => {
-    cy.visit("/agreements/9");
-    cy.get("#edit").click();
-    cy.get("#contract-type").select("Time & Materials (T&M)");
-    cy.get('[data-cy="details-tab-Agreement Details"]').click();
-    cy.get("#ops-modal").should("exist");
-});
+    it("Grants load with temp banner", () => {
+        cy.visit("/agreements/3");
+        cy.get('[data-cy="alert"]').contains(
+            "Agreements that are grants, inter-agency agreements (IAAs), assisted acquisitions (AAs) or direct obligations have not been developed yet, but are coming soon."
+        );
+        cy.get("#edit").should("not.exist");
+    });
 
-it("should handle cancel edits", () => {
-    cy.visit("/agreements/9");
-    // Agreement Details Tab
-    cy.get("#edit").click();
-    cy.get("#contract-type").select("Firm Fixed Price (FFP)");
-    cy.get('[data-cy="cancel-button"]').click();
-    cy.get("#ops-modal-heading").contains("Are you sure you want to cancel editing? Your changes will not be saved.");
-    cy.get('[data-cy="confirm-action"]').click();
-    //test Agreement BLI Tab
-    cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
-    cy.get("#edit").click();
-    cy.get('[data-cy="cancel-button"]').click();
-    cy.get("#ops-modal-heading").contains("Are you sure you want to cancel editing? Your changes will not be saved.");
-    cy.get('[data-cy="confirm-action"]').click();
+    it("IAAs load with temp banner", () => {
+        cy.visit("/agreements/4");
+        cy.get('[data-cy="alert"]').contains(
+            "Agreements that are grants, inter-agency agreements (IAAs), assisted acquisitions (AAs) or direct obligations have not been developed yet, but are coming soon."
+        );
+        cy.get("#edit").should("not.exist");
+    });
+
+    it("AAs load with temp banner", () => {
+        cy.visit("/agreements/5");
+        cy.get('[data-cy="alert"]').contains(
+            "Agreements that are grants, inter-agency agreements (IAAs), assisted acquisitions (AAs) or direct obligations have not been developed yet, but are coming soon."
+        );
+        cy.get("#edit").should("not.exist");
+    });
+
+    it("should not warn when not making changes to agreement and tabbing to BLI tab", () => {
+        cy.visit("/agreements/9");
+        cy.get("#edit").click();
+        cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
+        cy.get("#ops-modal").should("not.exist");
+    });
+
+    it("should warn when making changes to agreement and tabbing out", () => {
+        cy.visit("/agreements/9");
+        cy.get("#edit").click();
+        cy.get("#contract-type").select("Time & Materials (T&M)");
+        cy.get('[data-cy="details-tab-Agreement Details"]').click();
+        cy.get("#ops-modal").should("exist");
+    });
+
+    it("should handle cancel edits", () => {
+        cy.visit("/agreements/9");
+        // Agreement Details Tab
+        cy.get("#edit").click();
+        cy.get("#contract-type").select("Firm Fixed Price (FFP)");
+        cy.get('[data-cy="cancel-button"]').click();
+        cy.get("#ops-modal-heading").contains(
+            "Are you sure you want to cancel editing? Your changes will not be saved."
+        );
+        cy.get('[data-cy="confirm-action"]').click();
+        //test Agreement BLI Tab
+        cy.get('[data-cy="details-tab-SCs & Budget Lines"]').click();
+        cy.get("#edit").click();
+        cy.get('[data-cy="cancel-button"]').click();
+        cy.get("#ops-modal-heading").contains(
+            "Are you sure you want to cancel editing? Your changes will not be saved."
+        );
+        cy.get('[data-cy="confirm-action"]').click();
+    });
 });

--- a/frontend/cypress/e2e/agreementDetails.cy.js
+++ b/frontend/cypress/e2e/agreementDetails.cy.js
@@ -1,6 +1,5 @@
 /// <reference types="cypress" />
 import { terminalLog, testLogin } from "./utils";
-
 beforeEach(() => {
     testLogin("system-owner");
 });
@@ -84,8 +83,8 @@ describe("agreement details", () => {
         cy.get(".usa-table").should("exist");
     });
 
-    it.skip("should not allow editing Obligated BLIs", () => {
-        cy.visit("/agreements/7/budget-lines");
+    it("should not allow editing OBLIGATED BLIs", () => {
+        cy.visit("/agreements/10/budget-lines");
         cy.get("#edit").click();
         cy.get("[data-testid='budget-line-row-15005']").trigger("mouseover");
         cy.get("[data-testid='budget-line-row-15005'] .usa-tooltip .usa-tooltip__body").should(
@@ -93,8 +92,16 @@ describe("agreement details", () => {
             "Obligated budget lines cannot be edited"
         );
     });
-    //TODO: add a test for this
-    it.skip("should not allow editing Executing BLIs", () => {});
+
+    it("should not allow editing EXECUTING bLIs", () => {
+        cy.visit("/agreements/10/budget-lines");
+        cy.get("#edit").click();
+        cy.get("[data-testid='budget-line-row-15004']").trigger("mouseover");
+        cy.get("[data-testid='budget-line-row-15004'] .usa-tooltip .usa-tooltip__body").should(
+            "contain",
+            "If you need to edit a budget line in Executing Status, please contact the budget team"
+        );
+    });
 
     it("Direct Obligation type agreement loads with budget lines and temp banner", () => {
         cy.visit("/agreements/2");

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
@@ -95,9 +95,7 @@ export const AgreementTableRow = ({ agreementId }) => {
     const areAllBudgetLinesInDraftStatus = isSuccess ? areAllBudgetLinesInStatus(agreement, BLI_STATUS.DRAFT) : false;
     const canUserEditAgreement = isSuccess ? agreement?._meta.isEditable : false;
     const areThereAnyBudgetLines = isSuccess ? isThereAnyBudgetLines(agreement) : false;
-    const isAgreementTypeNotDeveloped = isSuccess
-        ? isNotDevelopedYet(agreement?.agreement_type, agreement?.procurement_shop?.abbr)
-        : false;
+    const isAgreementTypeNotDeveloped = isSuccess ? isNotDevelopedYet(agreement?.agreement_type ?? "") : false;
     const isEditable = canUserEditAgreement && !isAgreementTypeNotDeveloped;
     const canUserDeleteAgreement = canUserEditAgreement && (areAllBudgetLinesInDraftStatus || !areThereAnyBudgetLines);
     // hooks

--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -1,5 +1,5 @@
 import { NO_DATA } from "../constants";
-import { AgreementType, ProcurementShopType } from "../pages/agreements/agreements.constants";
+import { AgreementType } from "../pages/agreements/agreements.constants";
 import { BLI_STATUS } from "./budgetLines.helpers";
 import { convertCodeForDisplay } from "./utils";
 
@@ -66,14 +66,9 @@ export const getProcurementShopSubTotal = (agreement, budgetLines = [], isAfterA
 /**
  * Determines if the agreement is not developed yet based on the agreement type and procurement shop.
  * @param {string} agreementType - The type of the agreement.
- * @param {string} procurementShop - The type of the procurement shop.
  * @returns {boolean} - True if the agreement is not developed yet, otherwise false.
  */
-export const isNotDevelopedYet = (agreementType, procurementShop) => {
-    // This is a AA agreement type
-    if (procurementShop && procurementShop !== ProcurementShopType.GCS && agreementType === AgreementType.CONTRACT)
-        return true;
-
+export const isNotDevelopedYet = (agreementType) => {
     if (
         agreementType === AgreementType.GRANT ||
         agreementType === AgreementType.DIRECT_OBLIGATION ||
@@ -81,6 +76,7 @@ export const isNotDevelopedYet = (agreementType, procurementShop) => {
     ) {
         return true;
     }
+
     return false;
 };
 
@@ -96,13 +92,9 @@ export const getAgreementType = (agreement, abbr = true) => {
     }
 
     let agreementTypeLabel = convertCodeForDisplay("agreementType", agreement?.agreement_type);
-    const procurementShop = agreement?.procurement_shop?.abbr;
-    if (
-        procurementShop &&
-        procurementShop !== ProcurementShopType.GCS &&
-        agreement.agreement_type === AgreementType.CONTRACT
-    ) {
-        agreementTypeLabel = abbr ? "AA" : "Assisted Acquisition (AA)";
+
+    if (agreementTypeLabel === "AA" && abbr === false) {
+        agreementTypeLabel = "Assisted Acquisition (AA)";
     }
 
     if (agreementTypeLabel === "IAA" && abbr === false) {

--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -21,6 +21,7 @@ const handleAgreementProp = (agreement) => {
  */
 export const getAgreementSubTotal = (agreement) => {
     handleAgreementProp(agreement);
+
     return (
         agreement.budget_line_items
             ?.filter(({ status }) => status !== BLI_STATUS.DRAFT)

--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -72,7 +72,8 @@ export const isNotDevelopedYet = (agreementType) => {
     if (
         agreementType === AgreementType.GRANT ||
         agreementType === AgreementType.DIRECT_OBLIGATION ||
-        agreementType === AgreementType.IAA
+        agreementType === AgreementType.IAA ||
+        agreementType === AgreementType.AA
     ) {
         return true;
     }

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -204,6 +204,7 @@ export const codesToDisplayText = {
         RESEARCH: "Research"
     },
     projectOfficer: {
+        AA: "COR",
         CONTRACT: "COR",
         GRANT: "Project Officer",
         DIRECT_OBLIGATION: "Project Officer",

--- a/frontend/src/pages/agreements/agreements.constants.js
+++ b/frontend/src/pages/agreements/agreements.constants.js
@@ -13,6 +13,7 @@ export const AgreementType = {
     GRANT: "GRANT",
     DIRECT_OBLIGATION: "DIRECT_OBLIGATION",
     IAA: "IAA",
+    AA: "AA",
     IAA_AA: "IAA_AA",
     MISCELLANEOUS: "MISCELLANEOUS"
 };

--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -144,10 +144,7 @@ const Agreement = () => {
         ];
     }
 
-    const isAgreementNotaContract = isNotDevelopedYet(
-        agreement?.agreement_type ?? "",
-        agreement?.procurement_shop?.abbr ?? ""
-    );
+    const isAgreementNotaContract = isNotDevelopedYet(agreement?.agreement_type ?? "");
 
     useEffect(() => {
         /**

--- a/frontend/src/pages/agreements/details/AgreementDetails.test.js
+++ b/frontend/src/pages/agreements/details/AgreementDetails.test.js
@@ -432,7 +432,7 @@ describe("AgreementDetails", () => {
                     navigator={history}
                 >
                     <AgreementDetails
-                        agreement={agreement}
+                        agreement={{...agreement, agreement_type: "AA"}}
                         projectOfficer={projectOfficer}
                         isEditMode={false}
                         setIsEditMode={mockFn}


### PR DESCRIPTION
## What changed

This PR reverts the temporary UI handling of AA (Assisted Acquisition) agreement types to use a proper AA enum value instead of dynamically determining AA status based on procurement shop and contract type.

- Adds explicit "AA" enum to AgreementType constants
- Simplifies agreement type detection logic by removing procurement shop dependencies
- Updates test cases to reflect the new AA agreement type handling

## Issue

This PR closes #4131 and essentially reverses #3807

## How to test

1. e2e tests pass
2. visit agreement 5 and should see correct tag from BE and temp banner 

## Screenshots

<img width="821" height="654" alt="image" src="https://github.com/user-attachments/assets/cff74ce8-289c-4f87-8c84-105316a89b81" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated