### PR TITLE
fix: restore project title filter placeholder to empty string

### DIFF
--- a/frontend/src/pages/agreements/list/AgreementsFilterButton/AgreementsFilterButton.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsFilterButton/AgreementsFilterButton.jsx
@@ -74,7 +74,7 @@ export const AgreementsFilterButton = ({ filters, setFilters, agreementFilterOpt
                 setSelectedProjects={setProjectTitle}
                 agreementFilterOptions={agreementFilterOptions}
                 legendClassname={legendStyles}
-                defaultString={"All FYs"}
+                defaultString={""}
                 overrideStyles={{ width: "22.7rem" }}
             />
         </fieldset>,


### PR DESCRIPTION
## What changed

Restore the placeholder to blank for the ProjectTitleComboBox in the agreements filter. It was accidentally set to "All FYs" in a previous merge conflict resolution. 

## Issue

#4928

## How to test

1. goto /agreements
2. open the filter
3. the Project Title placeholder should be blank

## Screenshots
<img width="463" height="682" alt="Screenshot 2026-02-17 at 11 01 05 AM" src="https://github.com/user-attachments/assets/723f49ed-f725-407f-a39b-b8af02b74355" />



## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated