### PR TITLE
fix: revert Vite to 7.1.7 due to containerization regression

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -55,6 +55,11 @@
             "platformAutomerge": true
         },
         {
+            "matchPackageNames": ["vite"],
+            "allowedVersions": "7.1.7",
+            "description": "Pin Vite to 7.1.7 due to containerization regression in 7.1.8+"
+        },
+        {
             "matchDepTypes": [
                 "devDependencies",
                 "dev-packages"

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -73,7 +73,7 @@
         "redux-mock-store": "1.5.5",
         "sass-loader": "16.0.5",
         "semantic-release": "24.2.9",
-        "vite": "7.1.8",
+        "vite": "7.1.7",
         "vite-jsconfig-paths": "2.0.1",
         "vite-plugin-babel-macros": "1.0.6",
         "vite-plugin-eslint": "1.8.1",
@@ -2490,7 +2490,7 @@
 
     "vinyl-sourcemaps-apply": ["vinyl-sourcemaps-apply@0.2.1", "", { "dependencies": { "source-map": "^0.5.1" } }, "sha512-+oDh3KYZBoZC8hfocrbrxbLUeaYtQK7J5WU5Br9VqWqmCll3tFJqKp97GC9GmMsVIL0qnx2DgEDVxdo5EZ5sSw=="],
 
-    "vite": ["vite@7.1.8", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-oBXvfSHEOL8jF+R9Am7h59Up07kVVGH1NrFGFoEG6bPDZP3tGpQhvkBpy5x7U6+E6wZCu9OihsWgJqDbQIm8LQ=="],
+    "vite": ["vite@7.1.7", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA=="],
 
     "vite-jsconfig-paths": ["vite-jsconfig-paths@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "recrawl-sync": "^2.0.3", "tsconfig-paths": "^3.9.0" }, "peerDependencies": { "vite": ">2.0.0-0" } }, "sha512-rabcTTfKs0MdAsQWcZjbIMo5fcp6jthZce7uFEPgVPgpSY+RNOwjzIJOPES6cB/GJZLSoLGfHM9kt5HNmJvp7A=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,7 +77,7 @@
         "redux-mock-store": "1.5.5",
         "sass-loader": "16.0.5",
         "semantic-release": "24.2.9",
-        "vite": "7.1.8",
+        "vite": "7.1.7",
         "vite-jsconfig-paths": "2.0.1",
         "vite-plugin-babel-macros": "1.0.6",
         "vite-plugin-eslint": "1.8.1",


### PR DESCRIPTION
## Summary
- Revert Vite from 7.1.8 to 7.1.7 to fix frontend container startup failures
- Add Renovate configuration to pin Vite at 7.1.7 until upstream regression is resolved

## Problem
Vite 7.1.8 introduced a process spawning regression that causes the frontend container to hang at startup when using Bun in containerized environments. The container would show:

```
$ vite
[hangs indefinitely, then exits with code 0]
```

## Root Cause
Automatic dependency upgrade by Renovate on October 2nd upgraded Vite from 7.1.7 → 7.1.8. This version contains a regression affecting Bun + containerized environments.

## Solution
1. **Immediate fix**: Downgrade Vite to last known working version (7.1.7)
2. **Prevention**: Pin Vite version in Renovate config to prevent future automatic upgrades until regression is fixed upstream

## Testing
- ✅ Frontend container starts successfully with Vite 7.1.7
- ✅ Full stack runs without issues
- ✅ Vite dev server loads in 285ms (normal performance)

## Related Issues
- Upstream Vite issue: vitejs/vite#20884 (process spawning problems in v7.1.8)
- Related Bun compatibility issues: oven-sh/bun#22367, #21930