### PR TITLE
Pin trufflehog OSS GHA to a specific commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,12 @@ on:
   push:
     branches: [main, development, staging]
     paths-ignore:
-      - '.github/**' # We don't want to trigger when we update the workflows.
-      - 'docs/**' # We don't want to trigger when we update the docs.
-      - '*.md'
-      - 'terraform/**'
+      - ".github/**" # We don't want to trigger when we update the workflows.
+      - "docs/**" # We don't want to trigger when we update the docs.
+      - "*.md"
+      - "terraform/**"
 
 jobs:
-
   secret-scanning:
     name: Trufflehog Secret Scanning
     runs-on: ubuntu-latest
@@ -23,7 +22,7 @@ jobs:
           fetch-depth: 0
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@ef6e76c3c4023279497fab4721ffa071a722fd05 # v3.92.4
         env:
           GITHUB_HEAD_REF_SAFE: ${{ github.head_ref }}
         continue-on-error: true


### PR DESCRIPTION
## What changed

Taking the only 3rd party Github Action that is pinned to a tag and pinning it to a commit hash. 

## Issue

[OPS-4869](https://github.com/HHS/OPRE-OPS/issues/4869)

## How to test

Github Build process should still pass

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated


## Links

[Github Action security article](https://orca.security/resources/blog/github-actions-security-risks/)
