### PR TITLE
style: update expanded BLI row on portfolio and CAN spending page

### DIFF
--- a/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.jsx
+++ b/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.jsx
@@ -111,8 +111,8 @@ const CANBudgetLineTableRow = ({
             className="border-top-none"
             style={expandedRowBGColor}
         >
-            <div className="display-flex padding-right-9">
-                <dl className="font-12px">
+            <div className="grid-row grid-gap-4">
+                <dl className="grid-col font-12px">
                     <dt className="margin-0 text-base-dark">Created By</dt>
                     <dd
                         id={`created-by-name-${blId}`}
@@ -128,60 +128,42 @@ const CANBudgetLineTableRow = ({
                         {displayCreatedDate}
                     </dt>
                 </dl>
-                <dl
-                    className="font-12px"
-                    style={{ marginLeft: "9.0625rem" }}
-                >
+                <dl className="grid-col-4 font-12px">
                     <dt className="margin-0 text-base-dark">Description</dt>
-                    <dd
-                        className="margin-0 wrap-text"
-                        style={{ maxWidth: "25rem" }}
-                    >
-                        {description}
+                    <dd className="margin-0 wrap-text">{description}</dd>
+                </dl>
+
+                <dl className="grid-col-auto font-12px text-no-wrap">
+                    <dt className="margin-0 text-base-dark">Procurement Shop</dt>
+                    <dd className="margin-0">{`${procShopLabel}`}</dd>
+                </dl>
+
+                <dl className="grid-col font-12px">
+                    <dt className="margin-0 text-base-dark">SubTotal</dt>
+                    <dd className="margin-0">
+                        <CurrencyFormat
+                            value={amount}
+                            displayType={"text"}
+                            thousandSeparator={true}
+                            prefix={"$"}
+                            decimalScale={2}
+                            fixedDecimalScale={true}
+                        />
                     </dd>
                 </dl>
-                <div
-                    className="font-12px"
-                    style={{ marginLeft: "15rem" }}
-                >
-                    <dl className="margin-bottom-0">
-                        <dt className="margin-0 text-base-dark">Procurement Shop</dt>
-                        <dd
-                            className="margin-0"
-                            style={{ maxWidth: "25rem" }}
-                        >
-                            {`${procShopLabel}`}
-                        </dd>
-                    </dl>
-                    <div className="font-12px display-flex margin-top-1">
-                        <dl className="margin-0">
-                            <dt className="margin-0 text-base-dark">SubTotal</dt>
-                            <dd className="margin-0">
-                                <CurrencyFormat
-                                    value={amount}
-                                    displayType={"text"}
-                                    thousandSeparator={true}
-                                    prefix={"$"}
-                                    decimalScale={2}
-                                    fixedDecimalScale={true}
-                                />
-                            </dd>
-                        </dl>
-                        <dl className=" margin-0 margin-left-2">
-                            <dt className="margin-0 text-base-dark">Fees</dt>
-                            <dd className="margin-0">
-                                <CurrencyFormat
-                                    value={feeTotal}
-                                    displayType={"text"}
-                                    thousandSeparator={true}
-                                    prefix={"$"}
-                                    decimalScale={2}
-                                    fixedDecimalScale={true}
-                                />
-                            </dd>
-                        </dl>
-                    </div>
-                </div>
+                <dl className="grid-col font-12px">
+                    <dt className="margin-0 text-base-dark">Fees</dt>
+                    <dd className="margin-0">
+                        <CurrencyFormat
+                            value={feeTotal}
+                            displayType={"text"}
+                            thousandSeparator={true}
+                            prefix={"$"}
+                            decimalScale={2}
+                            fixedDecimalScale={true}
+                        />
+                    </dd>
+                </dl>
             </div>
         </td>
     );

--- a/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.jsx
+++ b/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.jsx
@@ -112,7 +112,7 @@ const CANBudgetLineTableRow = ({
             style={expandedRowBGColor}
         >
             <div className="grid-row grid-gap-4">
-                <dl className="grid-col font-12px">
+                <dl className="grid-col margin-top-0 font-12px">
                     <dt className="margin-0 text-base-dark">Created By</dt>
                     <dd
                         id={`created-by-name-${blId}`}
@@ -128,17 +128,17 @@ const CANBudgetLineTableRow = ({
                         {displayCreatedDate}
                     </dt>
                 </dl>
-                <dl className="grid-col-4 font-12px">
+                <dl className="grid-col-4 margin-top-0 font-12px">
                     <dt className="margin-0 text-base-dark">Description</dt>
                     <dd className="margin-0 wrap-text">{description}</dd>
                 </dl>
 
-                <dl className="grid-col-auto font-12px text-no-wrap">
+                <dl className="grid-col-auto margin-top-0 font-12px text-no-wrap">
                     <dt className="margin-0 text-base-dark">Procurement Shop</dt>
                     <dd className="margin-0">{`${procShopLabel}`}</dd>
                 </dl>
 
-                <dl className="grid-col font-12px">
+                <dl className="grid-col margin-top-0 font-12px">
                     <dt className="margin-0 text-base-dark">SubTotal</dt>
                     <dd className="margin-0">
                         <CurrencyFormat
@@ -151,7 +151,7 @@ const CANBudgetLineTableRow = ({
                         />
                     </dd>
                 </dl>
-                <dl className="grid-col font-12px">
+                <dl className="grid-col margin-top-0 font-12px">
                     <dt className="margin-0 text-base-dark">Fees</dt>
                     <dd className="margin-0">
                         <CurrencyFormat


### PR DESCRIPTION
## What changed

Updated the layout of the expanded BLI row on the portfolio and CAN spending page.

## Issue

#5460 
#5485 

## How to test

1. goto portfolio spending tab and CAN spending tab
2. verify the expanded row has the correct data and layout

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

<img width="967" height="163" alt="Screenshot 2026-04-10 at 12 02 42 PM" src="https://github.com/user-attachments/assets/ca5a992e-ea69-4cb1-8563-c4a916565dce" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated