### PR TITLE
fix(help-center): move SharePoint icon after link text

### DIFF
--- a/frontend/src/pages/help/HelpCenter.jsx
+++ b/frontend/src/pages/help/HelpCenter.jsx
@@ -34,19 +34,19 @@ const HelpCenter = () => {
                 <HelpTabs
                     rightContent={
                         <a
-                            className="usa-link text-bold display-flex flex-align-center"
+                            className="usa-link display-flex flex-align-center"
                             href={HELP_CENTER_EXPORT_URL}
                             target="_blank"
                             rel="noopener noreferrer"
                         >
-                            <svg
-                                className="height-2 width-2 margin-right-05"
-                                aria-hidden="true"
-                                style={{ fill: "#005EA2", height: "24px", width: "24px" }}
-                            >
-                                <use href={`${icons}#save_alt`}></use>
-                            </svg>
                             <span>Open in SharePoint</span>
+                            <svg
+                                className="margin-left-05"
+                                aria-hidden="true"
+                                style={{ fill: "#005EA2", height: "20px", width: "20px" }}
+                            >
+                                <use href={`${icons}#launch`}></use>
+                            </svg>
                         </a>
                     }
                 />


### PR DESCRIPTION
## What changed

Moved the SharePoint external-link icon to appear after the link text in the Help Center and swapped the glyph to the external-link style used for this action.

## Issue
NA

## How to test

- Open the Help Center page
- Confirm the SharePoint link shows the icon after the text
- Confirm the link still opens in a new tab
- Verify `bun run lint` and `bun run test --watch=false` pass

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

<img width="987" height="419" alt="image" src="https://github.com/user-attachments/assets/917b44f6-e3ab-4882-9373-d2a2651b4b5e" />

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A