### PR TITLE
Modernization of direct obligation importing

### DIFF
--- a/backend/data_tools/src/load_direct_obligations/utils.py
+++ b/backend/data_tools/src/load_direct_obligations/utils.py
@@ -88,7 +88,7 @@ def create_models(data: DirectObligationData, sys_user: User, session: Session) 
     try:
         direct_obligation = DirectAgreement(
             name=data.DIRECT_OBLIGATION_NAME,
-            # maps_sys_id=data.SYS_DIRECT_OBLIGATION_ID,
+            id=data.SYS_DIRECT_OBLIGATION_ID,
             project=project,
             created_by=sys_user.id,
             updated_by=sys_user.id,
@@ -101,7 +101,6 @@ def create_models(data: DirectObligationData, sys_user: User, session: Session) 
         ).scalar_one_or_none()
 
         if existing_direct_obligation:
-            direct_obligation.id = existing_direct_obligation.id
             direct_obligation.created_on = existing_direct_obligation.created_on
 
         logger.debug(f"Created Direct Obligation model for {direct_obligation.to_dict()}")

--- a/backend/data_tools/tests/load_direct_obligations/test_load_direct_obligations.py
+++ b/backend/data_tools/tests/load_direct_obligations/test_load_direct_obligations.py
@@ -172,8 +172,8 @@ def test_create_models_upsert(db_for_direct_obligations):
         select(DirectAgreement).where(DirectAgreement.id == 100)
     ).scalar()
 
-    assert direct_obligation_model.name == "Research Support Services"
     assert direct_obligation_model.id == 100
+    assert direct_obligation_model.name == "Research Support Services"
     assert direct_obligation_model.project_id == 1
     assert direct_obligation_model.project.title == "Test Project"
     assert direct_obligation_model.created_by == sys_user.id


### PR DESCRIPTION
## What changed

Since we've now imported the initial Direct Obligations from MAPS, the ongoing DO upserting we're doing cares less about the maps sys id and should instead reference the OPS DO ID.

## Issue

#4329 

## How to test


## Screenshots


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
~- [ ] Form validations updated~
