### PR TITLE
chore: adding extra logging to 403 error handlers to catch details

### DIFF
--- a/backend/ops_api/ops/error_handlers.py
+++ b/backend/ops_api/ops/error_handlers.py
@@ -67,6 +67,7 @@ def register_error_handlers(app):  # noqa: C901
         """
         Handle exception when the user is not authorized to access the resource.
         """
+        app.logger.warning(f"Forbidden access: {e}")
         return make_response_with_headers({}, 403)
 
     @app.errorhandler(BadRequest)
@@ -112,6 +113,7 @@ def register_error_handlers(app):  # noqa: C901
 
     @app.errorhandler(AuthorizationError)
     def handle_authorization_error(e):
+        app.logger.exception(e)
         return make_response_with_headers({"message": e.message}, 403)
 
     @app.errorhandler(UserInactiveError)


### PR DESCRIPTION
## What changed

Adding logging to the two 403-related error handlers to see if I can isolate what exactly is happening when attempting to create an agreement with a BLI that belongs to specific CANs

## Issue

OPS-4721

## How to test

Nothing to test


## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

