### PR TITLE
feat(procurement-tracker): adds instructional text for undeveloped steps

### DIFF
--- a/frontend/src/pages/agreements/details/AgreementProcurementTracker.jsx
+++ b/frontend/src/pages/agreements/details/AgreementProcurementTracker.jsx
@@ -115,37 +115,37 @@ const AgreementProcurementTracker = ({ agreement }) => {
                             />
                         )}
                         {step.step_number === 2 && (
-                            <fieldset className="usa-fieldset">
+                            <div className="usa-fieldset">
                                 <p>
                                     Edit the pre-solicitation package in collaboration with the Procurement Shop. Once
                                     the documents are finalized, go to the Documents Tab, upload the final and signed
                                     versions, and check this step as complete. If you have a target completion date for
                                     when the package will be finalized, enter it below.
                                 </p>
-                            </fieldset>
+                            </div>
                         )}
                         {step.step_number === 3 && (
-                            <fieldset className="usa-fieldset">
+                            <div className="usa-fieldset">
                                 <p>
                                     Once the Procurement Shop has posted the Solicitation and it’s “on the street”,
                                     enter the Solicitation Start and End Dates. After all proposals are received, vendor
                                     questions have been answered, and evaluations are starting, check this step as
                                     complete.
                                 </p>
-                            </fieldset>
+                            </div>
                         )}
                         {step.step_number === 4 && (
-                            <fieldset className="usa-fieldset">
+                            <div className="usa-fieldset">
                                 <p>
-                                    Once the Procurement Shop has posted the Solicitation and it’s “on the street”,
-                                    enter the Solicitation Start and End Dates. After all proposals are received, vendor
-                                    questions have been answered, and evaluations are starting, check this step as
-                                    complete.
+                                    Complete the technical evaluations and any potential negotiations. If you have a
+                                    target completion date for when evaluations will be complete, enter it below. Once
+                                    you internally select a vendor check this task as complete (Internally means
+                                    internal to OPRE, before you send the Final Consensus Memo to the Procurement Shop).
                                 </p>
-                            </fieldset>
+                            </div>
                         )}
                         {step.step_number === 5 && (
-                            <fieldset className="usa-fieldset">
+                            <div className="usa-fieldset">
                                 <p>
                                     All agreements need Pre-Award Approval before the Final Consensus Memo can be sent
                                     to the Procurement Shop. Review the Vendor Price Sheet and make any edits or budget
@@ -154,10 +154,10 @@ const AgreementProcurementTracker = ({ agreement }) => {
                                     Pre-Award Approval, check this step as complete. If you have a target completion
                                     date for when the Final Consensus Memo will be sent, enter it below.
                                 </p>
-                            </fieldset>
+                            </div>
                         )}
                         {step.step_number === 6 && (
-                            <fieldset className="usa-fieldset">
+                            <div className="usa-fieldset">
                                 <p>
                                     Once you receive the signed award, click Request Award Approval below. During this
                                     process you will upload the award document, add CLINs, and update the Vendor and
@@ -166,7 +166,7 @@ const AgreementProcurementTracker = ({ agreement }) => {
                                     the date you expect to receive the signed award, and once you Request Award
                                     Approval, check this step as complete.
                                 </p>
-                            </fieldset>
+                            </div>
                         )}
                     </StepBuilderAccordion>
                 );

--- a/frontend/src/pages/agreements/details/AgreementProcurementTracker.test.jsx
+++ b/frontend/src/pages/agreements/details/AgreementProcurementTracker.test.jsx
@@ -887,13 +887,13 @@ describe("AgreementProcurementTracker", () => {
                             {
                                 id: 101,
                                 step_number: 1,
-                                step_type: "PRE_SOLICITATION",
+                                step_type: "ACQUISITION_PLANNING",
                                 status: "COMPLETED"
                             },
                             {
                                 id: 102,
                                 step_number: 2,
-                                step_type: "SOLICITATION",
+                                step_type: "PRE_SOLICITATION",
                                 status: "ACTIVE"
                             }
                         ]
@@ -918,6 +918,58 @@ describe("AgreementProcurementTracker", () => {
             ).toBeInTheDocument();
             expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
         });
+
+        it.each([
+            [3, "SOLICITATION", /Once the Procurement Shop has posted the Solicitation and it’s “on the street”/],
+            [4, "EVALUATION", /Complete the technical evaluations and any potential negotiations/],
+            [5, "PRE_AWARD", /All agreements need Pre-Award Approval before the Final Consensus Memo/],
+            [6, "AWARD", /Once you receive the signed award, click Request Award Approval below/]
+        ])(
+            "renders step %i instructional content when that step is active",
+            (activeStepNumber, activeStepType, expectedInstructionalText) => {
+                const mockTrackerWithActiveInstructionalStep = {
+                    data: [
+                        {
+                            id: 4,
+                            agreement_id: 13,
+                            display_name: "ProcurementTracker#4",
+                            status: "ACTIVE",
+                            tracker_type: "DEFAULT",
+                            active_step_number: activeStepNumber,
+                            steps: [
+                                {
+                                    id: 101,
+                                    step_number: 1,
+                                    step_type: "ACQUISITION_PLANNING",
+                                    status: "COMPLETED"
+                                },
+                                {
+                                    id: 100 + activeStepNumber,
+                                    step_number: activeStepNumber,
+                                    step_type: activeStepType,
+                                    status: "ACTIVE"
+                                }
+                            ]
+                        }
+                    ]
+                };
+
+                useGetProcurementTrackersByAgreementIdQuery.mockReturnValue({
+                    data: mockTrackerWithActiveInstructionalStep,
+                    isLoading: false,
+                    isError: false
+                });
+
+                render(
+                    <Provider store={setupStore()}>
+                        <AgreementProcurementTracker agreement={mockAgreement} />
+                    </Provider>
+                );
+
+                expect(screen.getByText(expectedInstructionalText)).toBeInTheDocument();
+                expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+            }
+        );
     });
 
     describe("Step 1 Completed State", () => {


### PR DESCRIPTION
## What changed

- adds instructional text to not yet developed steps in the Procurement Tracker

## Issue

- #1603

## How to test

- go to any agreement's procurement tracker
- open steps 2-6 and see text

## Screenshots

<img width="971" height="653" alt="image" src="https://github.com/user-attachments/assets/df52cdfb-c917-457c-9079-109df1c90535" />

## Definition of Done Checklist
- [-] OESA: Code refactored for clarity
- [-] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated