### PR TITLE
feat: allows power user to edit obligate by date

### DIFF
--- a/frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js
+++ b/frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js
@@ -626,8 +626,6 @@ describe("Power User tests", () => {
                 cy.get("#need-by-date").type("02/02/2048");
                 cy.get("#enteredAmount").clear();
                 cy.get("#enteredAmount").type("1_000_000");
-                cy.get("#enteredAmount").clear();
-                cy.get("#enteredAmount").type("1_000_000");
                 cy.get("#can-combobox-input").clear();
                 cy.get("#can-combobox-input").type("G994426{enter}");
                 cy.get('[data-cy="update-budget-line"]').click();

--- a/frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js
+++ b/frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js
@@ -66,7 +66,7 @@ describe("Power User tests", () => {
         cy.get(".usa-card__body").should("contain", "power.user@email.com");
     });
 
-    it("can edit an CONTRACT agreement budget lines amount", () => {
+    it.only("can edit an CONTRACT agreement budget lines", () => {
         expect(localStorage.getItem("access_token")).to.exist;
 
         // create test agreement
@@ -119,6 +119,8 @@ describe("Power User tests", () => {
                         cy.get("#allServicesComponentSelect").select("SC1");
                         cy.get("#enteredAmount").clear();
                         cy.get("#enteredAmount").type("2_000_000");
+                        cy.get("#need-by-date").clear();
+                        cy.get("#need-by-date").type("02/02/2048");
                         cy.get('[data-cy="update-budget-line"]').click();
                         cy.get('[data-cy="continue-btn"]').click();
                         cy.get('[data-cy="alert"]').should("exist");
@@ -131,8 +133,10 @@ describe("Power User tests", () => {
                             .then(() => {
                                 // verify the updated amount is displayed in the table
                                 cy.visit(`http://localhost:3000/agreements/${agreementId}/budget-lines`);
-                                cy.get("@table-rows").eq(0).should("contain", "$2,000,000.00");
-
+                                cy.get("@table-rows")
+                                    .eq(0)
+                                    .should("contain", "$2,000,000.00")
+                                    .and("contains", "2/2/2048");
                                 cy.request({
                                     method: "DELETE",
                                     url: `http://localhost:8080/api/v1/budget-line-items/${bliId}`,

--- a/frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js
+++ b/frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js
@@ -66,7 +66,7 @@ describe("Power User tests", () => {
         cy.get(".usa-card__body").should("contain", "power.user@email.com");
     });
 
-    it.only("can edit an CONTRACT agreement budget lines", () => {
+    it("can edit an CONTRACT agreement budget lines", () => {
         expect(localStorage.getItem("access_token")).to.exist;
 
         // create test agreement
@@ -117,10 +117,10 @@ describe("Power User tests", () => {
                         cy.get("@table-rows").eq(0).find("[data-cy='expand-row']").click();
                         cy.get("[data-cy='edit-row']").click();
                         cy.get("#allServicesComponentSelect").select("SC1");
-                        cy.get("#enteredAmount").clear();
-                        cy.get("#enteredAmount").type("2_000_000");
                         cy.get("#need-by-date").clear();
                         cy.get("#need-by-date").type("02/02/2048");
+                        cy.get("#enteredAmount").clear();
+                        cy.get("#enteredAmount").type("2_000_000");
                         cy.get('[data-cy="update-budget-line"]').click();
                         cy.get('[data-cy="continue-btn"]').click();
                         cy.get('[data-cy="alert"]').should("exist");
@@ -131,12 +131,12 @@ describe("Power User tests", () => {
                                 );
                             })
                             .then(() => {
-                                // verify the updated amount is displayed in the table
+                                // verify the updated data is displayed in the table
                                 cy.visit(`http://localhost:3000/agreements/${agreementId}/budget-lines`);
                                 cy.get("@table-rows")
                                     .eq(0)
                                     .should("contain", "$2,000,000.00")
-                                    .and("contains", "2/2/2048");
+                                    .and("contain", "2/2/2048");
                                 cy.request({
                                     method: "DELETE",
                                     url: `http://localhost:8080/api/v1/budget-line-items/${bliId}`,
@@ -164,7 +164,7 @@ describe("Power User tests", () => {
             });
     });
 
-    it("can edit a GRANT agreement budget lines amount", () => {
+    it("can edit a GRANT agreement budget lines", () => {
         expect(localStorage.getItem("access_token")).to.exist;
 
         // create test agreement
@@ -216,6 +216,8 @@ describe("Power User tests", () => {
                         cy.get("@table-rows").eq(0).find("[data-cy='expand-row']").click();
                         cy.get("[data-cy='edit-row']").click();
                         cy.get("#allServicesComponentSelect").select("SC1");
+                        cy.get("#need-by-date").clear();
+                        cy.get("#need-by-date").type("02/02/2048");
                         cy.get("#enteredAmount").clear();
                         cy.get("#enteredAmount").type("2_000_000");
                         cy.get('[data-cy="update-budget-line"]').click();
@@ -228,9 +230,12 @@ describe("Power User tests", () => {
                                 );
                             })
                             .then(() => {
-                                // verify the updated amount is displayed in the table
+                                // verify the updated data is displayed in the table
                                 cy.visit(`http://localhost:3000/agreements/${agreementId}/budget-lines`);
-                                cy.get("@table-rows").eq(0).should("contain", "$2,000,000.00");
+                                cy.get("@table-rows")
+                                    .eq(0)
+                                    .should("contain", "$2,000,000.00")
+                                    .and("contain", "2/2/2048");
 
                                 cy.request({
                                     method: "DELETE",
@@ -259,7 +264,7 @@ describe("Power User tests", () => {
             });
     });
 
-    it("can edit an AA agreement budget lines amount", () => {
+    it("can edit an AA agreement budget lines", () => {
         expect(localStorage.getItem("access_token")).to.exist;
 
         // create test agreement
@@ -316,6 +321,8 @@ describe("Power User tests", () => {
                         cy.get("@table-rows").eq(0).find("[data-cy='expand-row']").click();
                         cy.get("[data-cy='edit-row']").click();
                         cy.get("#allServicesComponentSelect").select("SC1");
+                        cy.get("#need-by-date").clear();
+                        cy.get("#need-by-date").type("02/02/2048");
                         cy.get("#enteredAmount").clear();
                         cy.get("#enteredAmount").type("2_000_000");
                         cy.get('[data-cy="update-budget-line"]').click();
@@ -328,9 +335,12 @@ describe("Power User tests", () => {
                                 );
                             })
                             .then(() => {
-                                // verify the updated amount is displayed in the table
+                                // verify the updated data is displayed in the table
                                 cy.visit(`http://localhost:3000/agreements/${agreementId}/budget-lines`);
-                                cy.get("@table-rows").eq(0).should("contain", "$2,000,000.00");
+                                cy.get("@table-rows")
+                                    .eq(0)
+                                    .should("contain", "$2,000,000.00")
+                                    .and("contain", "2/2/2048");
 
                                 cy.request({
                                     method: "DELETE",
@@ -359,7 +369,7 @@ describe("Power User tests", () => {
             });
     });
 
-    it("can edit a Direct Obligation agreement budget lines amount", () => {
+    it("can edit a Direct Obligation agreement budget lines", () => {
         expect(localStorage.getItem("access_token")).to.exist;
 
         // create test agreement
@@ -411,6 +421,8 @@ describe("Power User tests", () => {
                         cy.get("@table-rows").eq(0).find("[data-cy='expand-row']").click();
                         cy.get("[data-cy='edit-row']").click();
                         cy.get("#allServicesComponentSelect").select("SC1");
+                        cy.get("#need-by-date").clear();
+                        cy.get("#need-by-date").type("02/02/2048");
                         cy.get("#enteredAmount").clear();
                         cy.get("#enteredAmount").type("2_000_000");
                         cy.get('[data-cy="update-budget-line"]').click();
@@ -423,9 +435,12 @@ describe("Power User tests", () => {
                                 );
                             })
                             .then(() => {
-                                // verify the updated amount is displayed in the table
+                                // verify the updated data is displayed in the table
                                 cy.visit(`http://localhost:3000/agreements/${agreementId}/budget-lines`);
-                                cy.get("@table-rows").eq(0).should("contain", "$2,000,000.00");
+                                cy.get("@table-rows")
+                                    .eq(0)
+                                    .should("contain", "$2,000,000.00")
+                                    .and("contain", "2/2/2048");
 
                                 cy.request({
                                     method: "DELETE",
@@ -454,7 +469,7 @@ describe("Power User tests", () => {
             });
     });
 
-    it("can edit a IAA agreement budget lines amount", () => {
+    it("can edit a IAA agreement budget lines", () => {
         expect(localStorage.getItem("access_token")).to.exist;
 
         const bearer_token = `Bearer ${window.localStorage.getItem("access_token")}`;
@@ -504,6 +519,8 @@ describe("Power User tests", () => {
                         cy.get("@table-rows").eq(0).find("[data-cy='expand-row']").click();
                         cy.get("[data-cy='edit-row']").click();
                         cy.get("#allServicesComponentSelect").select("SC1");
+                        cy.get("#need-by-date").clear();
+                        cy.get("#need-by-date").type("02/02/2048");
                         cy.get("#enteredAmount").clear();
                         cy.get("#enteredAmount").type("2_000_000");
                         cy.get('[data-cy="update-budget-line"]').click();
@@ -516,9 +533,12 @@ describe("Power User tests", () => {
                                 );
                             })
                             .then(() => {
-                                // verify the updated amount is displayed in the table
+                                // verify the updated data is displayed in the table
                                 cy.visit(`http://localhost:3000/agreements/${agreementId}/budget-lines`);
-                                cy.get("@table-rows").eq(0).should("contain", "$2,000,000.00");
+                                cy.get("@table-rows")
+                                    .eq(0)
+                                    .should("contain", "$2,000,000.00")
+                                    .and("contain", "2/2/2048");
 
                                 cy.request({
                                     method: "DELETE",
@@ -587,10 +607,10 @@ describe("Power User tests", () => {
                 cy.get("@table-rows").eq(0).find("[data-cy='expand-row']").click();
                 cy.get("[data-cy='edit-row']").click();
                 // edit DRAFT budget line
-                cy.get("#enteredAmount").clear();
-                cy.get("#enteredAmount").type("1_000_000");
                 cy.get("#need-by-date").clear();
                 cy.get("#need-by-date").type("02/02/2048");
+                cy.get("#enteredAmount").clear();
+                cy.get("#enteredAmount").type("1_000_000");
                 cy.get("#can-combobox-input").clear();
                 cy.get("#can-combobox-input").type("G994426{enter}");
                 cy.get('[data-cy="update-budget-line"]').click();

--- a/frontend/src/components/BudgetLineItems/BudgetLinesForm/BudgetLinesForm.jsx
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesForm/BudgetLinesForm.jsx
@@ -52,8 +52,8 @@ export const BudgetLinesForm = ({
     isReviewMode,
     budgetFormSuite,
     datePickerSuite,
-    isBudgetLineNotDraft = false,
-    isSuperUser = false
+    isBudgetLineNotDraft = false
+    // isSuperUser = false
 }) => {
     let dateRes = datePickerSuite.get();
 
@@ -110,7 +110,7 @@ export const BudgetLinesForm = ({
     };
 
     const isFormNotValid = dateRes.hasErrors() || budgetFormSuite.hasErrors();
-    const canSuperUserEdit = isSuperUser && isEditing && isBudgetLineNotDraft;
+    // const canSuperUserEdit = isSuperUser && isEditing && isBudgetLineNotDraft;
 
     return (
         <form
@@ -168,7 +168,7 @@ export const BudgetLinesForm = ({
                             validateDatePicker("needByDate", e.target.value);
                         }
                     }}
-                    isDisabled={canSuperUserEdit}
+                    // isDisabled={canSuperUserEdit}
                 />
                 <CurrencyInput
                     name="enteredAmount"

--- a/frontend/src/components/BudgetLineItems/BudgetLinesForm/BudgetLinesForm.jsx
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesForm/BudgetLinesForm.jsx
@@ -30,7 +30,6 @@ import DatePicker from "../../UI/USWDS/DatePicker";
  * @param {import('vest').Suite<any, any>} props.budgetFormSuite - The budget form validation suite.
  * @param {import('vest').Suite<any, any>} props.datePickerSuite - The date picker validation suite.
  * @param {boolean} props.isBudgetLineNotDraft - Whether the budget line is not in draft mode.
- * @param {boolean} [props.isSuperUser ]
  * @returns {React.ReactElement} - The rendered component.
  */
 export const BudgetLinesForm = ({
@@ -53,7 +52,6 @@ export const BudgetLinesForm = ({
     budgetFormSuite,
     datePickerSuite,
     isBudgetLineNotDraft = false
-    // isSuperUser = false
 }) => {
     let dateRes = datePickerSuite.get();
 
@@ -110,7 +108,6 @@ export const BudgetLinesForm = ({
     };
 
     const isFormNotValid = dateRes.hasErrors() || budgetFormSuite.hasErrors();
-    // const canSuperUserEdit = isSuperUser && isEditing && isBudgetLineNotDraft;
 
     return (
         <form
@@ -168,7 +165,6 @@ export const BudgetLinesForm = ({
                             validateDatePicker("needByDate", e.target.value);
                         }
                     }}
-                    // isDisabled={canSuperUserEdit}
                 />
                 <CurrencyInput
                     name="enteredAmount"

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
@@ -749,8 +749,7 @@ const useCreateBLIsAndSCs = (
         showModal,
         subTotalForCards,
         tempBudgetLines,
-        totalsForCards,
-        isSuperUser
+        totalsForCards
     };
 };
 

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
@@ -93,7 +93,6 @@ export const CreateBLIsAndSCs = ({
         isBudgetLineNotDraft,
         budgetFormSuite,
         datePickerSuite,
-        isSuperUser
     } = useCreateBLIsAndSCs(
         isEditMode,
         isReviewMode,
@@ -209,7 +208,6 @@ export const CreateBLIsAndSCs = ({
                     isBudgetLineNotDraft={isBudgetLineNotDraft}
                     budgetFormSuite={budgetFormSuite}
                     datePickerSuite={datePickerSuite}
-                    isSuperUser={isSuperUser}
                 />
             )}
 


### PR DESCRIPTION
## What changed

This PR enables power users to edit the "obligate by date" field in budget line items.

Key changes:

- Removes the isSuperUser parameter and related logic that disabled the obligate by date field
- Updates tests to verify that power users can now edit both amount and date fields
- Simplifies the BudgetLinesForm component by removing conditional date field disabling

## Issue

closes #4359 

## How to test

1. login as power user
2. goto /agreements/10
3. edit the planned budget line's obligate by date and save changes
4. ensure the changes are persisted

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated