### PR TITLE
feat: remove default placeholder from portfolio filter

### DIFF
--- a/frontend/src/pages/portfolios/list/PortfolioFilterButton/AvailableBudgetPercentageFilter.jsx
+++ b/frontend/src/pages/portfolios/list/PortfolioFilterButton/AvailableBudgetPercentageFilter.jsx
@@ -70,7 +70,6 @@ const AvailableBudgetPercentageFilter = ({
                         data={rangeOptions}
                         selectedData={selectedRangeObjects}
                         setSelectedData={handleRangeChange}
-                        defaultString="Available Budget"
                         overrideStyles={{ width: "22.7rem" }}
                         isMulti={true}
                     />

--- a/frontend/src/pages/portfolios/list/PortfolioFilterButton/AvailableBudgetPercentageFilter.test.jsx
+++ b/frontend/src/pages/portfolios/list/PortfolioFilterButton/AvailableBudgetPercentageFilter.test.jsx
@@ -29,7 +29,7 @@ describe("AvailableBudgetPercentageFilter", () => {
         // ComboBox shows placeholder text when no selection is made
         // Text appears in both label and placeholder, so we verify it exists
         const placeholderTexts = screen.getAllByText("Available Budget");
-        expect(placeholderTexts.length).toBeGreaterThanOrEqual(2); // Label + placeholder
+        expect(placeholderTexts.length).toBeGreaterThanOrEqual(1); // Label + placeholder
     });
 
     it("should display selected ranges", () => {

--- a/frontend/src/pages/portfolios/list/PortfolioFilterButton/PortfolioFilterButton.jsx
+++ b/frontend/src/pages/portfolios/list/PortfolioFilterButton/PortfolioFilterButton.jsx
@@ -92,7 +92,6 @@ export const PortfolioFilterButton = ({ filters, setFilters, allPortfolios, fyBu
                 selectedPortfolios={portfolios}
                 setSelectedPortfolios={setPortfolios}
                 legendClassname={legendStyles}
-                defaultString={"All Portfolios"}
                 overrideStyles={{ width: "22.7rem" }}
             />
         </fieldset>,

--- a/frontend/src/pages/portfolios/list/PortfolioFilterButton/PortfolioFilterButton.test.jsx
+++ b/frontend/src/pages/portfolios/list/PortfolioFilterButton/PortfolioFilterButton.test.jsx
@@ -129,7 +129,6 @@ describe("PortfolioFilterButton", () => {
         await user.click(filterButton);
 
         await waitFor(() => {
-            expect(screen.getByText("All Portfolios")).toBeInTheDocument();
             expect(screen.getByText("FY Budget")).toBeInTheDocument();
             // "Available Budget" appears in both label and placeholder
             expect(screen.getAllByText("Available Budget")[0]).toBeInTheDocument();


### PR DESCRIPTION
## What changed

This PR removes the defaultString prop from two ComboBox components in the portfolio filter UI:
  - Portfolio selector ComboBox - removed "All Portfolios" placeholder
  - Available Budget Percentage filter ComboBox - removed "Available Budget" placeholder

## Issue

#4930 

## How to test

1. goto /portfolios
2. Click the filter button
3. The default filter placeholder should be removed

## Screenshots

<img width="474" height="419" alt="Screenshot 2026-01-28 at 10 09 34 PM" src="https://github.com/user-attachments/assets/bf439d34-eae7-49a1-b800-5cb2a820f1a6" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated