### PR TITLE
feat: migrate pre-award alerts to notification system

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+
+[dev-packages]
+
+[requires]
+python_version = "3.14"

--- a/backend/alembic/versions/2026_04_15_1631-ae2ee26e19d5_add_pre_award_approval_notification_type.py
+++ b/backend/alembic/versions/2026_04_15_1631-ae2ee26e19d5_add_pre_award_approval_notification_type.py
@@ -1,0 +1,63 @@
+"""add pre award approval notification type
+
+Revision ID: ae2ee26e19d5
+Revises: c47768234303
+Create Date: 2026-04-15 16:31:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ae2ee26e19d5'
+down_revision: Union[str, None] = 'c47768234303'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add new notification type enum value
+    op.execute("ALTER TYPE notificationtype ADD VALUE IF NOT EXISTS 'PRE_AWARD_APPROVAL_NOTIFICATION'")
+
+    # Add procurement_tracker_step_id column to notification table
+    op.add_column(
+        'notification',
+        sa.Column('procurement_tracker_step_id', sa.Integer(), nullable=True)
+    )
+    op.create_foreign_key(
+        'fk_notification_procurement_tracker_step_id',
+        'notification', 'procurement_tracker_step',
+        ['procurement_tracker_step_id'], ['id'],
+        ondelete='CASCADE'
+    )
+    # Create single-column index (matches pattern from change_request_id)
+    op.create_index(
+        op.f('ix_notification_procurement_tracker_step_id'),
+        'notification',
+        ['procurement_tracker_step_id'],
+        unique=False
+    )
+    # Create composite index for common query pattern (filtering by step + read status)
+    op.create_index(
+        'idx_notification_procurement_tracker_step',
+        'notification',
+        ['procurement_tracker_step_id', 'is_read']
+    )
+
+    # Add procurement_tracker_step_id column to notification_version table (for audit history)
+    op.add_column(
+        'notification_version',
+        sa.Column('procurement_tracker_step_id', sa.Integer(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('notification_version', 'procurement_tracker_step_id')
+    op.drop_index('idx_notification_procurement_tracker_step', table_name='notification')
+    op.drop_index(op.f('ix_notification_procurement_tracker_step_id'), table_name='notification')
+    op.drop_constraint('fk_notification_procurement_tracker_step_id', 'notification', type_='foreignkey')
+    op.drop_column('notification', 'procurement_tracker_step_id')
+    # Note: Can't remove enum value in PostgreSQL without recreating the enum

--- a/backend/models/notifications.py
+++ b/backend/models/notifications.py
@@ -11,25 +11,42 @@ from models.base import BaseModel
 class NotificationType(Enum):
     NOTIFICATION = auto()
     CHANGE_REQUEST_NOTIFICATION = auto()
+    PRE_AWARD_APPROVAL_NOTIFICATION = auto()
 
 
 class Notification(BaseModel):
     __tablename__ = "notification"
     id: Mapped[int] = BaseModel.get_pk_column()
     notification_type: Mapped[NotificationType] = mapped_column(
-        ENUM(NotificationType), default=NotificationType.NOTIFICATION, nullable=False, index=True
+        ENUM(NotificationType),
+        default=NotificationType.NOTIFICATION,
+        nullable=False,
+        index=True,
     )
     title: Mapped[Optional[str]] = mapped_column(String)
     message: Mapped[Optional[str]] = mapped_column(String)
     is_read: Mapped[bool] = mapped_column(Boolean, default=False, index=True)
     expires: Mapped[Optional[Date]] = mapped_column(Date)
 
-    recipient_id: Mapped[Optional[int]] = mapped_column(ForeignKey("ops_user.id"))
-    recipient = relationship("User", back_populates="notifications", foreign_keys=[recipient_id])
+    recipient_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("ops_user.id")
+    )
+    recipient = relationship(
+        "User", back_populates="notifications", foreign_keys=[recipient_id]
+    )
 
     __table_args__ = (
-        Index("idx_notification_recipient_created", "recipient_id", text("created_on DESC")),
-        Index("idx_notification_complete", "is_read", "notification_type", text("created_on DESC")),
+        Index(
+            "idx_notification_recipient_created",
+            "recipient_id",
+            text("created_on DESC"),
+        ),
+        Index(
+            "idx_notification_complete",
+            "is_read",
+            "notification_type",
+            text("created_on DESC"),
+        ),
     )
 
     __mapper_args__ = {
@@ -40,7 +57,9 @@ class Notification(BaseModel):
 
 class ChangeRequestNotification(Notification):
     change_request_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("change_request.id", ondelete="CASCADE"), index=True, nullable=True
+        ForeignKey("change_request.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
     )
     change_request = relationship(
         "ChangeRequest",
@@ -49,4 +68,24 @@ class ChangeRequestNotification(Notification):
 
     __mapper_args__ = {
         "polymorphic_identity": NotificationType.CHANGE_REQUEST_NOTIFICATION,
+    }
+
+
+class PreAwardApprovalNotification(Notification):
+    """Notification for pre-award approval requests and responses."""
+
+    procurement_tracker_step_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("procurement_tracker_step.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    procurement_tracker_step = relationship(
+        "ProcurementTrackerStep",
+        passive_deletes=True,
+    )
+
+    __mapper_args__ = {
+        "polymorphic_identity": (
+            NotificationType.PRE_AWARD_APPROVAL_NOTIFICATION
+        ),
     }

--- a/backend/ops_api/ops/resources/notifications.py
+++ b/backend/ops_api/ops/resources/notifications.py
@@ -7,9 +7,9 @@ from flask import Response, current_app, request
 from flask_jwt_extended import current_user
 from loguru import logger
 from marshmallow import Schema, fields
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import InstrumentedAttribute, contains_eager
+from sqlalchemy.orm import InstrumentedAttribute, contains_eager, selectinload
 
 from models import (
     AgreementChangeRequest,
@@ -17,6 +17,9 @@ from models import (
     Notification,
     NotificationType,
     OpsEventType,
+    PreAwardApprovalNotification,
+    ProcurementTracker,
+    ProcurementTrackerStep,
     User,
 )
 from ops_api.ops.auth.auth_types import Permission, PermissionType
@@ -60,6 +63,7 @@ class NotificationResponseSchema(Schema):
     recipient = fields.Nested(RecipientSchema(), allow_none=True)
     expires = fields.Date(allow_none=True)
     change_request = fields.Nested(BudgetLineItemChangeRequestResponseSchema(), allow_none=True)
+    procurement_tracker_step_id = fields.Int(allow_none=True)
 
 
 class ListAPIRequest(Schema):
@@ -180,24 +184,44 @@ class NotificationListAPI(BaseListAPI):
         agreement_id: Optional[int] = None,
     ):
         if agreement_id:
-            # only ChangeRequestNotifications are associated with an agreement
+            # Query for both ChangeRequestNotifications and PreAwardApprovalNotifications
             stmt = (
-                select(ChangeRequestNotification)
+                select(Notification)
                 .join(
                     User,
-                    ChangeRequestNotification.recipient_id == User.id,
+                    Notification.recipient_id == User.id,
                     isouter=True,
                 )
-                .join(
+                .outerjoin(
                     AgreementChangeRequest,
-                    ChangeRequestNotification.change_request_id == AgreementChangeRequest.id,
+                    and_(
+                        Notification.id == ChangeRequestNotification.id,
+                        ChangeRequestNotification.change_request_id == AgreementChangeRequest.id,
+                    ),
                 )
-                .where(AgreementChangeRequest.agreement_id == agreement_id)
+                .outerjoin(
+                    ProcurementTrackerStep,
+                    and_(
+                        Notification.id == PreAwardApprovalNotification.id,
+                        PreAwardApprovalNotification.procurement_tracker_step_id == ProcurementTrackerStep.id,
+                    ),
+                )
+                .outerjoin(
+                    ProcurementTracker,
+                    ProcurementTrackerStep.procurement_tracker_id == ProcurementTracker.id,
+                )
+                .where(
+                    or_(
+                        AgreementChangeRequest.agreement_id == agreement_id,
+                        ProcurementTracker.agreement_id == agreement_id,
+                    )
+                )
                 .options(
-                    contains_eager(ChangeRequestNotification.recipient),
-                    contains_eager(ChangeRequestNotification.change_request),
+                    contains_eager(Notification.recipient),
+                    selectinload(ChangeRequestNotification.change_request),
+                    selectinload(PreAwardApprovalNotification.procurement_tracker_step),
                 )
-                .order_by(ChangeRequestNotification.created_on.desc())
+                .order_by(Notification.created_on.desc())
             )
         else:
             stmt = (
@@ -205,6 +229,8 @@ class NotificationListAPI(BaseListAPI):
                 .join(User, Notification.recipient_id == User.id, isouter=True)
                 .options(
                     contains_eager(Notification.recipient),
+                    selectinload(ChangeRequestNotification.change_request),
+                    selectinload(PreAwardApprovalNotification.procurement_tracker_step),
                 )
                 .order_by(Notification.created_on.desc())
             )

--- a/backend/ops_api/ops/services/notifications.py
+++ b/backend/ops_api/ops/services/notifications.py
@@ -1,6 +1,11 @@
 from typing import Any, Type
 
-from models import ChangeRequestNotification, Notification, NotificationType
+from models import (
+    ChangeRequestNotification,
+    Notification,
+    NotificationType,
+    PreAwardApprovalNotification,
+)
 from ops_api.ops.services.ops_service import OpsService, ResourceNotFoundError
 
 
@@ -18,6 +23,8 @@ class NotificationService(OpsService[Notification]):
         cls: Type[Notification]
         if notification_type == NotificationType.CHANGE_REQUEST_NOTIFICATION:
             cls = ChangeRequestNotification
+        elif notification_type == NotificationType.PRE_AWARD_APPROVAL_NOTIFICATION:
+            cls = PreAwardApprovalNotification
         else:
             cls = Notification
 

--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -387,9 +387,7 @@ class ProcurementTrackerStepService:
                 .values(is_read=True)
             )
 
-            logger.debug(
-                f"Auto-dismissed {dismiss_result.rowcount or 0} 'in review' notifications for reviewers"
-            )
+            logger.debug(f"Auto-dismissed {dismiss_result.rowcount or 0} 'in review' notifications for reviewers")
 
     def _get_approval_reviewers(self, agreement) -> set[int]:
         """

--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from flask import current_app
 from loguru import logger
-from sqlalchemy import Select, func, select
+from sqlalchemy import Select, func
 from sqlalchemy.orm import selectinload
 
 from models import (
@@ -340,7 +340,8 @@ class ProcurementTrackerStepService:
                         ),
                         "is_read": False,
                         "recipient_id": recipient_id,
-                        "notification_type": NotificationType.NOTIFICATION,
+                        "notification_type": NotificationType.PRE_AWARD_APPROVAL_NOTIFICATION,
+                        "procurement_tracker_step_id": step.id,
                     }
                 )
             logger.debug(f"Created {len(recipient_ids)} pre-award approval request notifications")
@@ -363,10 +364,33 @@ class ProcurementTrackerStepService:
                         ),
                         "is_read": False,
                         "recipient_id": step.pre_award_approval_requested_by,
-                        "notification_type": NotificationType.NOTIFICATION,
+                        "notification_type": NotificationType.PRE_AWARD_APPROVAL_NOTIFICATION,
+                        "procurement_tracker_step_id": step.id,
                     }
                 )
                 logger.debug(f"Created pre-award approval {status_text} notification for submitter")
+
+            # Auto-dismiss "in review" notifications for reviewers
+            # Auto-dismiss "in review" notifications for reviewers via bulk UPDATE
+            from sqlalchemy import and_, select, update
+
+            from models import PreAwardApprovalNotification
+
+            dismiss_result = self.db_session.execute(
+                update(PreAwardApprovalNotification)
+                .where(
+                    and_(
+                        PreAwardApprovalNotification.title == "Pre-Award Approval Request",
+                        PreAwardApprovalNotification.is_read.is_(False),
+                        PreAwardApprovalNotification.procurement_tracker_step_id == step.id,
+                    )
+                )
+                .values(is_read=True)
+            )
+
+            logger.debug(
+                f"Auto-dismissed {dismiss_result.rowcount or 0} 'in review' notifications for reviewers"
+            )
 
     def _get_approval_reviewers(self, agreement) -> set[int]:
         """

--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from flask import current_app
 from loguru import logger
-from sqlalchemy import Select, select, func
+from sqlalchemy import Select, func, select
 from sqlalchemy.orm import selectinload
 
 from models import (

--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from flask import current_app
 from loguru import logger
-from sqlalchemy import Select, func
+from sqlalchemy import Select, func, select
 from sqlalchemy.orm import selectinload
 
 from models import (

--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -370,9 +370,8 @@ class ProcurementTrackerStepService:
                 )
                 logger.debug(f"Created pre-award approval {status_text} notification for submitter")
 
-            # Auto-dismiss "in review" notifications for reviewers
             # Auto-dismiss "in review" notifications for reviewers via bulk UPDATE
-            from sqlalchemy import and_, select, update
+            from sqlalchemy import and_, update
 
             from models import PreAwardApprovalNotification
 
@@ -405,8 +404,6 @@ class ProcurementTrackerStepService:
         Returns:
             Set of user IDs authorized to review
         """
-        from sqlalchemy import select
-
         from models import Role
         from ops_api.ops.utils.agreements_helpers import get_division_directors_for_agreement
 

--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -405,6 +405,7 @@ class ProcurementTrackerStepService:
             Set of user IDs authorized to review
         """
         from models import Role
+
         from ops_api.ops.utils.agreements_helpers import get_division_directors_for_agreement
 
         reviewer_ids = set()

--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -403,7 +403,6 @@ class ProcurementTrackerStepService:
             Set of user IDs authorized to review
         """
         from models import Role
-
         from ops_api.ops.utils.agreements_helpers import get_division_directors_for_agreement
 
         reviewer_ids = set()

--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from flask import current_app
 from loguru import logger
-from sqlalchemy import Select, func, select
+from sqlalchemy import Select, select, func
 from sqlalchemy.orm import selectinload
 
 from models import (

--- a/backend/ops_api/tests/ops/procurement_tracker/test_procurement_tracker_steps_duplicate_notifications.py
+++ b/backend/ops_api/tests/ops/procurement_tracker/test_procurement_tracker_steps_duplicate_notifications.py
@@ -203,3 +203,45 @@ def test_approval_transitions_are_idempotent(auth_client, test_pre_award_step, l
     assert (
         total_notifications_sent == notifications_sent_first_time
     ), "Only the first request should have sent notifications"
+
+
+def test_approval_response_auto_dismisses_in_review_notifications(auth_client, test_pre_award_step, loaded_db):
+    """Test that approval response auto-dismisses 'in review' notifications for reviewers."""
+    # Step 1: Request approval - creates "in review" notifications for reviewers
+    update_data = {
+        "approval_requested": True,
+        "approval_requested_date": date.today().isoformat(),
+        "requestor_notes": "Please review and approve",
+    }
+    response = auth_client.patch(
+        f"/api/v1/procurement-tracker-steps/{test_pre_award_step.id}",
+        json=update_data,
+    )
+    assert response.status_code == 200
+
+    # Verify "in review" notifications were created
+    in_review_notifications = loaded_db.scalars(
+        select(Notification)
+        .where(Notification.title == "Pre-Award Approval Request")
+        .where(Notification.is_read.is_(False))
+    ).all()
+    assert len(in_review_notifications) > 0, "Should have unread approval request notifications"
+
+    # Store the notification IDs to verify later
+    reviewer_notification_ids = [n.id for n in in_review_notifications]
+
+    # Step 2: Approve request - should auto-dismiss reviewer notifications
+    update_data = {
+        "approval_status": "APPROVED",
+        "reviewer_notes": "Looks good, approved",
+    }
+    response = auth_client.patch(
+        f"/api/v1/procurement-tracker-steps/{test_pre_award_step.id}",
+        json=update_data,
+    )
+    assert response.status_code == 200
+
+    # Step 3: Verify all "in review" notifications are marked as read
+    for notification_id in reviewer_notification_ids:
+        notification = loaded_db.get(Notification, notification_id)
+        assert notification.is_read, f"Notification {notification_id} should be auto-dismissed (marked as read)"

--- a/frontend/src/components/Agreements/AgreementChangesResponseAlert/AgreementChangesResponseAlert.hooks.jsx
+++ b/frontend/src/components/Agreements/AgreementChangesResponseAlert/AgreementChangesResponseAlert.hooks.jsx
@@ -18,13 +18,13 @@ const useAgreementChangesResponseAlert = (
     let newAwardingEntityId = -1;
     let oldAwardingEntityId = -1;
     const approvedRequests = changeRequestNotifications?.filter(
-        (request) => request.change_request.status === "APPROVED"
+        (request) => request.change_request?.status === "APPROVED"
     );
     const declinedRequests = changeRequestNotifications?.filter(
-        (request) => request.change_request.status === "REJECTED"
+        (request) => request.change_request?.status === "REJECTED"
     );
 
-    const procurementShopChangeNotification = changeRequestNotifications.find(
+    const procurementShopChangeNotification = changeRequestNotifications?.find(
         (notification) => notification.change_request?.requested_change_diff?.awarding_entity_id !== undefined
     );
 
@@ -143,8 +143,9 @@ export function formatChangeRequest(changeRequest, oldProcurementShop = {}, newP
 export function getChangeRequestNotes(changeRequests) {
     let reviewerNotes = "";
     changeRequests?.forEach((changeRequest) => {
-        if (changeRequest.change_request?.reviewer_notes !== "") {
-            reviewerNotes = changeRequest.change_request?.reviewer_notes;
+        const notes = changeRequest?.change_request?.reviewer_notes;
+        if (notes && notes !== "") {
+            reviewerNotes = notes;
         }
     });
 

--- a/frontend/src/components/Agreements/PreAwardApprovalAlert/PreAwardApprovalAlert.jsx
+++ b/frontend/src/components/Agreements/PreAwardApprovalAlert/PreAwardApprovalAlert.jsx
@@ -1,0 +1,118 @@
+import { useMemo } from "react";
+import PropTypes from "prop-types";
+import SimpleAlert from "../../UI/Alert/SimpleAlert";
+import { useDismissNotificationMutation } from "../../../api/opsAPI";
+
+// Keywords for identifying notification types
+const APPROVAL_KEYWORDS = ["approved", "approval granted"];
+const DECLINE_KEYWORDS = ["declined", "rejected", "denial"];
+
+/**
+ * Check if notification title indicates approval
+ * @param {string} title - Notification title
+ * @returns {boolean} True if title contains approval keywords
+ */
+const isApprovedNotification = (title) => {
+    const lowerTitle = title?.toLowerCase() || "";
+    return APPROVAL_KEYWORDS.some((keyword) => lowerTitle.includes(keyword));
+};
+
+/**
+ * Check if notification title indicates decline
+ * @param {string} title - Notification title
+ * @returns {boolean} True if title contains decline keywords
+ */
+const isDeclinedNotification = (title) => {
+    const lowerTitle = title?.toLowerCase() || "";
+    return DECLINE_KEYWORDS.some((keyword) => lowerTitle.includes(keyword));
+};
+
+/**
+ * Alert component for pre-award approval response notifications.
+ * Only displays Approved/Declined notifications (not "In Review" notifications).
+ * "In Review" alerts are shown via SimpleAlert based on procurement tracker data.
+ *
+ * @component
+ * @param {Object} props - The component props.
+ * @param {Object[]} props.notifications - Array of notification objects
+ * @param {boolean} props.isVisible - Whether the alert is visible
+ * @returns {React.ReactElement|null} The rendered component or null if no notifications
+ */
+function PreAwardApprovalAlert({ notifications, isVisible }) {
+    const [dismissNotification, { isError }] = useDismissNotificationMutation();
+
+    // Filter for unread pre-award approval RESPONSE notifications (Approved/Declined only)
+    // Exclude "Request" notifications - those are for approvers in NotificationCenter only
+    const preAwardNotifications = useMemo(
+        () =>
+            notifications?.filter(
+                (n) =>
+                    !n.is_read &&
+                    n.notification_type === "PRE_AWARD_APPROVAL_NOTIFICATION" &&
+                    (isApprovedNotification(n.title) || isDeclinedNotification(n.title))
+            ) || [],
+        [notifications]
+    );
+
+    const handleDismiss = (notificationId) => {
+        dismissNotification(notificationId);
+    };
+
+    // Don't render if not visible or no notifications
+    if (!isVisible || preAwardNotifications.length === 0) {
+        return null;
+    }
+
+    // Helper to determine alert type based on title
+    const getAlertType = (title) => {
+        if (isApprovedNotification(title)) {
+            return "success";
+        }
+        if (isDeclinedNotification(title)) {
+            return "error";
+        }
+        return "warning";
+    };
+
+    return (
+        <>
+            {isError && (
+                <SimpleAlert
+                    type="error"
+                    heading="Error"
+                    message="Failed to dismiss notification. Please try again."
+                    isClosable={false}
+                />
+            )}
+            {preAwardNotifications.map((notification) => {
+                const alertType = getAlertType(notification.title);
+
+                return (
+                    <SimpleAlert
+                        key={notification.id}
+                        type={alertType}
+                        heading={notification.title}
+                        message={notification.message}
+                        isClosable={true}
+                        setIsAlertVisible={() => handleDismiss(notification.id)}
+                    />
+                );
+            })}
+        </>
+    );
+}
+
+PreAwardApprovalAlert.propTypes = {
+    notifications: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.number.isRequired,
+            notification_type: PropTypes.string.isRequired,
+            title: PropTypes.string,
+            message: PropTypes.string,
+            is_read: PropTypes.bool.isRequired
+        })
+    ),
+    isVisible: PropTypes.bool.isRequired
+};
+
+export default PreAwardApprovalAlert;

--- a/frontend/src/components/Agreements/PreAwardApprovalAlert/PreAwardApprovalAlert.test.jsx
+++ b/frontend/src/components/Agreements/PreAwardApprovalAlert/PreAwardApprovalAlert.test.jsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { vi } from "vitest";
+import store from "../../../store";
+import PreAwardApprovalAlert from "./PreAwardApprovalAlert";
+import * as opsAPI from "../../../api/opsAPI";
+
+const mockDismissNotification = vi.fn();
+
+vi.spyOn(opsAPI, "useDismissNotificationMutation").mockReturnValue([
+    mockDismissNotification,
+    { isError: false, error: null }
+]);
+
+const approvedNotification = {
+    id: 1,
+    notification_type: "PRE_AWARD_APPROVAL_NOTIFICATION",
+    title: "Pre-Award Approval Approved",
+    message: "Your pre-award approval request has been approved by John Doe.",
+    is_read: false
+};
+
+const declinedNotification = {
+    id: 2,
+    notification_type: "PRE_AWARD_APPROVAL_NOTIFICATION",
+    title: "Pre-Award Approval Declined",
+    message: "Your pre-award approval request has been declined by Jane Smith.",
+    is_read: false
+};
+
+const requestNotification = {
+    id: 3,
+    notification_type: "PRE_AWARD_APPROVAL_NOTIFICATION",
+    title: "Pre-Award Approval Request",
+    message: "A pre-award approval has been requested.",
+    is_read: false
+};
+
+const readNotification = {
+    id: 4,
+    notification_type: "PRE_AWARD_APPROVAL_NOTIFICATION",
+    title: "Pre-Award Approval Approved",
+    message: "Already read notification.",
+    is_read: true
+};
+
+describe("PreAwardApprovalAlert", () => {
+    beforeEach(() => {
+        mockDismissNotification.mockClear();
+    });
+
+    it("should render approved alert with success type", () => {
+        render(
+            <Provider store={store}>
+                <PreAwardApprovalAlert
+                    notifications={[approvedNotification]}
+                    isVisible={true}
+                    setIsVisible={() => {}}
+                />
+            </Provider>
+        );
+
+        expect(screen.getByText("Pre-Award Approval Approved")).toBeInTheDocument();
+        expect(screen.getByText(/Your pre-award approval request has been approved by John Doe/)).toBeInTheDocument();
+    });
+
+    it("should render declined alert with error type", () => {
+        render(
+            <Provider store={store}>
+                <PreAwardApprovalAlert
+                    notifications={[declinedNotification]}
+                    isVisible={true}
+                    setIsVisible={() => {}}
+                />
+            </Provider>
+        );
+
+        expect(screen.getByText("Pre-Award Approval Declined")).toBeInTheDocument();
+        expect(screen.getByText(/Your pre-award approval request has been declined by Jane Smith/)).toBeInTheDocument();
+    });
+
+    it("should NOT render request alert (only shows Approved/Declined)", () => {
+        render(
+            <Provider store={store}>
+                <PreAwardApprovalAlert
+                    notifications={[requestNotification]}
+                    isVisible={true}
+                    setIsVisible={() => {}}
+                />
+            </Provider>
+        );
+
+        // Request notifications are filtered out - only Approved/Declined show in PreAwardApprovalAlert
+        expect(screen.queryByText("Pre-Award Approval Request")).not.toBeInTheDocument();
+        expect(screen.queryByText(/A pre-award approval has been requested/)).not.toBeInTheDocument();
+    });
+
+    it("should call dismissNotification when close button clicked", () => {
+        render(
+            <Provider store={store}>
+                <PreAwardApprovalAlert
+                    notifications={[approvedNotification]}
+                    isVisible={true}
+                    setIsVisible={() => {}}
+                />
+            </Provider>
+        );
+
+        const closeButton = screen.getByRole("img", { name: "close" });
+        fireEvent.click(closeButton);
+
+        expect(mockDismissNotification).toHaveBeenCalledWith(1);
+    });
+
+    it("should hide component when isVisible is false", () => {
+        render(
+            <Provider store={store}>
+                <PreAwardApprovalAlert
+                    notifications={[approvedNotification]}
+                    isVisible={false}
+                    setIsVisible={() => {}}
+                />
+            </Provider>
+        );
+
+        expect(screen.queryByText("Pre-Award Approval Approved")).not.toBeInTheDocument();
+    });
+
+    it("should hide component when no notifications", () => {
+        render(
+            <Provider store={store}>
+                <PreAwardApprovalAlert
+                    notifications={[]}
+                    isVisible={true}
+                    setIsVisible={() => {}}
+                />
+            </Provider>
+        );
+
+        expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+    });
+
+    it("should filter out read notifications", () => {
+        render(
+            <Provider store={store}>
+                <PreAwardApprovalAlert
+                    notifications={[readNotification]}
+                    isVisible={true}
+                    setIsVisible={() => {}}
+                />
+            </Provider>
+        );
+
+        expect(screen.queryByText("Pre-Award Approval Approved")).not.toBeInTheDocument();
+    });
+
+    it("should filter out non-pre-award notifications", () => {
+        render(
+            <Provider store={store}>
+                <PreAwardApprovalAlert
+                    notifications={[
+                        {
+                            id: 5,
+                            notification_type: "CHANGE_REQUEST_NOTIFICATION",
+                            title: "Change Request",
+                            message: "A change request.",
+                            is_read: false
+                        }
+                    ]}
+                    isVisible={true}
+                    setIsVisible={() => {}}
+                />
+            </Provider>
+        );
+
+        expect(screen.queryByText("Change Request")).not.toBeInTheDocument();
+    });
+
+    it("should render multiple notifications", () => {
+        render(
+            <Provider store={store}>
+                <PreAwardApprovalAlert
+                    notifications={[approvedNotification, declinedNotification]}
+                    isVisible={true}
+                    setIsVisible={() => {}}
+                />
+            </Provider>
+        );
+
+        expect(screen.getByText("Pre-Award Approval Approved")).toBeInTheDocument();
+        expect(screen.getByText("Pre-Award Approval Declined")).toBeInTheDocument();
+    });
+});

--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -6,10 +6,12 @@ import { getUser } from "../../../api/getUser";
 import {
     useGetAgreementByIdQuery,
     useGetNotificationsByUserIdAndAgreementIdQuery,
-    useGetProcurementShopByIdQuery
+    useGetProcurementShopByIdQuery,
+    useGetProcurementTrackersByAgreementIdQuery
 } from "../../../api/opsAPI";
 import AgreementChangesAlert from "../../../components/Agreements/AgreementChangesAlert";
 import AgreementChangesResponseAlert from "../../../components/Agreements/AgreementChangesResponseAlert";
+import PreAwardApprovalAlert from "../../../components/Agreements/PreAwardApprovalAlert/PreAwardApprovalAlert";
 import DetailsTabs from "../../../components/Agreements/DetailsTabs";
 import DocumentView from "../../../components/Agreements/Documents/DocumentView";
 import SimpleAlert from "../../../components/UI/Alert/SimpleAlert";
@@ -44,6 +46,8 @@ const Agreement = () => {
     const [isTempUiAlertVisible, setIsTempUiAlertVisible] = useState(true);
     const [isApproveAlertVisible, setIsApproveAlertVisible] = useState(true);
     const [isDeclinedAlertVisible, setIsDeclinedAlertVisible] = useState(true);
+    const [isPreAwardAlertVisible] = useState(true);
+    const [isPreAwardInReviewAlertVisible, setIsPreAwardInReviewAlertVisible] = useState(true);
 
     const searchParams = new URLSearchParams(location.search);
     const mode = searchParams.get("mode") || undefined;
@@ -77,6 +81,11 @@ const Agreement = () => {
     if (query_response) {
         user_agreement_notifications = query_response.data;
     }
+
+    // Query procurement tracker to check for pre-award approval status
+    const { data: procurementTrackers } = useGetProcurementTrackersByAgreementIdQuery(agreementId, {
+        skip: !agreementId
+    });
 
     if (isSuccess && agreement) {
         doesAgreementHaveBlIsInReview = hasBlIsInReview(agreement.budget_line_items ?? []);
@@ -175,6 +184,14 @@ const Agreement = () => {
     const showReviewAlert = (doesAgreementHaveBlIsInReview || agreement?.in_review) && isAlertVisible;
     const showNonContractAlert = isAgreementNotDeveloped && isTempUiAlertVisible;
 
+    // Check if pre-award approval is in review (approval_requested but not yet approved/declined)
+    const trackers = procurementTrackers?.data || [];
+    const activeTracker = trackers.find((tracker) => tracker.status === "ACTIVE");
+    const preAwardStep = activeTracker?.steps?.find((step) => step.step_type === "PRE_AWARD");
+    const preAwardApprovalStatus = preAwardStep?.approval_status;
+    const isPreAwardInReview =
+        preAwardStep?.approval_requested && (preAwardApprovalStatus == null || preAwardApprovalStatus === "PENDING");
+
     const isAgreementAwarded = agreement?.is_awarded;
     return (
         <App breadCrumbName={agreement?.name}>
@@ -183,6 +200,15 @@ const Agreement = () => {
                     changeRequests={allChangeRequests}
                     isAlertVisible={isAlertVisible}
                     setIsAlertVisible={setIsAlertVisible}
+                />
+            )}
+            {isPreAwardInReview && isPreAwardInReviewAlertVisible && (
+                <SimpleAlert
+                    type="warning"
+                    heading="Pre-Award Approval In Review"
+                    isClosable={true}
+                    message="This agreement is In Review for Pre-Award Approval. Edits or changes cannot be made at this time."
+                    setIsAlertVisible={setIsPreAwardInReviewAlertVisible}
                 />
             )}
             {showNonContractAlert && (
@@ -215,14 +241,20 @@ const Agreement = () => {
             </h2>
 
             {user_agreement_notifications?.length > 0 && (
-                <AgreementChangesResponseAlert
-                    changeRequestNotifications={user_agreement_notifications}
-                    isApproveAlertVisible={isApproveAlertVisible}
-                    isDeclineAlertVisible={isDeclinedAlertVisible}
-                    setIsApproveAlertVisible={setIsApproveAlertVisible}
-                    setIsDeclineAlertVisible={setIsDeclinedAlertVisible}
-                    budgetLines={agreement?.budget_line_items ?? []}
-                />
+                <>
+                    <AgreementChangesResponseAlert
+                        changeRequestNotifications={user_agreement_notifications}
+                        isApproveAlertVisible={isApproveAlertVisible}
+                        isDeclineAlertVisible={isDeclinedAlertVisible}
+                        setIsApproveAlertVisible={setIsApproveAlertVisible}
+                        setIsDeclineAlertVisible={setIsDeclinedAlertVisible}
+                        budgetLines={agreement?.budget_line_items ?? []}
+                    />
+                    <PreAwardApprovalAlert
+                        notifications={user_agreement_notifications}
+                        isVisible={isPreAwardAlertVisible}
+                    />
+                </>
             )}
             <div>
                 <section className="display-flex flex-justify margin-top-3">

--- a/frontend/src/pages/agreements/details/AgreementProcurementTracker.jsx
+++ b/frontend/src/pages/agreements/details/AgreementProcurementTracker.jsx
@@ -1,6 +1,4 @@
 import React from "react";
-import { useSelector } from "react-redux";
-import { useLocation, useNavigate } from "react-router-dom";
 import { useGetProcurementTrackersByAgreementIdQuery, useGetUsersQuery } from "../../../api/opsAPI";
 import ProcurementTrackerStepOne from "../../../components/Agreements/ProcurementTracker/ProcurementTrackerStepOne";
 import ProcurementTrackerStepTwo from "../../../components/Agreements/ProcurementTracker/ProcurementTrackerStepTwo";
@@ -9,11 +7,9 @@ import ProcurementTrackerStepFour from "../../../components/Agreements/Procureme
 import ProcurementTrackerStepFive from "../../../components/Agreements/ProcurementTracker/ProcurementTrackerStepFive";
 import StepBuilderAccordion from "../../../components/Agreements/ProcurementTracker/StepBuilderAccordion";
 import DebugCode from "../../../components/DebugCode";
-import SimpleAlert from "../../../components/UI/Alert/SimpleAlert";
 import StepIndicator from "../../../components/UI/StepIndicator";
 import { IS_PROCUREMENT_TRACKER_READY_MAP } from "../../../constants";
 import { useIsUserSuperUser, useIsUserOnlyProcurementTeam } from "../../../hooks/user.hooks";
-import { ProcurementTrackerPreAwardApprovalStatus } from "../../../components/Agreements/ProcurementTracker/ProcurementTracker.constants";
 
 /**
  * @typedef {Object} AgreementProcurementTrackerProps
@@ -27,14 +23,6 @@ import { ProcurementTrackerPreAwardApprovalStatus } from "../../../components/Ag
  */
 
 const AgreementProcurementTracker = ({ agreement }) => {
-    const location = useLocation();
-    const navigate = useNavigate();
-    const [showSuccessAlert, setShowSuccessAlert] = React.useState(false);
-    const [showInReviewAlert, setShowInReviewAlert] = React.useState(false);
-    const [showApprovedAlert, setShowApprovedAlert] = React.useState(false);
-    const [showDeclinedAlert, setShowDeclinedAlert] = React.useState(false);
-    const isJustSubmittedRef = React.useRef(false);
-
     const WIZARD_STEPS = [
         "Acquisition Planning",
         "Pre-Solicitation",
@@ -48,27 +36,7 @@ const AgreementProcurementTracker = ({ agreement }) => {
         setCompletedStepNumber(stepNumber);
     };
     const agreementId = agreement?.id;
-    const currentUserId = useSelector((state) => state.auth?.activeUser?.id);
 
-    // Check for success message from location state (runs once on mount)
-    React.useEffect(() => {
-        if (location.state?.success) {
-            isJustSubmittedRef.current = true;
-            setShowSuccessAlert(true);
-            setShowInReviewAlert(false);
-            // Clear the location state to avoid showing alert on refresh/revisit
-            navigate(location.pathname, { replace: true, state: {} });
-
-            // After 5 seconds, transition to in-review alert
-            const timeoutId = setTimeout(() => {
-                isJustSubmittedRef.current = false;
-                setShowSuccessAlert(false);
-                setShowInReviewAlert(true);
-            }, 5000);
-
-            return () => clearTimeout(timeoutId);
-        }
-    }, [location.state, location.pathname, navigate]);
     const isSuperUser = useIsUserSuperUser();
     const isProcurementTeamOnly = useIsUserOnlyProcurementTeam();
     const isEditable = isSuperUser || (agreement?._meta?.isEditable ?? false);
@@ -100,37 +68,6 @@ const AgreementProcurementTracker = ({ agreement }) => {
     const stepThreeData = activeTracker?.steps.find((step) => step.step_number === 3);
     const stepFourData = activeTracker?.steps.find((step) => step.step_number === 4);
     const stepFiveData = activeTracker?.steps.find((step) => step.step_number === 5);
-
-    // Show "In Review" alert when approval is requested and not in the "just submitted" state
-    // Hide alert when pre-award has been approved or declined
-    React.useEffect(() => {
-        // Show "In Review" alert only when approval is truly pending (requested but not yet processed)
-        // This matches the logic in RequestPreAwardApproval.hooks.js
-        const shouldShowInReview =
-            stepFiveData?.approval_requested &&
-            !isJustSubmittedRef.current &&
-            (!stepFiveData?.approval_status ||
-                stepFiveData?.approval_status === ProcurementTrackerPreAwardApprovalStatus.PENDING);
-
-        setShowInReviewAlert(shouldShowInReview);
-    }, [stepFiveData?.approval_requested, stepFiveData?.approval_status]);
-
-    // Show approved/declined alerts only to the user who requested approval
-    React.useEffect(() => {
-        const isRequester = currentUserId && stepFiveData?.approval_requested_by === currentUserId;
-        const approvalStatus = stepFiveData?.approval_status;
-
-        if (isRequester && approvalStatus === ProcurementTrackerPreAwardApprovalStatus.APPROVED) {
-            setShowApprovedAlert(true);
-            setShowDeclinedAlert(false);
-        } else if (isRequester && approvalStatus === ProcurementTrackerPreAwardApprovalStatus.DECLINED) {
-            setShowApprovedAlert(false);
-            setShowDeclinedAlert(true);
-        } else {
-            setShowApprovedAlert(false);
-            setShowDeclinedAlert(false);
-        }
-    }, [currentUserId, stepFiveData?.approval_requested_by, stepFiveData?.approval_status]);
 
     // Handle loading state
     if (isLoading) {
@@ -164,46 +101,6 @@ const AgreementProcurementTracker = ({ agreement }) => {
 
     return (
         <>
-            {showApprovedAlert && (
-                <SimpleAlert
-                    type="success"
-                    heading="Pre-Award Approved"
-                    message={`This agreement has been approved for Pre-Award. Please send the Final Consensus Memo to the Procurement Shop and continue your progress in the Procurement Tracker.${
-                        stepFiveData?.reviewer_notes ? `\n\nNotes: ${stepFiveData.reviewer_notes}` : ""
-                    }`}
-                    isClosable={true}
-                    setIsAlertVisible={setShowApprovedAlert}
-                />
-            )}
-            {showDeclinedAlert && (
-                <SimpleAlert
-                    type="error"
-                    heading="Pre-Award Declined"
-                    message={`This agreement has been declined for Pre-Award. Please do not send the Final Consensus Memo until changes have been made and re-submitted for approval.${
-                        stepFiveData?.reviewer_notes ? `\n\nNotes: ${stepFiveData.reviewer_notes}` : ""
-                    }`}
-                    isClosable={true}
-                    setIsAlertVisible={setShowDeclinedAlert}
-                />
-            )}
-            {showInReviewAlert && (
-                <SimpleAlert
-                    type="warning"
-                    heading="Pre-Award Approval In Review"
-                    message="This agreement is In Review for Pre-Award Approval. Edits or changes cannot be made at this time."
-                    isClosable={true}
-                    setIsAlertVisible={setShowInReviewAlert}
-                />
-            )}
-            {showSuccessAlert && (
-                <SimpleAlert
-                    type="success"
-                    heading="Agreement Sent to Pre-Award Approval"
-                    message="This agreement has been successfully sent to your Division Director to review. After it's approved, you can send the Final Consensus Memo and continue your progress in the Procurement Tracker."
-                    isClosable={true}
-                    setIsAlertVisible={setShowSuccessAlert}
-                />
-            )}
             <div className="display-flex flex-justify flex-align-center">
                 <h2 className="font-sans-lg">Procurement Tracker</h2>
             </div>


### PR DESCRIPTION
## Summary

Migrates pre-award approval status alerts from procurement tracker data to the notification system, following the BLI change request notification pattern.

## Changes

**Backend:**
- Add `PreAwardApprovalNotification` polymorphic subclass with `procurement_tracker_step_id` FK
- Create notifications when approval is requested (to reviewers) and granted/declined (to submitter)
- Auto-dismiss "in review" notifications via bulk UPDATE when approval response is created
- Add database migration for new notification type and FK

**Frontend:**
- Add `PreAwardApprovalAlert` component for Approved/Declined notifications (dismissible)
- Add persistent "In Review" warning based on procurement tracker data (reappears on refresh)
- Remove old alert logic from procurement tracker tab (111 lines)
- Display notifications on all agreement detail tabs

## Test Plan

- ✅ All 48 E2E tests passing
- ✅ All 2701 frontend unit tests passing
- ✅ Backend unit tests passing
- ✅ Manual testing: request approval → approve/decline → verify notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)