### PR TITLE
refactor: improve parameter naming clarity for calculateAgreementTotal

### DIFF
--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -34,20 +34,20 @@ export const getAgreementSubTotal = (agreement) => {
  * Calculates the total cost of a list of items, taking into account a fee per item and non-DRAFT budgetlines.
  * @param {import("../types/BudgetLineTypes").BudgetLine[]} budgetLines - The list of items to calculate the total cost for.
  * @param {number | null} feeRate - The fee rate as a percentage (e.g., 5 for 5%).
- * @param {boolean} [isAfterApproval] - Whether to include DRAFT budget lines or not.
+ * @param {boolean} [includeDraftBLIs] - Whether to include DRAFT budget lines or not.
  * @returns {number} The total cost of the items.
  */
-export const calculateAgreementTotal = (budgetLines, feeRate = null, isAfterApproval = false) => {
+export const calculateAgreementTotal = (budgetLines, feeRate = null, includeDraftBLIs = false) => {
     return (
         budgetLines
-            ?.filter(({ status }) => (isAfterApproval ? true : status !== BLI_STATUS.DRAFT))
+            ?.filter(({ status }) => (includeDraftBLIs ? true : status !== BLI_STATUS.DRAFT))
             .reduce(
                 (acc, { amount = 0, fees = 0 }) =>
-                    acc + amount + (
-                        // When feeRate is provided, calculate fees dynamically from the rate
-                        // When feeRate is null, use pre-calculated fees from the budget line
-                        feeRate !== null ? amount * (feeRate / 100) : fees
-                    ),
+                    acc +
+                    amount +
+                    // When feeRate is provided, calculate fees dynamically from the rate
+                    // When feeRate is null, use pre-calculated fees from the budget line
+                    (feeRate !== null ? amount * (feeRate / 100) : fees),
                 0
             ) || 0
     );

--- a/frontend/src/helpers/agreement.helpers.test.js
+++ b/frontend/src/helpers/agreement.helpers.test.js
@@ -215,13 +215,13 @@ describe("calculateTotal", () => {
         expect(result).toBe(512.5);
     });
 
-    it("excludes DRAFT budget lines when isAfterApproval is false", () => {
+    it("excludes DRAFT budget lines when includeDraftBLIs is false", () => {
         const result = calculateAgreementTotal(budgetLines, 5, false);
         // Only non-DRAFT: (200 + 300) + (200 + 300) * 0.05 = 500 + 25 = 525
         expect(result).toBe(525);
     });
 
-    it("includes all budget lines when isAfterApproval is true", () => {
+    it("includes all budget lines when includeDraftBLIs is true", () => {
         const result = calculateAgreementTotal(budgetLines, 5, true);
         // All lines: (100 + 200 + 300) + (100 + 200 + 300) * 0.05 = 600 + 30 = 630
         expect(result).toBe(630);
@@ -349,7 +349,7 @@ describe("getProcurementShopFees", () => {
         expect(result).toBe(15);
     });
 
-    it("includes fees for all budget lines when isAfterApproval is true", () => {
+    it("includes fees for all budget lines when includeDraftBLIs is true", () => {
         const result = getProcurementShopFees(agreement, budgetLines, true);
         // Both DRAFT and PLANNED budget line fees: (50 + 150) * 10 / 100 = 20
         expect(result).toBe(20);


### PR DESCRIPTION
## Summary
• Rename `isAfterApproval` parameter to `includeDraftBLIs` in `calculateAgreementTotal` function for better clarity
• Update corresponding test descriptions to match the new parameter name
• Minor code formatting improvements for better readability

The new parameter name `includeDraftBLIs` more clearly describes what the boolean controls - whether to include DRAFT budget line items in the calculation, rather than the more ambiguous `isAfterApproval`.