### PR TITLE
Updating date of last data submission

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -46,6 +46,6 @@ const constants = {
 
 export const NO_DATA = "TBD";
 
-export const LAST_DATA_UPDATE = "2025-09-04";
+export const LAST_DATA_UPDATE = "2025-09-06";
 
 export default constants;


### PR DESCRIPTION
## What changed

The frontend string constant that reflects the date corresponding to when OPRE last submitted BLI data to update that we've now processed.


## Issue

#4329