### PR TITLE
fix: update tooltip message for upcoming tab in DetailsTabs component

### DIFF
--- a/frontend/src/components/Agreements/DetailsTabs/DetailsTabs.jsx
+++ b/frontend/src/components/Agreements/DetailsTabs/DetailsTabs.jsx
@@ -76,7 +76,7 @@ const DetailsTabs = ({ agreementId, isAgreementNotDeveloped, isAgreementAwarded 
             return (
                 <Tooltip
                     key={pathName}
-                    label={`${path.label} tab is coming soon`}
+                    label={`${path.label} tab is coming soon! For now, please upload to the OPRE preferred tool to share documents`}
                     position="bottom"
                 >
                     {button}


### PR DESCRIPTION
## What changed
Updated tooltip message for Documents Tab for Procurement Tracker Workflow

## Issue

[1501](https://github.com/HHS/OPRE-OPS/issues/1501
)
## How to test
1. Navigate to agreements/13/procurement-tracker
2. Hove over Documents Tab
3. Verify that tooltip matches FIgma: "Documents tab is coming soon! For now, please 
upload to the OPRE preferred tool to share documents"

## Screenshots
<img width="1116" height="797" alt="Screenshot 2026-02-27 at 3 18 26 PM" src="https://github.com/user-attachments/assets/c63b6db4-72a9-44c3-8be4-7ab98e7be40a" />

_If relevant, e.g. for a front-end feature_

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated


## Links

_If relevant, e.g. for a link to a piece of markdown documentation_
