### PR TITLE
Updating authoritative spreasheet import BL status mapping

### DIFF
--- a/backend/data_tools/src/load_master_spreadsheet_budget_lines/utils.py
+++ b/backend/data_tools/src/load_master_spreadsheet_budget_lines/utils.py
@@ -108,7 +108,12 @@ def get_bli_status(status: str) -> Optional[BudgetLineItemStatus]:
     """
     status_mapping = {
         "obl": BudgetLineItemStatus.OBLIGATED,
+        "obligated": BudgetLineItemStatus.OBLIGATED,
         "com": BudgetLineItemStatus.IN_EXECUTION,
+        "in_execution": BudgetLineItemStatus.IN_EXECUTION,
+        "executing": BudgetLineItemStatus.IN_EXECUTION,
+        "planned": BudgetLineItemStatus.PLANNED,
+        "draft": BudgetLineItemStatus.DRAFT,
     }
 
     if status:


### PR DESCRIPTION
## What changed

Updates the status mapping options for BLs during the authoritative spreadsheet importation. Previously, values only supported legacy MAPS BL statuses. Recent spreadsheets provided by OPRE have shown they're now using the new OPS statuses instead. 

## Issue

#3973 I guess ?

## How to test

Attempt to do a tsv import with these new values for the status field

## Screenshots

N/A

## Definition of Done Checklist
~- [ ] OESA: Code refactored for clarity~
~- [ ] OESA: Dependency rules followed~
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
~- [ ] Form validations updated~


