### PR TITLE
feat: PowerUser can edit BLI CAN for Contract

### DIFF
--- a/frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js
+++ b/frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js
@@ -236,4 +236,98 @@ describe("Power User tests", () => {
                     });
             });
     });
+
+    it("can edit an CONTRACT agreement budget lines CAN", () => {
+        expect(localStorage.getItem("access_token")).to.exist;
+
+        // create test agreement
+        const bearer_token = `Bearer ${window.localStorage.getItem("access_token")}`;
+        cy.request({
+            method: "POST",
+            url: "http://localhost:8080/api/v1/agreements/",
+            body: testAgreement,
+            headers: {
+                Authorization: bearer_token,
+                "Content-Type": "application/json",
+                Accept: "application/json"
+            }
+        })
+            .then((response) => {
+                expect(response.status).to.eq(201);
+                expect(response.body.id).to.exist;
+                const agreementId = response.body.id;
+                return agreementId;
+            })
+            // create BLI
+            .then((agreementId) => {
+                const bliData = { ...testBli, agreement_id: agreementId };
+                cy.request({
+                    method: "POST",
+                    url: "http://localhost:8080/api/v1/budget-line-items/",
+                    body: bliData,
+                    headers: {
+                        Authorization: bearer_token,
+                        Accept: "application/json"
+                    }
+                })
+                    .then((response) => {
+                        expect(response.status).to.eq(201);
+                        expect(response.body.id).to.exist;
+                        const bliId = response.body.id;
+                        return { agreementId, bliId };
+                    })
+                    .then(({ agreementId, bliId }) => {
+                        cy.visit(`http://localhost:3000/agreements/${agreementId}/budget-lines`);
+                        cy.get("#edit").click();
+                        cy.get("#servicesComponentSelect").select("1");
+                        cy.get("#pop-start-date").type("01/01/2044");
+                        cy.get("#pop-end-date").type("01/01/2045");
+                        cy.get("#description").type("This is a description.");
+                        cy.get("[data-cy='add-services-component-btn']").click();
+                        cy.get("tbody").children().as("table-rows").should("have.length", 1);
+                        cy.get("@table-rows").eq(0).find("[data-cy='expand-row']").click();
+                        cy.get("[data-cy='edit-row']").click();
+                        cy.get("#allServicesComponentSelect").select("SC1");
+                        cy.get("#can-combobox-input").clear();
+                        cy.get("#can-combobox-input").type("G99MVT3{enter}");
+                        cy.get('[data-cy="update-budget-line"]').click();
+                        cy.get('[data-cy="continue-btn"]').click();
+                        cy.get('[data-cy="alert"]').should("exist");
+                        cy.get('[data-cy="alert"]')
+                            .should(($alert) => {
+                                expect($alert).to.contain(
+                                    `The agreement ${testAgreement.display_name} has been successfully updated.`
+                                );
+                            })
+                            .then(() => {
+                                // verify the updated amount is displayed in the table
+                                cy.visit(`http://localhost:3000/agreements/${agreementId}/budget-lines`);
+                                cy.get("@table-rows").eq(0).should("contain", "G99MVT3");
+
+                                cy.request({
+                                    method: "DELETE",
+                                    url: `http://localhost:8080/api/v1/budget-line-items/${bliId}`,
+                                    headers: {
+                                        Authorization: bearer_token,
+                                        Accept: "application/json"
+                                    }
+                                }).then((response) => {
+                                    expect(response.status).to.eq(200);
+                                });
+                            })
+                            .then(() => {
+                                cy.request({
+                                    method: "DELETE",
+                                    url: `http://localhost:8080/api/v1/agreements/${agreementId}`,
+                                    headers: {
+                                        Authorization: bearer_token,
+                                        Accept: "application/json"
+                                    }
+                                }).then((response) => {
+                                    expect(response.status).to.eq(200);
+                                });
+                            });
+                    });
+            });
+    });
 });

--- a/frontend/src/components/BudgetLineItems/BudgetLinesForm/BudgetLinesForm.jsx
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesForm/BudgetLinesForm.jsx
@@ -145,7 +145,6 @@ export const BudgetLinesForm = ({
                                 validateBudgetForm(name, value);
                             }
                         }}
-                        isDisabled={canSuperUserEdit}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## What changed

This PR enables PowerUsers to edit the CAN for Budget Line Items in Contract agreements.

## Issue

#4289 

## How to test

1. e2e tests pass

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
