### PR TITLE
Updating datestamp of last submission for import

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -46,6 +46,6 @@ const constants = {
 
 export const NO_DATA = "TBD";
 
-export const LAST_DATA_UPDATE = "2025-09-26";
+export const LAST_DATA_UPDATE = "2025-11-03";
 
 export default constants;


### PR DESCRIPTION
## What changed

the frontend constant representing the datestamp of the last OPRE submission to us of data that has been imported. 

## Issue

#4602

## How to test

check out the banner after logging in to a production build of the frontend
