### PR TITLE
fix: suppress Cypress DBUS and terminal noise in CI

### DIFF
--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install minimal runtime deps for headless browser
         run: |
           sudo apt-get update
-          sudo apt-get install -y dbus-x11 xvfb libgtk-3-0 libnss3 libxss1 libasound2 libgbm1
+          sudo apt-get install -y dbus-x11 xvfb libgtk-3-0 libnss3 libxss1 libasound2t64 libgbm1
 
       - name: Run Cypress (dbus-run-session)
         working-directory: frontend

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -61,11 +61,12 @@ jobs:
           TEST_FILE=$(basename "${{ matrix.file }}" | sed 's/\.cy\.js//')
           echo "TEST_FILE=$TEST_FILE" >> $GITHUB_OUTPUT
 
-      # Setup virtual display for Cypress
-      - name: Setup X11 Virtual Display
+      # Setup virtual display and dependencies for Cypress
+      - name: Setup X11 Virtual Display and Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb
+          sudo apt-get install -y xvfb dbus-x11 libgtk-3-0 libgconf-2-4 libnss3-dev libxss1 libasound2-dev
+          sudo service dbus start
           export DISPLAY=:99
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 
@@ -77,7 +78,6 @@ jobs:
           NO_COLOR: 1
           DISPLAY: :99
         run: |
-          unset DBUS_SESSION_BUS_ADDRESS
           bun run cypress install && bun run test:e2e:ci --spec $(echo "${{ matrix.file }}" | sed 's/frontend\///')
 
       # Upload Cypress screenshots as artifact if a test fails

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup X11 Virtual Display and Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb dbus-x11 libgtk-3-0 libgconf-2-4 libnss3-dev libxss1 libasound2-dev
+          sudo apt-get install -y xvfb dbus-x11 libgtk-3-0 libnss3-dev libxss1 libasound2-dev libgbm1
           sudo service dbus start
           export DISPLAY=:99
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -63,10 +63,11 @@ jobs:
         with:
           working-directory: frontend
           quiet: true
-          # Use the matrix file directly as spec (strip leading frontend/)
-          spec: $(echo "${{ matrix.file }}" | sed 's/frontend\///')
+          spec: ${{ matrix.file }}
           config-file: frontend/cypress.config.ci.js
-          install-command: bun install --frozen-lockfile
+          # We already installed deps in setup-javascript (bun). Supply a noop to skip lockfile expectation.
+          install-command: echo "Deps installed via setup-javascript"
+          build: echo "Skip build step"
         env:
           TERM: xterm
           CYPRESS_CACHE_FOLDER: ~/.cache/Cypress

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -67,6 +67,8 @@ jobs:
         env:
           TERM: xterm
           NO_COLOR: 1
+          DBUS_SESSION_BUS_ADDRESS: /dev/null
+          DISPLAY: :99
         run: |
           bun run cypress install && bun run test:e2e:ci --spec $(echo "${{ matrix.file }}" | sed 's/frontend\///')
 

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -63,28 +63,20 @@ jobs:
           REL_SPEC=$(echo "${{ matrix.file }}" | sed 's#^frontend/##')
           echo "REL_SPEC=$REL_SPEC" >> $GITHUB_OUTPUT
 
-      - name: Generate npm lockfile (for Cypress action)
-        working-directory: frontend
+      - name: Install minimal runtime deps for headless browser
         run: |
-          if [ ! -f package-lock.json ]; then
-            npm install --package-lock-only --no-audit --no-fund
-          fi
+          sudo apt-get update
+          sudo apt-get install -y dbus-x11 xvfb libgtk-3-0 libnss3 libxss1 libasound2 libgbm1
 
-      - name: Cypress Run
-        uses: cypress-io/github-action@v6
-        with:
-          working-directory: frontend
-          quiet: true
-          spec: ${{ steps.rel-spec.outputs.REL_SPEC }}
-          config-file: frontend/cypress.config.ci.js
-          install-command: echo "Deps installed via setup-javascript (bun)"
-          build: echo "Skip build step"
+      - name: Run Cypress (dbus-run-session)
+        working-directory: frontend
         env:
           TERM: xterm
-          CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
-          # Needed for app under test
           JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
           JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
+        run: |
+          echo "Spec: ${{ steps.rel-spec.outputs.REL_SPEC }}"
+          dbus-run-session -- npx cypress run --config-file ./cypress.config.ci.js --headless --spec "${{ steps.rel-spec.outputs.REL_SPEC }}"
 
       # Upload Cypress screenshots as artifact if a test fails
       - name: Upload screenshots if failure

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -61,6 +61,14 @@ jobs:
           TEST_FILE=$(basename "${{ matrix.file }}" | sed 's/\.cy\.js//')
           echo "TEST_FILE=$TEST_FILE" >> $GITHUB_OUTPUT
 
+      # Setup virtual display for Cypress
+      - name: Setup X11 Virtual Display
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          export DISPLAY=:99
+          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+
       # Run the Cypress E2E Tests
       - name: E2E Test
         working-directory: frontend

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install minimal runtime deps for headless browser
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends dbus-x11 xvfb libgtk-3-0 libnss3 libxss1 libasound2 libgbm1
+          sudo apt-get install -y --no-install-recommends dbus-x11 xvfb libgtk-3-0 libnss3 libxss1 libasound2t64 libgbm1
 
       - name: Run Cypress (dbus-run-session)
         working-directory: frontend

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -64,6 +64,9 @@ jobs:
       # Run the Cypress E2E Tests
       - name: E2E Test
         working-directory: frontend
+        env:
+          TERM: xterm
+          NO_COLOR: 1
         run: |
           bun run cypress install && bun run test:e2e:ci --spec $(echo "${{ matrix.file }}" | sed 's/frontend\///')
 

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -75,9 +75,9 @@ jobs:
         env:
           TERM: xterm
           NO_COLOR: 1
-          DBUS_SESSION_BUS_ADDRESS: /dev/null
           DISPLAY: :99
         run: |
+          unset DBUS_SESSION_BUS_ADDRESS
           bun run cypress install && bun run test:e2e:ci --spec $(echo "${{ matrix.file }}" | sed 's/frontend\///')
 
       # Upload Cypress screenshots as artifact if a test fails

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -99,4 +99,4 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           path: full-stack-logs-${{ steps.get-filename.outputs.TEST_FILE }}.log
-          name: full-stack-logs-${{ github.run_id }}-${{ github.sha }}-${{ steps.get-filename.outputs.TEST_FILE }}
+          name: full-stack-logs-${{ github.run_id }}-${{ github.sha }}-${{ steps.get-filename.outputs.TEST_FILE }}.log

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install minimal runtime deps for headless browser
         run: |
           sudo apt-get update
-          sudo apt-get install -y dbus-x11 xvfb libgtk-3-0 libnss3 libxss1 libasound2t64 libgbm1
+          sudo apt-get install -y --no-install-recommends dbus-x11 xvfb libgtk-3-0 libnss3 libxss1 libasound2 libgbm1
 
       - name: Run Cypress (dbus-run-session)
         working-directory: frontend

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -50,10 +50,6 @@ jobs:
           JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
           JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
 
-      # Install Cypress globally
-      - name: Install Cypress globally
-        run: bun install -g cypress
-
       # Extract test filename
       - name: Get Filename
         id: get-filename
@@ -61,24 +57,22 @@ jobs:
           TEST_FILE=$(basename "${{ matrix.file }}" | sed 's/\.cy\.js//')
           echo "TEST_FILE=$TEST_FILE" >> $GITHUB_OUTPUT
 
-      # Setup virtual display and dependencies for Cypress
-      - name: Setup X11 Virtual Display and Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y xvfb dbus-x11 libgtk-3-0 libnss3-dev libxss1 libasound2-dev libgbm1
-          sudo service dbus start
-          export DISPLAY=:99
-          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-
-      # Run the Cypress E2E Tests
-      - name: E2E Test
-        working-directory: frontend
+      # Run Cypress tests using official action
+      - name: Cypress Run
+        uses: cypress-io/github-action@v6
+        with:
+          working-directory: frontend
+          quiet: true
+          # Use the matrix file directly as spec (strip leading frontend/)
+          spec: $(echo "${{ matrix.file }}" | sed 's/frontend\///')
+          config-file: frontend/cypress.config.ci.js
+          install-command: bun install --frozen-lockfile
         env:
           TERM: xterm
-          NO_COLOR: 1
-          DISPLAY: :99
-        run: |
-          bun run cypress install && bun run test:e2e:ci --spec $(echo "${{ matrix.file }}" | sed 's/frontend\///')
+          CYPRESS_CACHE_FOLDER: ~/.cache/Cypress
+          # Needed for app under test
+          JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
+          JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
 
       # Upload Cypress screenshots as artifact if a test fails
       - name: Upload screenshots if failure
@@ -100,7 +94,5 @@ jobs:
         if: always() # Ensure this runs, even if E2E fails
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          # Set the path to the log file
-          path: full-stack-logs-${{ steps.get-filename.outputs.TEST_FILE }}
-          # Optionally, set a name for the artifact
-          name: full-stack-logs-${{ github.run_id }}-${{ github.sha }}-${{ steps.get-filename.outputs.TEST_FILE }}.log
+          path: full-stack-logs-${{ steps.get-filename.outputs.TEST_FILE }}.log
+          name: full-stack-logs-${{ github.run_id }}-${{ github.sha }}-${{ steps.get-filename.outputs.TEST_FILE }}

--- a/.github/workflows/e2e_test_reusable.yml
+++ b/.github/workflows/e2e_test_reusable.yml
@@ -57,16 +57,27 @@ jobs:
           TEST_FILE=$(basename "${{ matrix.file }}" | sed 's/\.cy\.js//')
           echo "TEST_FILE=$TEST_FILE" >> $GITHUB_OUTPUT
 
-      # Run Cypress tests using official action
+      - name: Derive Relative Spec Path
+        id: rel-spec
+        run: |
+          REL_SPEC=$(echo "${{ matrix.file }}" | sed 's#^frontend/##')
+          echo "REL_SPEC=$REL_SPEC" >> $GITHUB_OUTPUT
+
+      - name: Generate npm lockfile (for Cypress action)
+        working-directory: frontend
+        run: |
+          if [ ! -f package-lock.json ]; then
+            npm install --package-lock-only --no-audit --no-fund
+          fi
+
       - name: Cypress Run
         uses: cypress-io/github-action@v6
         with:
           working-directory: frontend
           quiet: true
-          spec: ${{ matrix.file }}
+          spec: ${{ steps.rel-spec.outputs.REL_SPEC }}
           config-file: frontend/cypress.config.ci.js
-          # We already installed deps in setup-javascript (bun). Supply a noop to skip lockfile expectation.
-          install-command: echo "Deps installed via setup-javascript"
+          install-command: echo "Deps installed via setup-javascript (bun)"
           build: echo "Skip build step"
         env:
           TERM: xterm


### PR DESCRIPTION
## Summary

• Eliminates noisy DBus and terminal warnings from Cypress E2E tests in GitHub Actions while maintaining test functionality
• Optimizes CI performance by installing minimal required packages with --no-install-recommends
• Improves compatibility across Ubuntu versions by using standard package names

## Changes Made

• Added runtime dependencies: Install minimal system packages (dbus-x11, xvfb, libgtk-3-0, etc.) required for headless browser operation
• Wrapped Cypress execution in dbus-run-session to provide proper DBus context and eliminate warnings
• Fixed artifact upload path to include .log extension matching generated log files
• Optimized package installation with --no-install-recommends flag and Ubuntu 22.04 compatible package names

## Alternative Approaches Considered

• Official Cypress GitHub Action: Attempted but incompatible with Bun lockfile format
• Environment variable suppression: Tried various env vars (TERM, NO_COLOR, DBUS_SESSION_BUS_ADDRESS) but insufficient for eliminating all noise
• Complete noise hiding: Rejected in favor of "fix not hide" approach by installing proper dependencies
