### PR TITLE
style: fix text stretching in summary cards

### DIFF
--- a/frontend/src/components/Agreements/AgreementCountSummaryCard/AgreementCountSummaryCard.jsx
+++ b/frontend/src/components/Agreements/AgreementCountSummaryCard/AgreementCountSummaryCard.jsx
@@ -48,7 +48,7 @@ const AgreementCountSummaryCard = ({ title, fiscalYear, totals }) => {
                     <h3 className="margin-0 margin-bottom-3 font-12px text-base-dark text-normal">{title}</h3>
                     <div>
                         <span className="font-sans-xl text-bold line-height-sans-1">{totalCount}</span>
-                        <div className="display-flex flex-column grid-gap margin-top-1">
+                        <div className="display-flex flex-column flex-align-start grid-gap margin-top-1">
                             {typeCounts.map(({ type, count }, index) => (
                                 <Tag
                                     key={type}
@@ -67,7 +67,7 @@ const AgreementCountSummaryCard = ({ title, fiscalYear, totals }) => {
                     </h3>
                     <div>
                         <span className="font-sans-xl text-bold line-height-sans-1">{newCount}</span>
-                        <div className="display-flex flex-column grid-gap margin-top-1">
+                        <div className="display-flex flex-column flex-align-start grid-gap margin-top-1">
                             {newTypeCounts.map(({ type, count }, index) => (
                                 <Tag
                                     key={type}
@@ -86,7 +86,7 @@ const AgreementCountSummaryCard = ({ title, fiscalYear, totals }) => {
                     </h3>
                     <div>
                         <span className="font-sans-xl text-bold line-height-sans-1">{continuingCount}</span>
-                        <div className="display-flex flex-column grid-gap margin-top-1">
+                        <div className="display-flex flex-column flex-align-start grid-gap margin-top-1">
                             {continuingTypeCounts.map(({ type, count }, index) => (
                                 <Tag
                                     key={type}

--- a/frontend/src/components/UI/Cards/ProjectAgreementBLICard/ProjectAgreementBLICard.jsx
+++ b/frontend/src/components/UI/Cards/ProjectAgreementBLICard/ProjectAgreementBLICard.jsx
@@ -61,7 +61,7 @@ const ProjectAgreementBLICard = ({ fiscalYear, projects, agreements, budgetLines
                     <h3 className="margin-0 margin-bottom-3 font-12px text-base-dark text-normal">{projectHeading}</h3>
                     <div>
                         <span className="font-sans-xl text-bold line-height-sans-1">{totalProjectCount}</span>
-                        <div className="display-flex flex-column grid-gap margin-top-1">
+                        <div className="display-flex flex-column flex-align-start grid-gap margin-top-1">
                             {projects &&
                                 projects.length > 0 &&
                                 projects.map(({ type, count }, index) => (
@@ -83,7 +83,7 @@ const ProjectAgreementBLICard = ({ fiscalYear, projects, agreements, budgetLines
                     </h3>
                     <div>
                         <span className="font-sans-xl text-bold line-height-sans-1">{totalAgreementsCount}</span>
-                        <div className="display-flex flex-column grid-gap margin-top-1">
+                        <div className="display-flex flex-column flex-align-start grid-gap margin-top-1">
                             {agreements &&
                                 agreements.length > 0 &&
                                 groupAndSortAgreementTypeCounts(agreements).map(({ type, count }, index) => (
@@ -105,7 +105,7 @@ const ProjectAgreementBLICard = ({ fiscalYear, projects, agreements, budgetLines
                     </h3>
                     <div>
                         <span className="font-sans-xl text-bold line-height-sans-1">{totalBudgetLinesCount}</span>
-                        <div className="display-flex flex-column grid-gap margin-top-1">
+                        <div className="display-flex flex-column flex-align-start grid-gap margin-top-1">
                             {budgetLines &&
                                 budgetLines.length > 0 &&
                                 [...budgetLines]


### PR DESCRIPTION
## What changed

Fixed text stretching in ProjectAgreementBLICard and AgreementCountSummaryCard.

## Issue

#5448 

## How to test

1. goto /agreements
2. check text layout in Agreement count card
3. goto /portfolios/3
4. change the fiscal year dropdown to 2043
5. check text layout in Agreement BLI summary card

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

<img width="481" height="248" alt="Screenshot 2026-04-07 at 10 41 45 PM" src="https://github.com/user-attachments/assets/55e356d6-e439-4305-b31e-86b2cad0c73b" />
<img width="481" height="248" alt="Screenshot 2026-04-07 at 10 42 21 PM" src="https://github.com/user-attachments/assets/72e4c9d8-06e0-4962-85e4-8585ff735199" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated