### PR TITLE
docs: updates readme to reflect the watch flag is optional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,12 @@ bun run format
 
 ```bash
 # Run application with development server (hot reload)
+docker compose up --build
+
+# Run in detached mode
+docker compose up --build -d
+
+# Use enhanced file monitoring (optional, creates additional system overhead)
 docker compose up --build --watch
 
 # Run with production server configuration

--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ We have a Docker Compose configuration that makes it easy to run the application
 To run the application using the vite development server (allows hot reloading)...
 
 ```shell
+docker compose up --build
+```
+
+To run in detached mode...
+
+```shell
+docker compose up --build -d
+```
+
+To use enhanced file monitoring (optional, creates additional system overhead)...
+
+```shell
 docker compose up --build --watch
 ```
 


### PR DESCRIPTION
## What changed

Updates documentation to clarify Docker Compose usage options by providing multiple command variations and explicitly marking the --watch flag as optional with a note about system overhead.

- Adds standard Docker Compose commands without the watch flag
- Adds detached mode option with -d flag
- Clarifies that the --watch flag is optional and mentions its system overhead implications
