### PR TITLE
fix: update BLI validation suite of vest v6

### DIFF
--- a/frontend/src/pages/agreements/review/suite.js
+++ b/frontend/src/pages/agreements/review/suite.js
@@ -53,11 +53,13 @@ const budgetLineSuite = create((budgetLine = {}, fieldName) => {
     });
 
     test("Budget Line CAN", "This information is required to submit for approval", () => {
-        enforce(budgetLine.can_id).isNotNullish().greaterThan(0);
+        const canId = Number(budgetLine.can_id ?? 0);
+        enforce(canId).greaterThan(0);
     });
 
     test("Budget lines need to be assigned to a services component to change their status", () => {
-        enforce(budgetLine.services_component_id).isNotNullish().greaterThan(0);
+        const servicesComponentId = Number(budgetLine.services_component_id ?? 0);
+        enforce(servicesComponentId).greaterThan(0);
     });
 
     test("Budget Line Obligate By Date", "This information is required to submit for approval", () => {

--- a/frontend/src/pages/agreements/review/suite.test.js
+++ b/frontend/src/pages/agreements/review/suite.test.js
@@ -105,20 +105,44 @@ describe("Budget Line Suite", () => {
         expect(result.errors).toEqual({});
     });
 
+    it("passes when can_id and services_component_id are numeric strings", () => {
+        const result = validateBudgetLineItem({
+            ...validBudgetLine,
+            can_id: "502",
+            services_component_id: "6"
+        });
+        expect(result.isValid).toBe(true);
+        expect(result.errors).toEqual({});
+    });
+
     it("fails if amount is 0 or negative", () => {
         const result = validateBudgetLineItem({ ...validBudgetLine, amount: 0 });
         expect(result.isValid).toBe(false);
         expect(result.errors).toHaveProperty("Budget Line Amount");
     });
 
-    it("fails if can_id is blank", () => {
+    it("fails if can_id is null", () => {
         const result = validateBudgetLineItem({ ...validBudgetLine, can_id: null });
         expect(result.isValid).toBe(false);
         expect(result.errors).toHaveProperty("Budget Line CAN");
     });
 
-    it("fails if services_component_id is blank", () => {
+    it("fails if can_id is 0", () => {
+        const result = validateBudgetLineItem({ ...validBudgetLine, can_id: 0 });
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toHaveProperty("Budget Line CAN");
+    });
+
+    it("fails if services_component_id is null", () => {
         const result = validateBudgetLineItem({ ...validBudgetLine, services_component_id: null });
+        expect(result.isValid).toBe(false);
+        expect(result.errors).toHaveProperty(
+            "Budget lines need to be assigned to a services component to change their status"
+        );
+    });
+
+    it("fails if services_component_id is 0", () => {
+        const result = validateBudgetLineItem({ ...validBudgetLine, services_component_id: 0 });
         expect(result.isValid).toBe(false);
         expect(result.errors).toHaveProperty(
             "Budget lines need to be assigned to a services component to change their status"


### PR DESCRIPTION
## What changed

Updated BLI validation suite after upgrading to Vest v6.
- In vest v6, isNotBlank() only works on strings — passing a number always fails. Replaced with isNotNullish().greaterThan(0) which correctly validates numeric ID fields

## Issue

#5386 

## How to test

1. goto /agreements/review/9
2. select Change Planned Budget Lines to Executing Status
3. check all Planned budget lines
4. there should be no validation error

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated