### PR TITLE
OPS-4205: CANs filter bug fix

### DIFF
--- a/backend/data_tools/data/can_data.json5
+++ b/backend/data_tools/data/can_data.json5
@@ -162,7 +162,14 @@
       fiscal_year: 2025,
       fund_code: "UG349120251DBD",
       method_of_transfer: "DIRECT"
+    },
+    {
+      // 28
+      fiscal_year: 2025,
+      fund_code: "UG349120250DBD",
+      method_of_transfer: "DIRECT"
     }
+
   ],
   can: [
     {
@@ -380,6 +387,14 @@
       nick_name: "Data Improvement",
       portfolio_id: 5,
       funding_details_id: 27,
+    },
+    {
+      // 527
+      number: "G995679",
+      description: "0 Year CAN. Budget entered.",
+      nick_name: "Zero Year CAN",
+      portfolio_id: 5,
+      funding_details_id: 28,
     }
   ],
   can_funding_budget: [
@@ -586,6 +601,12 @@
       fiscal_year: 2025,
       can_id: 526,
       budget: 120220000.12,
+    },
+    {
+      // 35
+      fiscal_year: 2025,
+      can_id: 527,
+      budget: 120220000.12,
     }
   ],
   can_funding_received: [
@@ -749,6 +770,12 @@
       // 27
       fiscal_year: 2025,
       can_id: 526,
+      funding: 60110000.06,
+    },
+    {
+      // 28
+      fiscal_year: 2025,
+      can_id: 527,
       funding: 60110000.06,
     }
   ],

--- a/backend/models/cans.py
+++ b/backend/models/cans.py
@@ -25,6 +25,7 @@ class CANStatus(Enum):
     ACTIVE = auto()
     INACTIVE = auto()
 
+
 class CANSortCondition(Enum):
     def __str__(self):
         return str(self.value)

--- a/backend/ops_api/ops/services/cans.py
+++ b/backend/ops_api/ops/services/cans.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from flask import current_app
 from loguru import logger
-from sqlalchemy import Integer, func, select, cast
+from sqlalchemy import Integer, cast, func, select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import InstrumentedAttribute
 from werkzeug.exceptions import NotFound
@@ -113,7 +113,7 @@ class CANService:
 
         if search is not None and len(search) > 0:
             query_helper = QueryHelper(stmt)
-            query_helper.add_search(cast(InstrumentedAttribute, CAN.number), search)
+            query_helper.add_search(CAN.number, search)
             stmt = query_helper.get_stmt()
 
         return current_app.db_session.execute(stmt).scalars().all()
@@ -128,7 +128,7 @@ class CANService:
 
         if search is not None and len(search) > 0:
             query_helper = QueryHelper(stmt)
-            query_helper.add_search(cast(InstrumentedAttribute, CAN.number), search)
+            query_helper.add_search(CAN.number, search)
             stmt = query_helper.get_stmt()
 
         return current_app.db_session.execute(stmt).scalars().all()
@@ -139,7 +139,7 @@ class CANService:
 
         if search is not None and len(search) > 0:
             query_helper = QueryHelper(stmt)
-            query_helper.add_search(cast(InstrumentedAttribute, CAN.number), search)
+            query_helper.add_search(CAN.number, search)
             stmt = query_helper.get_stmt()
 
         return current_app.db_session.execute(stmt).scalars().all()

--- a/backend/ops_api/ops/services/cans.py
+++ b/backend/ops_api/ops/services/cans.py
@@ -3,7 +3,6 @@ from flask import current_app
 from loguru import logger
 from sqlalchemy import Integer, cast, func, select
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy.orm import InstrumentedAttribute
 from werkzeug.exceptions import NotFound
 
 from models import CAN, CANSortCondition

--- a/backend/ops_api/ops/services/cans.py
+++ b/backend/ops_api/ops/services/cans.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from flask import current_app
 from loguru import logger
 from sqlalchemy import Integer, func, select, cast
@@ -126,7 +127,7 @@ class CANService:
     def _get_multiple_year_cans(self, base_stmt, fiscal_year, search=None) -> list[CAN]:
         active_period_expr = cast(func.substr(CANFundingDetails.fund_code, 11, 1), Integer)
         stmt = base_stmt.where(
-            CANFundingDetails.active_period_expr > 1,
+            active_period_expr > 1,
             CANFundingDetails.fiscal_year <= fiscal_year,
             CANFundingDetails.fiscal_year + active_period_expr > fiscal_year,
         ).order_by(CAN.id)

--- a/backend/ops_api/ops/services/cans.py
+++ b/backend/ops_api/ops/services/cans.py
@@ -1,13 +1,12 @@
-from typing import Optional, cast
-
 from flask import current_app
 from loguru import logger
-from sqlalchemy import select
+from sqlalchemy import Integer, func, select, cast
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import InstrumentedAttribute
 from werkzeug.exceptions import NotFound
 
 from models import CAN, CANSortCondition
+from models.cans import CANFundingDetails
 from ops_api.ops.utils.cans import get_can_funding_summary
 from ops_api.ops.utils.query_helpers import QueryHelper
 
@@ -81,11 +80,74 @@ class CANService:
         """
         Get a list of CANs, optionally filtered by a search parameter.
         """
-        search_query = self._get_query(search)
-        results = current_app.db_session.execute(search_query).all()
-        cursor_results = [can for item in results for can in item]
+        """
+        1. if no fiscal_year is provided, we will return all CANs
+        2. if fiscal_year is provided, filter out CANs that do not have funding_details
+            a. get all 1-year CANs
+            b. get all multiple-year CANs
+            c. get all 0-year CANs
+        """
+        # search_query = self._get_query(search)
+        # results = current_app.db_session.execute(search_query).all()
+        # cursor_results = [can for item in results for can in item]
+        # sorted_results = self._sort_results(cursor_results, fiscal_year, sort_conditions, sort_descending)
+        # return sorted_results
+
+        if fiscal_year is None:
+            search_query = self._get_query(search)
+            results = current_app.db_session.execute(search_query).all()
+            cursor_results = [can for item in results for can in item]
+        else:
+            # Execute three separate queries and combine results
+            base_stmt = select(CAN).join(CANFundingDetails, CAN.funding_details_id == CANFundingDetails.id)
+            one_year_cans = self._get_one_year_cans(base_stmt, fiscal_year, search)
+            multiple_year_cans = self._get_multiple_year_cans(base_stmt, fiscal_year, search)
+            zero_year_cans = self._get_zero_year_cans(base_stmt, fiscal_year, search)
+
+            all_results = one_year_cans + multiple_year_cans + zero_year_cans
+            # Remove duplicates by converting to dict with CAN id as key, then back to list
+            unique_results = {can.id: can for can in all_results}
+            cursor_results = list(unique_results.values())
+
         sorted_results = self._sort_results(cursor_results, fiscal_year, sort_conditions, sort_descending)
         return sorted_results
+
+    def _get_one_year_cans(self, base_stmt, fiscal_year, search=None) -> list[CAN]:
+        active_period_expr = cast(func.substr(CANFundingDetails.fund_code, 11, 1), Integer)
+        stmt = base_stmt.where(active_period_expr == 1, CANFundingDetails.fiscal_year == fiscal_year).order_by(CAN.id)
+
+        if search is not None and len(search) > 0:
+            query_helper = QueryHelper(stmt)
+            query_helper.add_search(cast(InstrumentedAttribute, CAN.number), search)
+            stmt = query_helper.get_stmt()
+
+        return current_app.db_session.execute(stmt).scalars().all()
+
+    def _get_multiple_year_cans(self, base_stmt, fiscal_year, search=None) -> list[CAN]:
+        active_period_expr = cast(func.substr(CANFundingDetails.fund_code, 11, 1), Integer)
+        stmt = base_stmt.where(
+            CANFundingDetails.active_period_expr > 1,
+            CANFundingDetails.fiscal_year <= fiscal_year,
+            CANFundingDetails.fiscal_year + active_period_expr > fiscal_year,
+        ).order_by(CAN.id)
+
+        if search is not None and len(search) > 0:
+            query_helper = QueryHelper(stmt)
+            query_helper.add_search(cast(InstrumentedAttribute, CAN.number), search)
+            stmt = query_helper.get_stmt()
+
+        return current_app.db_session.execute(stmt).scalars().all()
+
+    def _get_zero_year_cans(self, base_stmt, fiscal_year, search=None) -> list[CAN]:
+        active_period_expr = cast(func.substr(CANFundingDetails.fund_code, 11, 1), Integer)
+        stmt = base_stmt.where(active_period_expr == 0, CANFundingDetails.fiscal_year >= fiscal_year).order_by(CAN.id)
+
+        if search is not None and len(search) > 0:
+            query_helper = QueryHelper(stmt)
+            query_helper.add_search(cast(InstrumentedAttribute, CAN.number), search)
+            stmt = query_helper.get_stmt()
+
+        return current_app.db_session.execute(stmt).scalars().all()
 
     @staticmethod
     def _sort_results(results, fiscal_year, sort_condition, sort_descending):

--- a/backend/ops_api/ops/services/cans.py
+++ b/backend/ops_api/ops/services/cans.py
@@ -79,20 +79,15 @@ class CANService:
 
     def get_list(self, search=None, fiscal_year=None, sort_conditions=None, sort_descending=None) -> list[CAN]:
         """
-        Get a list of CANs, optionally filtered by a search parameter.
-        """
-        """
-        1. if no fiscal_year is provided, we will return all CANs
+        Get a list of CANs, optionally filtered by a search parameter or fiscal year.
+
+        1. if no fiscal_year is provided, return all CANs
         2. if fiscal_year is provided, filter out CANs that do not have funding_details
             a. get all 1-year CANs
             b. get all multiple-year CANs
             c. get all 0-year CANs
+        3. join the results and remove duplicates
         """
-        # search_query = self._get_query(search)
-        # results = current_app.db_session.execute(search_query).all()
-        # cursor_results = [can for item in results for can in item]
-        # sorted_results = self._sort_results(cursor_results, fiscal_year, sort_conditions, sort_descending)
-        # return sorted_results
 
         if fiscal_year is None:
             search_query = self._get_query(search)
@@ -106,7 +101,6 @@ class CANService:
             zero_year_cans = self._get_zero_year_cans(base_stmt, fiscal_year, search)
 
             all_results = one_year_cans + multiple_year_cans + zero_year_cans
-            # Remove duplicates by converting to dict with CAN id as key, then back to list
             unique_results = {can.id: can for can in all_results}
             cursor_results = list(unique_results.values())
 
@@ -213,7 +207,7 @@ class CANService:
         if search is not None and len(search) == 0:
             query_helper.return_none()
         elif search:
-            query_helper.add_search(cast(InstrumentedAttribute, CAN.number), search)
+            query_helper.add_search(CAN.number, search)
 
         stmt = query_helper.get_stmt()
         logger.debug(f"SQL: {stmt}")

--- a/backend/ops_api/tests/ops/can/test_can.py
+++ b/backend/ops_api/tests/ops/can/test_can.py
@@ -259,7 +259,7 @@ def test_service_create_can(loaded_db):
     assert can.number == "G998235"
     assert can.description == "Test CAN Created by unit test"
     assert can.portfolio_id == 6
-    assert can.id == 527
+    assert can.id == 528
     assert can == new_can
 
     loaded_db.delete(new_can)
@@ -303,7 +303,7 @@ def test_can_patch(budget_team_auth_client, mocker, unadded_can):
 
 @pytest.mark.usefixtures("app_ctx")
 def test_can_patch_404(budget_team_auth_client, mocker, loaded_db, unadded_can):
-    test_can_id = 527
+    test_can_id = 528
     update_data = {
         "description": "Test CAN Created by unit test",
     }

--- a/backend/ops_api/tests/ops/funding_summary/test_can_funding_summary.py
+++ b/backend/ops_api/tests/ops/funding_summary/test_can_funding_summary.py
@@ -720,7 +720,7 @@ def test_aggregate_funding_summaries():
 def test_can_get_can_funding_summary_all_cans(auth_client: FlaskClient) -> None:
     response = auth_client.get(f"/api/v1/can-funding-summary?can_ids={0}")
     assert response.status_code == 200
-    assert len(response.json["cans"]) == 27
+    assert len(response.json["cans"]) == 28
 
 
 def test_new_funding_math(auth_client: FlaskClient) -> None:
@@ -737,7 +737,7 @@ def test_new_funding_math(auth_client: FlaskClient) -> None:
     expected_new_funding_data = {
         2027: 0,
         2026: 0,
-        2025: 120220000.12,
+        2025: 240440000.24,
         2024: 0,
         2023: 27060000,
         2022: 21162025,

--- a/frontend/cypress/e2e/canDetail.cy.js
+++ b/frontend/cypress/e2e/canDetail.cy.js
@@ -416,7 +416,7 @@ describe("CAN funding page", () => {
 
         // Check that all expected messages exist in the history list, regardless of order
         const expectedMessages = [
-            "Budget Team added funding received to funding ID 527 in the amount of $2,000,000.00",
+            "Budget Team added funding received to funding ID 528 in the amount of $2,000,000.00",
             "Budget Team edited the FY 2025 budget from $5,000,000.55 to $8,000,000.88",
             "Budget Team entered a FY 2025 budget of $5,000,000.55"
         ];

--- a/frontend/cypress/e2e/canList.cy.js
+++ b/frontend/cypress/e2e/canList.cy.js
@@ -45,7 +45,7 @@ describe("CAN List", () => {
         // budget-summary-card-2021 should contain $ 30,200,000
         cy.get("[data-cy='budget-summary-card-2021']").contains("$ 30,200,000");
 
-        const expectedValues = ["$10,000,000.00", "$10,000,000.00", "$10,000,000.00", "$200,000.00"];
+        const expectedValues = ["$10,000,000.00", "$10,000,000.00", "$10,000,000.00", "$0", "$200,000.00"];
         validateBudgetColumn(expectedValues);
     });
 

--- a/frontend/src/components/CANs/CANFundingInfoCard/CANFundingInfoCard.jsx
+++ b/frontend/src/components/CANs/CANFundingInfoCard/CANFundingInfoCard.jsx
@@ -48,16 +48,15 @@ const CANFundingInfoCard = ({ funding, fiscalYear }) => {
                 </div>
                 <div className="grid-col">
                     <dl>
-                        {funding.active_period && (
-                            <TermTag
-                                term="Active Period"
-                                description={
-                                    funding.active_period > 1
-                                        ? `${funding.active_period} Years`
-                                        : `${funding.active_period} Year`
-                                }
-                            />
-                        )}
+                        <TermTag
+                            term="Active Period"
+                            description={
+                                (funding.active_period ?? 0) > 1
+                                    ? `${funding.active_period} Years`
+                                    : `${funding.active_period} Year`
+                            }
+                        />
+
                         <TermTag
                             term="Allowance"
                             description={funding.allowance ?? NO_DATA}

--- a/frontend/src/components/CANs/CANTable/CANTableRow.helpers.js
+++ b/frontend/src/components/CANs/CANTable/CANTableRow.helpers.js
@@ -6,7 +6,7 @@
 export const displayActivePeriod = (activePeriod) => {
     switch (activePeriod) {
         case 0:
-            return "TBD";
+            return "0 year";
         case 1:
             return "1 year";
         default:

--- a/frontend/src/components/CANs/CANTable/CANTableRow.helpers.test.js
+++ b/frontend/src/components/CANs/CANTable/CANTableRow.helpers.test.js
@@ -3,7 +3,7 @@ import { displayActivePeriod } from "./CANTableRow.helpers";
 
 describe("displayActivePeriod", () => {
     it('should return "TBD" when activePeriod is 0', () => {
-        expect(displayActivePeriod(0)).toBe("TBD");
+        expect(displayActivePeriod(0)).toBe("0 year");
     });
 
     it('should return "1 year" when activePeriod is 1', () => {

--- a/frontend/src/pages/cans/list/CanList.helpers.js
+++ b/frontend/src/pages/cans/list/CanList.helpers.js
@@ -185,25 +185,3 @@ export const getSortedFYBudgets = (cans, fiscalYear) => {
 
     return uniqueBudgets;
 };
-
-/**
- *
- * @param {CAN[]} cans
- * @param {number} fiscalYear
- * @returns {CAN[]}
- */
-
-export const filterCANsByFiscalYear = (cans, fiscalYear) => {
-    if (!cans || cans.length === 0 || !fiscalYear) {
-        return [];
-    }
-
-    return cans.filter(
-        /** @param {CAN} can */
-        (can) =>
-            // @ts-ignore
-            can.funding_details?.fiscal_year <= fiscalYear &&
-            // @ts-ignore
-            fiscalYear < can.funding_details?.fiscal_year + can.active_period
-    );
-};

--- a/frontend/src/pages/cans/list/CanList.jsx
+++ b/frontend/src/pages/cans/list/CanList.jsx
@@ -12,7 +12,7 @@ import ErrorPage from "../../ErrorPage";
 import CANFilterButton from "./CANFilterButton";
 import CANFilterTags from "./CANFilterTags";
 import CANFiscalYearSelect from "./CANFiscalYearSelect";
-import { filterCANsByFiscalYear, getPortfolioOptions, getSortedFYBudgets, sortAndFilterCANs } from "./CanList.helpers";
+import { getPortfolioOptions, getSortedFYBudgets, sortAndFilterCANs } from "./CanList.helpers";
 import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
 
 /**
@@ -55,12 +55,9 @@ const CanList = () => {
         fyBudgets: filters.budget
     });
 
-    const filteredCANsByFiscalYear = React.useMemo(() => {
-        return filterCANsByFiscalYear(canList, fiscalYear);
-    }, [canList, fiscalYear]);
-    const sortedCANs = sortAndFilterCANs(filteredCANsByFiscalYear, myCANsUrl, activeUser, filters, fiscalYear) || [];
+    const sortedCANs = sortAndFilterCANs(canList, myCANsUrl, activeUser, filters, fiscalYear) || [];
     const portfolioOptions = getPortfolioOptions(canList);
-    const sortedFYBudgets = getSortedFYBudgets(filteredCANsByFiscalYear, fiscalYear);
+    const sortedFYBudgets = getSortedFYBudgets(canList, fiscalYear);
     const [minFYBudget, maxFYBudget] = [sortedFYBudgets[0], sortedFYBudgets[sortedFYBudgets.length - 1]];
 
     if (isLoading || fundingSummaryIsLoading) {
@@ -100,7 +97,7 @@ const CanList = () => {
                         setFilters={setFilters}
                         portfolioOptions={portfolioOptions}
                         fyBudgetRange={[minFYBudget, maxFYBudget]}
-                        disabled={filteredCANsByFiscalYear.length === 0}
+                        disabled={canList.length === 0}
                     />
                 }
                 FYSelect={


### PR DESCRIPTION
## What changed

This PR fixes a bug in the CANs filter functionality by moving fiscal year filtering from the frontend to the backend. The change eliminates the separate filterCANsByFiscalYear function and integrates the filtering logic directly into the backend API service.

- Refactored fiscal year filtering from frontend to backend for better performance and consistency
- Updated CANs service to handle fiscal year filtering with proper logic for 0-year, 1-year, and multi-year CANs
- Fixed display logic for 0-year active periods

## Issue

closes #4205 

## How to test

1. go to /cans
2. can G995679 should be in the table with Active Period 0 year
3. click on the CAN number, the can details page should display correct information
4. all tests pass

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
