### PR TITLE
docs: clarify scoped pre-push quality checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,15 @@ pre-commit install
 pre-commit install --hook-type commit-msg
 ```
 
+### Before Pushing Changes
+
+Run the checks that match the part of the repo you changed instead of relying on CI to catch basic formatting or lint issues.
+
+- Frontend changes: run `bun run lint` and `bun run format` from `frontend/` before pushing.
+- Backend changes: run the relevant backend quality checks from `backend/ops_api/`, such as `pipenv run nox -s lint` and formatting checks when Python files changed.
+- Mixed changes: run both frontend and backend checks for the files you touched.
+- Docs-only or metadata-only changes: use judgment and run only the checks relevant to the edited files.
+
 ### Conventional Commits
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/) specification for commit messages, enforced by commitlint.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -59,10 +59,11 @@ bun run lint --fix   # Auto-fix linting errors
 bun run format       # Format code (Prettier)
 ```
 
-**Before committing:**
+**Before pushing frontend code changes:**
 1. Run `bun run lint` to check for linting errors
 2. Run `bun run format` to fix formatting
-3. Pre-commit hooks will enforce these checks
+3. Re-run any focused frontend tests you changed or added
+4. Pre-commit hooks will enforce some of these checks, but do not rely on CI to catch avoidable frontend lint/format failures
 
 ## Architecture
 


### PR DESCRIPTION
## What changed

Adds explicit guidance for agents and developers to run scoped local quality checks before pushing code. The update calls out frontend lint/format commands directly and keeps the rule targeted to the parts of the repo that were changed.

## Issue

_No linked issue._

## How to test

1. Review `AGENTS.md` and confirm it now includes a scoped `Before Pushing Changes` section.
2. Review `frontend/CLAUDE.md` and confirm it now instructs frontend contributors to run `bun run lint`, `bun run format`, and focused frontend tests before pushing code changes.
3. Confirm the guidance is scoped so docs-only changes do not require unrelated frontend or backend checks.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

_Not relevant; documentation-only change._

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

- Related PR that surfaced the gap: https://github.com/HHS/OPRE-OPS/pull/5413