### PR TITLE
fix: fix HorizontalStackedBar corner styling

### DIFF
--- a/frontend/src/components/UI/DataViz/HorizontalStackedBar/HorizontalStackedBar.jsx
+++ b/frontend/src/components/UI/DataViz/HorizontalStackedBar/HorizontalStackedBar.jsx
@@ -21,7 +21,7 @@ import styles from "./HorizontalStackedBar.module.scss";
  * @returns {JSX.Element}
  */
 const HorizontalStackedBar = ({ data, setActiveId = () => {} }) => {
-    const segments = data?.filter((item) => !item.isPlaceholder) ?? [];
+    const segments = data?.filter((item) => !item.isPlaceholder && item.percent > 0) ?? [];
 
     if (segments.length === 0) {
         return null;

--- a/frontend/src/components/UI/DataViz/HorizontalStackedBar/HorizontalStackedBar.test.jsx
+++ b/frontend/src/components/UI/DataViz/HorizontalStackedBar/HorizontalStackedBar.test.jsx
@@ -284,6 +284,46 @@ describe("HorizontalStackedBar", () => {
         expect(screen.queryByRole("button")).not.toBeInTheDocument();
     });
 
+    it("filters out zero-percent segments so CSS border-radius applies correctly", () => {
+        const dataWithZeroPercent = [
+            {
+                id: 1,
+                label: "Child Care",
+                abbreviation: "CC",
+                value: 7500000,
+                color: "var(--portfolio-budget-1)",
+                percent: 45
+            },
+            {
+                id: 2,
+                label: "Child Welfare",
+                abbreviation: "CW",
+                value: 0,
+                color: "var(--portfolio-budget-2)",
+                percent: 0
+            },
+            {
+                id: 3,
+                label: "Office Director",
+                abbreviation: "OD",
+                value: 0,
+                color: "var(--portfolio-budget-9)",
+                percent: 0
+            }
+        ];
+
+        render(
+            <HorizontalStackedBar
+                data={dataWithZeroPercent}
+                setActiveId={vi.fn()}
+            />
+        );
+
+        const segments = screen.getAllByRole("button");
+        expect(segments).toHaveLength(1);
+        expect(segments[0]).toHaveStyle({ flexBasis: "45%", backgroundColor: "var(--portfolio-budget-1)" });
+    });
+
     it("uses default setActiveId if not provided", () => {
         const dataWithoutSetActiveId = {
             data: mockData


### PR DESCRIPTION
## What changed

Fixed the HorizontalStackedBar right corner bug on the Portfolio list page.

## Issue

#4144 

## How to test

1. goto /portfolios
2. switch fiscal year and verify the data visualization bar's corner styling is correct.

## Screenshots

<img width="988" height="300" alt="Screenshot 2026-02-14 at 9 56 13 PM" src="https://github.com/user-attachments/assets/07f44aed-84d6-4209-b739-09386d959541" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated


## Link
Please refer to the [comment](https://github.com/HHS/OPRE-OPS/issues/4144#issuecomment-3899538779) from Nate.