### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # OPRE OPS
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/HHS/OPRE-OPS)
 
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/HHS/OPRE-OPS) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.