### PR TITLE
Ops 4385/obligate by bug

### DIFF
--- a/backend/models/cans.py
+++ b/backend/models/cans.py
@@ -216,9 +216,11 @@ class CANFundingDetails(BaseModel):
         return None
 
     @property
-    def obligate_by(self) -> Optional[int]:
+    def obligate_by(self) -> int:
         """The fiscal year in which the funds must be obligated by"""
-        return self.fiscal_year + self.active_period
+        if self.active_period == 0:  # Perpetual funds
+            return 9999  # Far future year
+        return self.fiscal_year + self.active_period - 1
 
 
 class CANFundingReceived(BaseModel):

--- a/backend/ops_api/ops/utils/cans.py
+++ b/backend/ops_api/ops/utils/cans.py
@@ -135,7 +135,7 @@ def get_can_funding_summary(can: CAN, fiscal_year: Optional[int] = None) -> CanF
             {
                 "can": can.to_dict(),
                 "carry_forward_label": carry_forward_label,
-                "expiration_date": f"10/01/{can.obligate_by}" if can.obligate_by else "",
+                "expiration_date": f"9/30/{can.obligate_by}" if can.obligate_by else "",
             }
         ],
         "carry_forward_funding": carry_forward_funding,

--- a/backend/ops_api/tests/ops/funding_summary/test_can_funding_summary.py
+++ b/backend/ops_api/tests/ops/funding_summary/test_can_funding_summary.py
@@ -237,7 +237,7 @@ def test_get_can_funding_summary_no_fiscal_year(loaded_db, test_can) -> None:
                     "created_by_user": None,
                     "description": "Healthy Marriages Responsible Fatherhood - " "OPRE",
                     "display_name": "G99HRF2",
-                    "expiration_date": 2024,
+                    "expiration_date": 2023,
                     "funding_budgets": [
                         {
                             "budget": "1140000.0",
@@ -296,7 +296,7 @@ def test_get_can_funding_summary_no_fiscal_year(loaded_db, test_can) -> None:
                     "updated_by_user": None,
                 },
                 "carry_forward_label": " Carry-Forward",
-                "expiration_date": "10/01/2024",
+                "expiration_date": "9/30/2023",
             }
         ],
         "carry_forward_funding": 0,
@@ -383,7 +383,7 @@ def test_get_can_funding_summary_with_fiscal_year(loaded_db, test_can) -> None:
                     "created_by_user": None,
                     "description": "Healthy Marriages Responsible Fatherhood - " "OPRE",
                     "display_name": "G99HRF2",
-                    "expiration_date": 2024,
+                    "expiration_date": 2023,
                     "funding_budgets": [
                         {
                             "budget": "1140000.0",
@@ -442,7 +442,7 @@ def test_get_can_funding_summary_with_fiscal_year(loaded_db, test_can) -> None:
                     "updated_by_user": None,
                 },
                 "carry_forward_label": " Carry-Forward",
-                "expiration_date": "10/01/2024",
+                "expiration_date": "9/30/2023",
             }
         ],
         "carry_forward_funding": 0,

--- a/frontend/src/components/CANs/CANTable/CANTable.helpers.js
+++ b/frontend/src/components/CANs/CANTable/CANTable.helpers.js
@@ -1,13 +1,4 @@
 /**
- * Gets the last day of the fiscal year for a given year.
- * @param {number} fiscalYear - The fiscal year
- * @returns {Date} The last day of the fiscal year
- */
-const getLastDayOfFiscalYear = (fiscalYear) => {
-    // Fiscal year ends on September 30 of the previous calendar year
-    return new Date(fiscalYear - 1, 8, 30); // Month is 0-indexed, so 8 is September
-};
-/**
  * Formats the obligate by date to the last day of the fiscal year.
  * @param {number | undefined} obligateBy - The obligate by value
  * @returns {string} Formatted date string or "TBD"
@@ -16,10 +7,10 @@ export const formatObligateBy = (obligateBy) => {
     if (!obligateBy) return "TBD"; // Default value
     if (typeof obligateBy !== "number" || isNaN(obligateBy)) return "TBD"; // Default if parsing fails
 
-    const lastDay = getLastDayOfFiscalYear(obligateBy);
+    const getDateFromFiscalYear = new Date(obligateBy, 8, 30);
 
     // Format as MM/DD/YY
-    return lastDay.toLocaleDateString("en-US", {
+    return getDateFromFiscalYear.toLocaleDateString("en-US", {
         month: "2-digit",
         day: "2-digit",
         year: "2-digit"

--- a/frontend/src/components/CANs/CANTable/CANTable.helpers.test.js
+++ b/frontend/src/components/CANs/CANTable/CANTable.helpers.test.js
@@ -18,12 +18,12 @@ describe("formatObligateBy", () => {
     });
 
     test("formats valid fiscal year correctly", () => {
-        expect(formatObligateBy(2023)).toBe("09/30/22");
+        expect(formatObligateBy(2023)).toBe("09/30/23");
     });
 
     test("handles different fiscal years", () => {
-        expect(formatObligateBy(2024)).toBe("09/30/23");
-        expect(formatObligateBy(2025)).toBe("09/30/24");
+        expect(formatObligateBy(2024)).toBe("09/30/24");
+        expect(formatObligateBy(2025)).toBe("09/30/25");
     });
 });
 

--- a/frontend/src/components/CANs/CanCard/CanCard.jsx
+++ b/frontend/src/components/CANs/CanCard/CanCard.jsx
@@ -26,7 +26,7 @@ const CanCard = ({ canId, fiscalYear }) => {
     const appropriationYear = canFundingData?.cans[0].can.appropriation_date;
     const expirationDate = new Date(canFundingData?.cans[0].expiration_date);
     const obligateBy = new Date(expirationDate);
-    obligateBy.setDate(obligateBy.getDate() - 1);
+    obligateBy.setDate(obligateBy.getDate());
 
     const receivedPercent = calculatePercent(canFundingData?.received_funding, canFundingData?.total_funding);
     const receivedExpectedData = [


### PR DESCRIPTION
## What changed

- Change semantics of `obligate_by` to the last valid fiscal year rather than the following year
- Fix inconsistency in the UI `CANCard` and `CANFundingDetails`

## Issue

https://github.com/HHS/OPRE-OPS/issues/4385

## How to test

Automated tests pass.

## Screenshots

_If relevant, e.g. for a front-end feature_

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated
