### PR TITLE
Update required param test in FE unit test to use async/await

### DIFF
--- a/frontend/src/pages/researchProjects/detail/getResearchProject.test.js
+++ b/frontend/src/pages/researchProjects/detail/getResearchProject.test.js
@@ -25,13 +25,15 @@ test("successfully gets the Research Project from the backend", async () => {
     expect(actualResponse).toStrictEqual(actualResponse);
 });
 
-test("required param missing", () => {
+test("required param missing", async () => {
     expect.assertions(1);
-    return getResearchProject().catch((e) =>
+    try {
+        await getResearchProject();
+    } catch (e) {
         expect(e).toEqual(
             expect.objectContaining({
                 message: "id is required"
             })
-        )
-    );
+        );
+    }
 });


### PR DESCRIPTION
## What changed

Refactors a test to use asynchronous/await and a try catch rather than calling expect inside conditional statements. This makes linters happier and might just satisfy the issue we're seeing when some of our dependency versions get bumped up in renovate PR #4559 

## Issue

## How to test

See if other tests still pass and if with the updates in #4559, if the same errors in our testing suites persist

## Screenshots

N/A

## Definition of Done Checklist
~- [ ] OESA: Code refactored for clarity~
~- [ ] OESA: Dependency rules followed~
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
- [x] Form validations updated

