### PR TITLE
fix: show >99% instead of 100% when dominant project type has non-zero peers

### DIFF
--- a/frontend/src/components/Projects/ProjectTypeSummaryCard/ProjectTypeSummaryCard.jsx
+++ b/frontend/src/components/Projects/ProjectTypeSummaryCard/ProjectTypeSummaryCard.jsx
@@ -5,6 +5,7 @@ import {
     PROJECT_TYPE_ORDER,
     PROJECT_TYPE_TAG_STYLE_ACTIVE
 } from "../ProjectTypes.constants";
+import { computeDisplayPercents } from "../../../helpers/utils";
 import LegendItem from "../../UI/Cards/LineGraphWithLegendCard/LegendItem";
 import ResponsiveDonutWithInnerPercent from "../../UI/DataViz/ResponsiveDonutWithInnerPercent";
 import CustomLayerComponent from "../../UI/DataViz/ResponsiveDonutWithInnerPercent/CustomLayerComponent";
@@ -17,39 +18,6 @@ const PROJECT_TYPE_CONFIG = PROJECT_TYPE_ORDER.map((type) => ({
     color: PROJECT_TYPE_COLORS[type],
     tagStyleActive: PROJECT_TYPE_TAG_STYLE_ACTIVE[type]
 }));
-
-/**
- * Computes display-friendly percent labels for an array of items.
- *
- * Handles the edge case where one dominant item rounds to 100% while other
- * non-zero items exist — which would produce a contradictory legend like
- * "100% + <1%". In that case the dominant item is labelled ">99%" instead.
- *
- * Rules applied per item:
- *   - Zero value          → 0
- *   - Non-zero but rounds to 0 → "<1"
- *   - Rounds to 100 while other non-zero items exist → ">99"
- *   - Otherwise           → rounded integer
- *
- * @param {Array<{value: number}>} items - Data items with a numeric `value` field
- * @param {number} total - Sum of all item values
- * @returns {Array<number|string>} - Parallel array of display percent labels
- */
-const computeDisplayPercents = (items, total) => {
-    if (total === 0) return items.map(() => 0);
-
-    const rounded = items.map((item) => {
-        if (item.value === 0) return 0;
-        const exact = (item.value / total) * 100;
-        const r = Math.round(exact);
-        return r === 0 ? "<1" : r;
-    });
-
-    // Check if any item shows 100 while others have non-zero amounts
-    const hasOtherNonZero = (idx) => items.some((item, i) => i !== idx && item.value > 0);
-
-    return rounded.map((r, idx) => (r === 100 && hasOtherNonZero(idx) ? ">99" : r));
-};
 
 /**
  * Ensures every non-zero slice is at least 1% of the total so it remains

--- a/frontend/src/components/Projects/ProjectTypeSummaryCard/ProjectTypeSummaryCard.jsx
+++ b/frontend/src/components/Projects/ProjectTypeSummaryCard/ProjectTypeSummaryCard.jsx
@@ -19,17 +19,36 @@ const PROJECT_TYPE_CONFIG = PROJECT_TYPE_ORDER.map((type) => ({
 }));
 
 /**
- * Computes a display-friendly percent string.
- * Returns "<1" when a non-zero value rounds down to 0, otherwise the rounded integer.
- * @param {number} value - The slice value
- * @param {number} total - The total across all slices
- * @returns {number|string} - Rounded percent or "<1"
+ * Computes display-friendly percent labels for an array of items.
+ *
+ * Handles the edge case where one dominant item rounds to 100% while other
+ * non-zero items exist — which would produce a contradictory legend like
+ * "100% + <1%". In that case the dominant item is labelled ">99%" instead.
+ *
+ * Rules applied per item:
+ *   - Zero value          → 0
+ *   - Non-zero but rounds to 0 → "<1"
+ *   - Rounds to 100 while other non-zero items exist → ">99"
+ *   - Otherwise           → rounded integer
+ *
+ * @param {Array<{value: number}>} items - Data items with a numeric `value` field
+ * @param {number} total - Sum of all item values
+ * @returns {Array<number|string>} - Parallel array of display percent labels
  */
-const computeDisplayPercent = (value, total) => {
-    if (total === 0 || value === 0) return 0;
-    const exact = (value / total) * 100;
-    const rounded = Math.round(exact);
-    return rounded === 0 ? "<1" : rounded;
+const computeDisplayPercents = (items, total) => {
+    if (total === 0) return items.map(() => 0);
+
+    const rounded = items.map((item) => {
+        if (item.value === 0) return 0;
+        const exact = (item.value / total) * 100;
+        const r = Math.round(exact);
+        return r === 0 ? "<1" : r;
+    });
+
+    // Check if any item shows 100 while others have non-zero amounts
+    const hasOtherNonZero = (idx) => items.some((item, i) => i !== idx && item.value > 0);
+
+    return rounded.map((r, idx) => (r === 100 && hasOtherNonZero(idx) ? ">99" : r));
 };
 
 /**
@@ -106,10 +125,12 @@ const ProjectTypeSummaryCard = ({ title, summary }) => {
 
     const totalAmount = rawData.reduce((sum, item) => sum + item.value, 0);
 
-    // Legend data: real values + display-friendly percents
-    const legendData = rawData.map((item) => ({
+    // Legend data: real values + display-friendly percents (computed together
+    // so cross-item consistency — e.g. ">99%" alongside "<1%" — can be enforced)
+    const displayPercents = computeDisplayPercents(rawData, totalAmount);
+    const legendData = rawData.map((item, idx) => ({
         ...item,
-        percent: computeDisplayPercent(item.value, totalAmount)
+        percent: displayPercents[idx]
     }));
 
     // Chart data: floor tiny slices so every non-zero slice is visible,

--- a/frontend/src/components/Projects/ProjectTypeSummaryCard/ProjectTypeSummaryCard.test.jsx
+++ b/frontend/src/components/Projects/ProjectTypeSummaryCard/ProjectTypeSummaryCard.test.jsx
@@ -78,15 +78,17 @@ describe("ProjectTypeSummaryCard", () => {
         expect(screen.getByText("30%")).toBeInTheDocument();
     });
 
-    it("shows <1% tag when a non-zero amount rounds down to 0%", () => {
+    it("shows >99% and <1% when dominant item would otherwise round to 100% alongside non-zero items", () => {
         render(
             <ProjectTypeSummaryCard
                 title="FY 2025 Projects by Type"
                 summary={tinySliceSummary}
             />
         );
+        // Dominant item must not show 100% when other non-zero items exist
+        expect(screen.queryByText("100%")).not.toBeInTheDocument();
+        expect(screen.getByText(">99%")).toBeInTheDocument();
         expect(screen.getByText("<1%")).toBeInTheDocument();
-        expect(screen.getByText("100%")).toBeInTheDocument();
     });
 
     it("renders the donut chart when totalAmount > 0", () => {

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -30,6 +30,39 @@ export const calculatePercent = (numerator, denominator) => {
 
     return Math.round((numerator / denominator) * 100);
 };
+
+/**
+ * Computes display-friendly percent labels for an array of items.
+ *
+ * Handles the edge case where one dominant item rounds to 100% while other
+ * non-zero items exist — which would produce a contradictory legend like
+ * "100% + <1%". In that case the dominant item is labelled ">99%" instead.
+ *
+ * Rules applied per item:
+ *   - Zero value          → 0
+ *   - Non-zero but rounds to 0 → "<1"
+ *   - Rounds to 100 while other non-zero items exist → ">99"
+ *   - Otherwise           → rounded integer
+ *
+ * @param {Array<{value: number}>} items - Data items with a numeric `value` field
+ * @param {number} total - Sum of all item values
+ * @returns {Array<number|string>} - Parallel array of display percent labels
+ */
+export const computeDisplayPercents = (items, total) => {
+    if (total === 0) return items.map(() => 0);
+
+    const rounded = items.map((item) => {
+        if (item.value === 0) return 0;
+        const exact = (item.value / total) * 100;
+        const r = Math.round(exact);
+        return r === 0 ? "<1" : r;
+    });
+
+    // Check if any item shows 100 while others have non-zero amounts
+    const hasOtherNonZero = (idx) => items.some((item, i) => i !== idx && item.value > 0);
+
+    return rounded.map((r, idx) => (r === 100 && hasOtherNonZero(idx) ? ">99" : r));
+};
 /**
  * This function formats a date into a string in the format MM/DD/YYYY.
  * @param {Date} date - The date to format. This parameter is required.

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -32,21 +32,25 @@ export const calculatePercent = (numerator, denominator) => {
 };
 
 /**
- * Computes display-friendly percent labels for an array of items.
+ * Computes display-friendly percent values for an array of items.
  *
- * Handles the edge case where one dominant item rounds to 100% while other
- * non-zero items exist — which would produce a contradictory legend like
- * "100% + <1%". In that case the dominant item is labelled ">99%" instead.
+ * Returns the raw numeric/string percent tokens without a trailing "%".
+ * The percent sign is appended later by `LegendItem` and other consumers.
+ *
+ * Handles the edge case where one dominant item rounds to 100 while other
+ * non-zero items exist — which would otherwise render in the legend as a
+ * contradictory combination like "100% + <1%". In that case this helper
+ * returns ">99" for the dominant item instead.
  *
  * Rules applied per item:
- *   - Zero value          → 0
- *   - Non-zero but rounds to 0 → "<1"
+ *   - Zero value                         → 0
+ *   - Non-zero but rounds to 0          → "<1"
  *   - Rounds to 100 while other non-zero items exist → ">99"
- *   - Otherwise           → rounded integer
+ *   - Otherwise                         → rounded integer
  *
  * @param {Array<{value: number}>} items - Data items with a numeric `value` field
  * @param {number} total - Sum of all item values
- * @returns {Array<number|string>} - Parallel array of display percent labels
+ * @returns {Array<number|string>} - Parallel array of raw display percent values; "%" is appended later by consumers
  */
 export const computeDisplayPercents = (items, total) => {
     if (total === 0) return items.map(() => 0);

--- a/frontend/src/helpers/utils.test.js
+++ b/frontend/src/helpers/utils.test.js
@@ -1,6 +1,7 @@
 import {
     getCurrentFiscalYear,
     calculatePercent,
+    computeDisplayPercents,
     convertCodeForDisplay,
     fiscalYearFromDate,
     renderField,
@@ -25,6 +26,61 @@ test("percent is calculated correctly", () => {
     expect(calculatePercent(3, 4)).toEqual(75);
     expect(calculatePercent(7, 4)).toEqual(175);
     expect(calculatePercent(0, 4)).toEqual(0);
+});
+
+describe("computeDisplayPercents", () => {
+    test("returns zeros when total is 0", () => {
+        const items = [{ value: 100 }, { value: 200 }];
+        expect(computeDisplayPercents(items, 0)).toEqual([0, 0]);
+    });
+
+    test("returns 0 for zero values", () => {
+        const items = [{ value: 0 }, { value: 100 }];
+        expect(computeDisplayPercents(items, 100)).toEqual([0, 100]);
+    });
+
+    test("returns rounded integers for normal cases", () => {
+        const items = [{ value: 30 }, { value: 70 }];
+        expect(computeDisplayPercents(items, 100)).toEqual([30, 70]);
+    });
+
+    test("returns '<1' for non-zero values that round to 0", () => {
+        // 0.4% rounds to 0, but is non-zero
+        const items = [{ value: 0.4 }, { value: 99.6 }];
+        const result = computeDisplayPercents(items, 100);
+        expect(result[0]).toBe("<1");
+        // 99.6% rounds to 100, but since other item is non-zero, shows ">99"
+        expect(result[1]).toBe(">99");
+    });
+
+    test("returns '>99' when dominant item rounds to 100 while others exist", () => {
+        // Research: $3.5B, Admin: $301K - roughly 99.99% vs 0.008%
+        const items = [{ value: 3557011799.2 }, { value: 301500 }];
+        const total = 3557011799.2 + 301500;
+        const result = computeDisplayPercents(items, total);
+        expect(result[0]).toBe(">99");
+        expect(result[1]).toBe("<1");
+    });
+
+    test("allows 100% when it is the only non-zero item", () => {
+        const items = [{ value: 100 }, { value: 0 }];
+        expect(computeDisplayPercents(items, 100)).toEqual([100, 0]);
+    });
+
+    test("handles multiple non-zero items correctly", () => {
+        const items = [{ value: 33 }, { value: 33 }, { value: 34 }];
+        const result = computeDisplayPercents(items, 100);
+        expect(result).toEqual([33, 33, 34]);
+    });
+
+    test("handles edge case: one item rounds to 100, others are non-zero but tiny", () => {
+        const items = [{ value: 999 }, { value: 1 }];
+        const result = computeDisplayPercents(items, 1000);
+        // 999/1000 = 99.9% rounds to 100
+        // 1/1000 = 0.1% rounds to 0 -> "<1"
+        expect(result[0]).toBe(">99");
+        expect(result[1]).toBe("<1");
+    });
 });
 
 test("codes are converted for display correctly", () => {


### PR DESCRIPTION
## What changed

Replaced the per-item `computeDisplayPercent` helper in `ProjectTypeSummaryCard` with a multi-item-aware `computeDisplayPercents` function. The new function detects when rounding would produce `100%` alongside other non-zero items and caps the dominant item at `>99%` instead — eliminating the contradictory `100% + <1%` legend display.

No backend changes were needed; this is a pure frontend display fix.

## Issue

Closes #5511

## How to test

1. Navigate to the project list page
2. Find the "All FYs Projects by Type" summary card
3. Confirm the legend no longer shows `100%` alongside `<1%` — the dominant type should now read `>99%`
4. Confirm a normal split (e.g. 70% / 30%) still displays correctly

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

_Before:_
- Research `100%` | Admin & Support `<1%` ❌

_After:_
- Research `>99%` | Admin & Support `<1%` ✓

<img width="970" height="463" alt="SCR-20260415-jjmj" src="https://github.com/user-attachments/assets/7fc313b3-0f95-4013-b098-76c22fb2efc1" />


## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

_N/A_