### PR TITLE
Security: updating github actions to have explicit permissions

### DIFF
--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   deployment:
     name: Deploy to ${{ inputs.space }}

--- a/.github/workflows/dev_be_build_and_deploy.yml
+++ b/.github/workflows/dev_be_build_and_deploy.yml
@@ -51,7 +51,8 @@ jobs:
 
   deploy-data-tools:
     needs: build-data-tools
-
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -81,7 +82,8 @@ jobs:
 
   deploy-backend:
     needs: build-backend
-
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/prod_be_build_and_deploy.yml
+++ b/.github/workflows/prod_be_build_and_deploy.yml
@@ -46,7 +46,8 @@ jobs:
 
   deploy-data-tools:
     needs: build-data-tools
-
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -69,7 +70,8 @@ jobs:
 
   deploy-backend:
     needs: build-backend
-
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/stg_be_build_and_deploy.yml
+++ b/.github/workflows/stg_be_build_and_deploy.yml
@@ -51,7 +51,8 @@ jobs:
 
   deploy-data-tools:
     needs: build-data-tools
-
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -75,7 +76,8 @@ jobs:
 
   deploy-backend:
     needs: build-backend
-
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/unit_test_reusable.yml
+++ b/.github/workflows/unit_test_reusable.yml
@@ -1,6 +1,9 @@
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   backend-api:
     name: Backend API Unit Tests


### PR DESCRIPTION
## What changed

Added basic read only privileges to some github actions that had no explicit actions provided. 

## Issue

[OPS-4858](https://github.com/HHS/OPRE-OPS/issues/4858)

## How to test

1. Build processes should succeed in github. I don't know if there's a way to test deployments without actually doing a deploy. 


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated


## Links

[Blog article on security risks of Github Actions](https://orca.security/resources/blog/github-actions-security-risks/)
