### PR TITLE
fix(ui): prevent long tag text overlap

### DIFF
--- a/frontend/src/components/UI/FilterTags/FilterTags.jsx
+++ b/frontend/src/components/UI/FilterTags/FilterTags.jsx
@@ -16,7 +16,10 @@ import Tag from "../Tag";
  * @returns {JSX.Element} - The filter tag component. (A pill with an 'x' to remove it)
  */
 const FilterTag = ({ tag, tagIndex, removeFilter }) => (
-    <Tag className="bg-brand-primary-light text-brand-primary-dark display-flex flex-align-center">
+    <Tag
+        className="bg-brand-primary-light text-brand-primary-dark flex-align-center"
+        display="flex"
+    >
         {tag.tagText}
         <button
             type="button"

--- a/frontend/src/components/UI/Tag/Tag.jsx
+++ b/frontend/src/components/UI/Tag/Tag.jsx
@@ -6,6 +6,7 @@
  * @property {boolean} [active] - Whether the tag is active or not.
  * @property {string} [label] - The label of the tag.
  * @property {string} [className] - Additional CSS classes.
+ * @property {string} [display] - Optional display override for the tag container.
  * @property {number} [dataTestId] - The data test id.
  * @property {Object} [rest] - Additional props.
  * @property {React.ReactNode} [children] - Child elements.
@@ -23,16 +24,11 @@ const Tag = ({
     active = false,
     label,
     className = "",
+    display = "inline-block",
     style = {},
     children,
     ...rest
 }) => {
-    const resolvedDisplay = className.includes("display-inline-flex")
-        ? "inline-flex"
-        : className.includes("display-flex")
-          ? "flex"
-          : "inline-block";
-
     let tagClasses = "font-12px height-205 radius-md text-center",
         activeClass = "";
     // OVERRIDES FOR DEFAULT CLASSES
@@ -150,8 +146,7 @@ const Tag = ({
         height: "auto",
         whiteSpace: "normal",
         overflowWrap: "anywhere",
-        wordBreak: "break-word",
-        display: resolvedDisplay,
+        display,
         padding: ".25em .5em", // Adds some space inside the tag for better readability
         ...style // Merge with custom inline styles
     });

--- a/frontend/src/components/UI/Tag/Tag.test.jsx
+++ b/frontend/src/components/UI/Tag/Tag.test.jsx
@@ -4,15 +4,14 @@ import Tag from "./Tag";
 
 describe("Tag", () => {
     it("applies wrapping-friendly layout styles for long content", () => {
-        render(<Tag text="Chris Fortunatoasdljkasjd" />);
+        render(<Tag text="ChrisFortunatoasdljkasjd" />);
 
-        expect(screen.getByText("Chris Fortunatoasdljkasjd")).toHaveStyle({
+        expect(screen.getByText("ChrisFortunatoasdljkasjd")).toHaveStyle({
             width: "auto",
             maxWidth: "100%",
             height: "auto",
             whiteSpace: "normal",
             overflowWrap: "anywhere",
-            wordBreak: "break-word",
             display: "inline-block"
         });
     });
@@ -20,8 +19,9 @@ describe("Tag", () => {
     it("preserves flex display for filter-style tags", () => {
         render(
             <Tag
-                className="bg-brand-primary-light text-brand-primary-dark display-flex flex-align-center"
+                className="bg-brand-primary-light text-brand-primary-dark flex-align-center"
                 dataTestId="filter-tag"
+                display="flex"
             >
                 <span>Long filter tag</span>
                 <button type="button">Remove</button>
@@ -34,7 +34,14 @@ describe("Tag", () => {
     });
 
     it("preserves inline-flex display when requested", () => {
-        render(<Tag className="bg-brand-secondary display-inline-flex">Active</Tag>);
+        render(
+            <Tag
+                className="bg-brand-secondary"
+                display="inline-flex"
+            >
+                Active
+            </Tag>
+        );
 
         expect(screen.getByText("Active")).toHaveStyle({
             display: "inline-flex"

--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -195,7 +195,10 @@ const Agreement = () => {
                 />
             )}
             {isAgreementAwarded && agreement?.agreement_type !== AgreementType.DIRECT_OBLIGATION && (
-                <Tag className="bg-brand-secondary display-inline-flex margin-top-105 margin-bottom-1">
+                <Tag
+                    className="bg-brand-secondary margin-top-105 margin-bottom-1"
+                    display="inline-flex"
+                >
                     Awarded
                     <svg
                         className="usa-icon margin-left-05"


### PR DESCRIPTION
## What changed

- update the shared `Tag` component so long values wrap instead of overflowing adjacent content
- preserve `flex` and `inline-flex` tag layouts used by existing filter and inline tag variants
- add focused unit coverage for wrapping-friendly tag styles and preserved display behavior

## Issue

N/A

## How to test

1. Open an agreement details page with a long single-token value in a tag field such as Project Officer.
2. Confirm the tag wraps within its column instead of overlapping nearby content.
3. Confirm existing tag layouts still look correct for filter pills and inline tag variants.
4. Run `bunx vitest run src/components/UI/Tag/Tag.test.jsx src/components/UI/Tag/TagList.test.jsx src/pages/reporting/ReportingFilterTags.test.jsx src/pages/portfolios/list/PortfolioFilterTags.test.jsx` from `frontend/`.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

- before 
<img width="416" height="159" alt="image" src="https://github.com/user-attachments/assets/389897e9-10f0-4219-939a-396479841bf7" />

- after
<img width="379" height="296" alt="image" src="https://github.com/user-attachments/assets/9873d2d8-0cb8-40ea-8cb7-78085665430c" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated


## Links

N/A