### PR TITLE
Improvements to can upsert script

### DIFF
--- a/backend/data_tools/tests/load_cans/test_load_cans.py
+++ b/backend/data_tools/tests/load_cans/test_load_cans.py
@@ -528,7 +528,7 @@ def test_validate_fund_code_length_of_appropriation():
         SYS_CAN_ID=500,
         CAN_NBR="G99HRF2",
         CAN_DESCRIPTION="Healthy Marriages Responsible Fatherhood - OPRE",
-        FUND="AAXXXX20233DAD",
+        FUND="AAXXXX20236DAD",
         ALLOWANCE="0000000001",
         ALLOTMENT_ORG="YZC6S1JUGUN",
         SUB_ALLOWANCE="9KRZ2ND",
@@ -543,7 +543,7 @@ def test_validate_fund_code_length_of_appropriation():
     )
     with pytest.raises(ValueError) as e_info:
         validate_fund_code(data)
-    assert e_info.value.args[0] == "Invalid length of appropriation 3"
+    assert e_info.value.args[0] == "Invalid length of appropriation 6"
 
 
 def test_validate_fund_code_direct_or_reimbursable():


### PR DESCRIPTION
## What changed

Some tweaks to CAN importing/upserting script including:

* supporting the DRY_RUN environment variable
* Added some more logging for sanity
* Cleaning up comments
* refactoring of code handling existing vs. new can

## Issue

N/A

## How to test



## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~

