### PR TITLE
Improving can import with no existing id numbers

### DIFF
--- a/backend/data_tools/src/load_cans/utils.py
+++ b/backend/data_tools/src/load_cans/utils.py
@@ -52,7 +52,8 @@ class CANData:
             raise ValueError("FISCAL_YEAR and CAN_NBR are required.")
 
         self.FISCAL_YEAR = int(self.FISCAL_YEAR)
-        self.SYS_CAN_ID = int(self.SYS_CAN_ID) if self.SYS_CAN_ID.isdigit() else None
+        if isinstance(self.SYS_CAN_ID, str):
+            self.SYS_CAN_ID = int(self.SYS_CAN_ID) if self.SYS_CAN_ID.isdigit() else None
         self.CAN_NBR = str(self.CAN_NBR)
         self.CAN_DESCRIPTION = str(self.CAN_DESCRIPTION) if self.CAN_DESCRIPTION else None
         self.FUND = str(self.FUND) if self.FUND else None


### PR DESCRIPTION
## What changed

Previously, importing CANs did not handle a totally new CAN gracefully. The id number would get generated in the main cans table but then wasn't known to other operations such as at the history table and other dependent tables that needed the new ID number.  One could alternatively manually assign a new ID number outside the auspices of the Postgres sequence for the ID number, but that then makes the sequence quite angry.

So this grabs the new ID number from the returned `can` object during the SQLAlchemy merge operation and then lets all the other downstream operations use that new ID number. 


## Issue

#4799

## How to test

import some new CANs with an empty string for the SYS_CAN_ID module. Alternatively, if you put "new" or nothing that's not digits it should also have the same effect. 

## Screenshots

N/A

## Definition of Done Checklist
~- [ ] OESA: Code refactored for clarity~
~- [ ] OESA: Dependency rules followed~
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~


## Links

_If relevant, e.g. for a link to a piece of markdown documentation_
