### PR TITLE
Remove redundant percent symbol when hovering inside the ResponsiveDonut

### DIFF
--- a/frontend/src/components/UI/DataViz/ResponsiveDonutWithInnerPercent/ResponsiveDonutWithInnerPercent.jsx
+++ b/frontend/src/components/UI/DataViz/ResponsiveDonutWithInnerPercent/ResponsiveDonutWithInnerPercent.jsx
@@ -60,7 +60,7 @@ const ResponsiveDonutWithInnerPercent = ({
             colors={{ datum: "data.color" }}
             layers={["arcs", "slices", "sliceLabels", "radialLabels", "legends", CustomLayerComponent]}
             onMouseEnter={(node) => {
-                setPercent(`${node.data.percent}%`);
+                setPercent(`${node.data.percent}`);
                 setHoverId(node.data.id);
             }}
             onMouseLeave={() => {


### PR DESCRIPTION
## What changed

Corrects a recently-introduced unintentional extra percent symbol (%) when a user hovers on part of the ResponsiveDonut component

## Issue

#5441

## How to test

Hover over part of the donut pieces to trigger the percent that shows in the middle of the donut. 

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots


## Definition of Done Checklist
~- [ ] OESA: Code refactored for clarity~
~- [ ] OESA: Dependency rules followed~
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

