### PR TITLE
fix: export agreement list fee calculation

### DIFF
--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -17,11 +17,15 @@ const handleAgreementProp = (agreement) => {
 
 /**
  * Calculates the agreement subtotal based on the agreement and non-DRAFT budget lines.
- * @param {Object} agreement - The agreement object.
+ * @param {import("../types/AgreementTypes").Agreement} agreement - The agreement object.
  * @returns {number} - The agreement subtotal.
  */
 export const getAgreementSubTotal = (agreement) => {
     handleAgreementProp(agreement);
+
+    if (!agreement.budget_line_items || agreement.budget_line_items.length === 0) {
+        return 0;
+    }
 
     return (
         agreement.budget_line_items

--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -23,10 +23,6 @@ const handleAgreementProp = (agreement) => {
 export const getAgreementSubTotal = (agreement) => {
     handleAgreementProp(agreement);
 
-    if (!agreement.budget_line_items || agreement.budget_line_items.length === 0) {
-        return 0;
-    }
-
     return (
         agreement.budget_line_items
             ?.filter(({ status }) => status !== BLI_STATUS.DRAFT)

--- a/frontend/src/pages/agreements/list/AgreementsList.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.jsx
@@ -9,19 +9,19 @@ import {
     findNextNeedBy,
     getAgreementName,
     getAgreementSubTotal,
-    getProcurementShopSubTotal,
     getResearchProjectName
 } from "../../../components/Agreements/AgreementsTable/AgreementsTable.helpers";
 import ChangeRequests from "../../../components/ChangeRequests";
 import TablePageLayout from "../../../components/Layouts/TablePageLayout";
 import { setAlert } from "../../../components/UI/Alert/alertSlice";
+import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
+import { getAgreementFeesFromBackend } from "../../../helpers/agreement.helpers";
 import { exportTableToXlsx } from "../../../helpers/tableExport.helpers";
 import { convertCodeForDisplay } from "../../../helpers/utils";
 import icons from "../../../uswds/img/sprite.svg";
 import AgreementsFilterButton from "./AgreementsFilterButton/AgreementsFilterButton";
 import AgreementsFilterTags from "./AgreementsFilterTags/AgreementsFilterTags";
 import AgreementTabs from "./AgreementsTabs";
-import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
 
 /**
  * @typedef {import('../../../types/AgreementTypes').Agreement} Agreement
@@ -131,7 +131,7 @@ const AgreementsList = () => {
                     const agreementType = convertCodeForDisplay("agreementType", agreement?.agreement_type);
                     const contractType = convertCodeForDisplay("contractType", agreement?.contract_type);
                     const agreementSubTotal = getAgreementSubTotal(agreement);
-                    const agreementFees = getProcurementShopSubTotal(agreement);
+                    const agreementFees = getAgreementFeesFromBackend(agreement);
                     const nextBudgetLine = findNextBudgetLine(agreement);
                     const nextBudgetLineAmount = nextBudgetLine?.amount ?? 0;
                     let nextBudgetLineFees = nextBudgetLine?.fees;


### PR DESCRIPTION
## What changed

This PR refactors fee calculation in the agreements list by replacing a local helper function with a backend-sourced calculation and improves type safety and null handling in the agreement subtotal calculation.

- Replaced getProcurementShopSubTotal with getAgreementFeesFromBackend for consistent fee calculation
- Added null safety check for budget line items in getAgreementSubTotal
- Improved JSDoc type annotation for better TypeScript integration

## Issue

#4447

## How to test

1. goto agreements list
2. click on the export
3. review results

## Screenshots

<img width="1000" height="415" alt="SCR-20251006-jaht" src="https://github.com/user-attachments/assets/7756bdf2-151c-446e-8c22-5ac69c144d5c" />


## Definition of Done Checklist
- [-] OESA: Code refactored for clarity
- [-] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [-] 90%+ Code coverage achieved
- [-] Form validations updated