### PR TITLE
fix: update required fields validation for budget line item status ch…

### DIFF
--- a/backend/ops_api/ops/services/budget_line_items.py
+++ b/backend/ops_api/ops/services/budget_line_items.py
@@ -644,11 +644,7 @@ class BudgetLineItemService:
             and budget_line_item.status in [BudgetLineItemStatus.DRAFT]
         ) or (budget_line_item.status not in [BudgetLineItemStatus.DRAFT]):
             # check required fields on budget line item
-            bli_required_fields = (
-                BudgetLineItem.get_required_fields_for_status_change()
-                if not is_super_user(current_user, current_app)
-                else []
-            )
+            bli_required_fields = BudgetLineItem.get_required_fields_for_status_change()
 
             missing_fields = BudgetLineItemService._get_missing_fields(
                 bli_required_fields, budget_line_item, updated_fields

--- a/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_power_user.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_power_user.py
@@ -807,6 +807,7 @@ def test_power_user_update_obligate_by_date(
         status=bli_status,
         amount=5000,
         services_component_id=agreement.awarding_entity_id,
+        date_needed=datetime.now() + timedelta(days=1) if bli_status != BudgetLineItemStatus.DRAFT else None,
     )
     loaded_db.add(bli)
     loaded_db.commit()
@@ -819,7 +820,7 @@ def test_power_user_update_obligate_by_date(
         assert response.status_code == 200
     else:
         assert response.status_code == 400
-        assert "BLI must have a Need By Date when status is not DRAFT" in response.json["errors"]["date_needed"]
+        assert "Budget Line Item is missing required fields." in response.json["errors"]["status"]
 
     response = power_user_auth_client.patch(
         url_for("api.budget-line-items-item", id=bli.id),
@@ -951,11 +952,17 @@ def test_optional_services_component_for_power_user(
     )
     assert response.status_code == 200
 
+    # Power users can set services_component_id to None for DRAFT status
+    # but NOT for higher statuses (PLANNED, IN_EXECUTION, OBLIGATED)
     response = power_user_auth_client.patch(
         url_for("api.budget-line-items-item", id=bli.id),
         json={"services_component_id": None},
     )
-    assert response.status_code == 200
+    if bli_status == BudgetLineItemStatus.DRAFT:
+        assert response.status_code == 200
+    else:
+        assert response.status_code == 400
+        assert "Budget Line Item is missing required fields." in response.json["errors"]["status"]
 
     response = basic_user_auth_client.patch(
         url_for("api.budget-line-items-item", id=bli.id),


### PR DESCRIPTION
## What changed

- Removed API bypass for super user to check for required fields when the budget line is not `DRAFT`

## Issue

https://github.com/HHS/OPRE-OPS/issues/4709

## How to test

`PowerUser` should not be able to update a non `DRAFT` budget line, or change its status, if any of its required fields are missing.

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated
