### PR TITLE
feat: remove reference of fiscalYear in CANFundingInfoCard

### DIFF
--- a/frontend/src/components/CANs/CANFundingInfoCard/CANFundingInfoCard.jsx
+++ b/frontend/src/components/CANs/CANFundingInfoCard/CANFundingInfoCard.jsx
@@ -9,7 +9,6 @@ import { formatObligateBy } from "../CANTable/CANTable.helpers";
 /**
  * @typedef {Object} CANFundingInfoCard
  * @property {FundingDetails} [funding]
- * @property {number} fiscalYear
  */
 
 /**
@@ -17,7 +16,7 @@ import { formatObligateBy } from "../CANTable/CANTable.helpers";
  * @param {CANFundingInfoCard} props
  * @returns  {JSX.Element} - The component JSX.
  */
-const CANFundingInfoCard = ({ funding, fiscalYear }) => {
+const CANFundingInfoCard = ({ funding }) => {
     if (!funding) {
         return <div>No funding information available for this CAN.</div>;
     }
@@ -31,7 +30,7 @@ const CANFundingInfoCard = ({ funding, fiscalYear }) => {
                 className="margin-0 margin-bottom-2 font-12px text-base-dark text-normal"
                 style={{ whiteSpace: "pre-line", lineHeight: "20px" }}
             >
-                {`FY ${fiscalYear} CAN Funding Information`}
+                CAN Funding Information
             </h3>
             <div className="grid-row grid-gap">
                 <div className="grid-col">

--- a/frontend/src/pages/cans/detail/CanFunding.jsx
+++ b/frontend/src/pages/cans/detail/CanFunding.jsx
@@ -163,10 +163,11 @@ const CanFunding = ({
                     ? "The summary below shows the funding for this CAN for the select fiscal year."
                     : "Review the new FY Funding Information for this CAN."}
             </p>
-            <CANFundingInfoCard
-                funding={funding}
-                fiscalYear={fiscalYear}
-            />
+            <CANFundingInfoCard funding={funding} />
+            <p className="font-12px text-base-dark">
+                * CAN Funding Information contains the latest CANBACs data, and does not reference historical changes if
+                there were any
+            </p>
             {!isEditMode ? (
                 <section
                     id="cards"


### PR DESCRIPTION
## What changed

Removed reference of fiscalYear in CANFundingInfoCard and added sub-text.

## Issue

#5319 

## How to test

view any can funding details tab and make sure there is no fiscal year in the CAN Funding Information card.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

<img width="989" height="844" alt="Screenshot 2026-04-06 at 1 51 03 PM" src="https://github.com/user-attachments/assets/e98bbe3f-b7b0-494b-9654-d3592180fc7c" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated