### PR TITLE
test: stabilize frontend tests in local env

### DIFF
--- a/frontend/src/api/opsAPI.test.js
+++ b/frontend/src/api/opsAPI.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, beforeAll, afterEach, afterAll } from "vitest";
 import { server } from "../tests/mocks";
 import { http, HttpResponse } from "msw";

--- a/frontend/src/pages/agreements/details/AgreementDetails.test.js
+++ b/frontend/src/pages/agreements/details/AgreementDetails.test.js
@@ -41,6 +41,11 @@ vi.mock("react", async () => {
     };
 });
 
+vi.mock("./AgreementDetailsEdit", () => ({
+    __esModule: true,
+    default: () => <div data-testid="agreement-details-edit" />
+}));
+
 const agreementHistoryData = [
     {
         changes: {

--- a/frontend/src/tests/setupTests.js
+++ b/frontend/src/tests/setupTests.js
@@ -10,7 +10,9 @@ import { opsApi } from "../api/opsAPI";
 // The previous undici setup was causing issues with MSW in jsdom 28
 
 const noop = () => {};
-Object.defineProperty(window, "scrollTo", { value: noop, writable: true });
+if (typeof window !== "undefined") {
+    Object.defineProperty(window, "scrollTo", { value: noop, writable: true });
+}
 
 // Mock localStorage
 const localStorageMock = {
@@ -42,15 +44,19 @@ vi.mock("@fortawesome/react-fontawesome", () => ({
 }));
 
 // Setup root element for react-modal
-const root = document.createElement("div");
-root.setAttribute("id", "root");
-document.body.appendChild(root);
+if (typeof document !== "undefined") {
+    const root = document.createElement("div");
+    root.setAttribute("id", "root");
+    document.body.appendChild(root);
+}
 
 const observe = vi.fn();
 
-window.IntersectionObserver = vi.fn(function () {
-    this.observe = observe;
-});
+if (typeof window !== "undefined") {
+    window.IntersectionObserver = vi.fn(function () {
+        this.observe = observe;
+    });
+}
 
 ApplicationContext.registerApplicationContext(TestApplicationContext);
 


### PR DESCRIPTION
## Summary
- run opsAPI pagination tests in node env to avoid AbortSignal mismatch in jsdom
- mock AgreementDetailsEdit to keep header tests focused and avoid deep edit tree
- guard setupTests for node environment

## Testing
- bun run test --watch=false src/pages/agreements/details/AgreementDetails.test.js src/api/opsAPI.test.js
