### PR TITLE
feat: add project title to budget line item export

### DIFF
--- a/frontend/src/pages/budgetLines/list/BudgetLineItemList.jsx
+++ b/frontend/src/pages/budgetLines/list/BudgetLineItemList.jsx
@@ -127,6 +127,7 @@ const BudgetLineItemList = () => {
 
             const header = [
                 "BL ID #",
+                "Project",
                 "Agreement",
                 "SC",
                 "Description",
@@ -150,12 +151,13 @@ const BudgetLineItemList = () => {
                         const fees = totalBudgetLineFeeAmount(budgetLine?.amount ?? 0, feeRate / 100);
                         return [
                             budgetLine.id,
-                            budgetLine.agreement?.name || "TBD",
+                            budgetLine.agreement?.project?.title ?? "TBD",
+                            budgetLine.agreement?.name ?? "TBD",
                             budgetLinesDataMap[budgetLine.id]?.service_component_name,
                             budgetLine.line_description,
                             formatDateNeeded(budgetLine?.date_needed ?? ""),
                             budgetLine.fiscal_year,
-                            budgetLine.can?.display_name || "TBD",
+                            budgetLine.can?.display_name ?? "TBD",
                             budgetLine?.amount ?? 0,
                             fees ?? 0,
                             feeRate,


### PR DESCRIPTION
## What changed

Add project title to budget line item export

## Issue

This PR closes #4141 

## How to test

1. go to /budget-lines
2. apply a filter for faster export(e.g. Fiscal year = 2045)
3. click Export
4. verify the project title is in the export table

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
