### PR TITLE
Updating fontawesome and adapting frontend unit test

### DIFF
--- a/frontend/src/components/UI/Cards/BudgetCard/BigBudgetCard.test.jsx
+++ b/frontend/src/components/UI/Cards/BudgetCard/BigBudgetCard.test.jsx
@@ -27,7 +27,7 @@ describe("BudgetSummaryCard", () => {
 
         render(<BigBudgetCard {...overBudgetProps} />);
 
-        expect(screen.getByText("Over Budget")).toBeInTheDocument();
+        expect(screen.getByTitle("Over Budget")).toBeInTheDocument();
     });
 
     it("displays correct spending and funding amounts", () => {

--- a/frontend/src/components/UI/Cards/BudgetCard/BudgetCard.test.jsx
+++ b/frontend/src/components/UI/Cards/BudgetCard/BudgetCard.test.jsx
@@ -27,7 +27,7 @@ describe("BudgetSummaryCard", () => {
 
         render(<BudgetCard {...overBudgetProps} />);
 
-        expect(screen.getByText("Over Budget")).toBeInTheDocument();
+        expect(screen.getByTitle("Over Budget")).toBeInTheDocument();
     });
 
     it("displays correct spending and funding amounts", () => {

--- a/frontend/src/tests/setupTests.js
+++ b/frontend/src/tests/setupTests.js
@@ -22,6 +22,35 @@ globalThis.Headers = UndiciHeaders;
 const noop = () => {};
 Object.defineProperty(window, "scrollTo", { value: noop, writable: true });
 
+// Mock localStorage
+const localStorageMock = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn()
+};
+global.localStorage = localStorageMock;
+
+// Mock FontAwesome icons for proper rendering in tests
+vi.mock("@fortawesome/react-fontawesome", () => ({
+    FontAwesomeIcon: ({ icon, title, className, onClick, ...props }) => {
+        // Extract icon name from the icon definition
+        const iconName = icon?.iconName || title || "icon";
+        return (
+            <svg
+                role="img"
+                aria-label={title}
+                className={className}
+                onClick={onClick}
+                data-icon={iconName}
+                {...props}
+            >
+                <title>{title}</title>
+            </svg>
+        );
+    }
+}));
+
 // Setup root element for react-modal
 const root = document.createElement("div");
 root.setAttribute("id", "root");


### PR DESCRIPTION
## What changed

Upgrading fontawesome major version and adapting a couple frontend unit tests accordingly for breaking changes. Renovate has been trying to upgrade it since the summer and has been blocked due to breaking changes.

FontAwesome v7 exposed tests that call localStorage.getItem(), but jsdom doesn't provide a localStorage implementation by default. So this PR implements a mock of localStorage to keep those tests functional.

FontAwesome v7 changed how icons render in jsdom test environments, causing tests to fail when looking for icon elements. This PR creates a mock that renders the FA7 icons as SVG elements with the desired attributes for a11y testing.

## Issue

#4134

## How to test

See if CI tests pass

## Screenshots

N/A

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~


## Links