### PR TITLE
Change logic for pacmanloader rendering following recent …

### DIFF
--- a/frontend/src/components/Auth/MultiAuthSection.jsx
+++ b/frontend/src/components/Auth/MultiAuthSection.jsx
@@ -111,6 +111,10 @@ const MultiAuthSection = () => {
                 // Exit early - don't run the ensureActiveUser logic during auth callback
                 return;
             }
+        } else if (queryParams.has("state") && queryParams.has("code")) {
+            // OAuth params present but ops-state-key missing — can't process callback.
+            // Reset loader so the user sees the login form instead of being stuck.
+            setIsAuthenticating(false);
         }
 
         // Set state token if none exists

--- a/frontend/src/components/Auth/MultiAuthSection.test.jsx
+++ b/frontend/src/components/Auth/MultiAuthSection.test.jsx
@@ -192,6 +192,38 @@ describe("MultiAuthSection", () => {
             });
         });
 
+        it("shows PacmanLoader immediately on OAuth callback", async () => {
+            const stateWithProvider = "abc123|hhsams";
+            storage.set("ops-state-key", stateWithProvider);
+
+            // Keep the mutation pending so the loader stays visible
+            mockUnwrap.mockReturnValue(new Promise(() => {}));
+
+            window.history.pushState(
+                {},
+                "",
+                `/login?state=${encodeURIComponent(stateWithProvider)}&code=AUTH_CODE_123`
+            );
+
+            renderWithProviders(<MultiAuthSection />);
+
+            // Loader should be visible on first render (no waitFor needed)
+            expect(screen.getByTestId("loader")).toBeInTheDocument();
+            expect(screen.queryByText("Sign in to your account")).not.toBeInTheDocument();
+        });
+
+        it("resets loader when ops-state-key is missing during OAuth callback", async () => {
+            // Do NOT set ops-state-key — simulates it being cleared
+            window.history.pushState({}, "", "/login?state=abc123&code=AUTH_CODE_123");
+
+            renderWithProviders(<MultiAuthSection />);
+
+            await waitFor(() => {
+                expect(screen.getByText("Sign in to your account")).toBeInTheDocument();
+            });
+            expect(screen.queryByTestId("loader")).not.toBeInTheDocument();
+        });
+
         it("falls back to localStorage when state has no provider (backward compat)", async () => {
             const stateWithoutProvider = "abc123nopipe";
             storage.set("ops-state-key", stateWithoutProvider);


### PR DESCRIPTION
## What changed

Changes logic of setting `isAuthenticating` during login so that it's set in the same way and timing for all login methods so that the PacmanLoader will render the same way/time. 


1. When clicking a login provider button, handleSSOLogin sets isAuthenticating = true then immediately redirects the browser away (window.location.href), so the loader never renders.
2. When the browser returns from the provider with ?state=...&code=... query params, the component mounts fresh with isAuthenticating = false. The useEffect then calls callBackend which sets it to true, but there's a flash of the login form before the state update triggers a re-render.                                                                                                                                
 
The goal is to show the PacmanLoader immediately when returning from an auth provider redirect, with no flash of the login form. This PR initializes isAuthenticating to true on the very first render when the URL contains OAuth callback parameters, so the PacmanLoader shows immediately with no flash.                                                                        

## Issue

#5351 

## How to test

Attempt to login via FakeAuth and AMS

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots


## Definition of Done Checklist
~- [ ] OESA: Code refactored for clarity~
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated


## Links

