### PR TITLE
fix: include reviewer notes in pre-award approval/decline alerts

### DIFF
--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -355,13 +355,18 @@ class ProcurementTrackerStepService:
             status_text = "approved" if new_approval_status == "APPROVED" else "declined"
 
             if step.pre_award_approval_requested_by:
+                # Build message with optional reviewer notes
+                message = (
+                    f"Your pre-award approval request for Agreement {agreement.display_name} "
+                    f"has been {status_text} by {current_user.full_name}."
+                )
+                if step.pre_award_approval_reviewer_notes:
+                    message += f"\n\nNotes: {step.pre_award_approval_reviewer_notes}"
+
                 notification_service.create(
                     {
                         "title": f"Pre-Award Approval {status_text.capitalize()}",
-                        "message": (
-                            f"Your pre-award approval request for Agreement {agreement.display_name} "
-                            f"has been {status_text} by {current_user.full_name}."
-                        ),
+                        "message": message,
                         "is_read": False,
                         "recipient_id": step.pre_award_approval_requested_by,
                         "notification_type": NotificationType.PRE_AWARD_APPROVAL_NOTIFICATION,

--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -360,8 +360,9 @@ class ProcurementTrackerStepService:
                     f"Your pre-award approval request for Agreement {agreement.display_name} "
                     f"has been {status_text} by {current_user.full_name}."
                 )
-                if step.pre_award_approval_reviewer_notes:
-                    message += f"\n\nNotes: {step.pre_award_approval_reviewer_notes}"
+                if step.pre_award_approval_reviewer_notes and step.pre_award_approval_reviewer_notes.strip():
+                    escaped_notes = step.pre_award_approval_reviewer_notes.strip()
+                    message += f"\n\nNotes:\n```\n{escaped_notes}\n```"
 
                 notification_service.create(
                     {

--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -361,8 +361,9 @@ class ProcurementTrackerStepService:
                     f"has been {status_text} by {current_user.full_name}."
                 )
                 if step.pre_award_approval_reviewer_notes and step.pre_award_approval_reviewer_notes.strip():
-                    escaped_notes = step.pre_award_approval_reviewer_notes.strip()
-                    message += f"\n\nNotes:\n```\n{escaped_notes}\n```"
+                    reviewer_notes_text = step.pre_award_approval_reviewer_notes.strip()
+                    # Use 5 backticks to safely contain any triple-backtick sequences in notes
+                    message += f"\n\nNotes:\n`````\n{reviewer_notes_text}\n`````"
 
                 notification_service.create(
                     {

--- a/backend/ops_api/tests/ops/procurement_tracker/test_procurement_tracker_steps_duplicate_notifications.py
+++ b/backend/ops_api/tests/ops/procurement_tracker/test_procurement_tracker_steps_duplicate_notifications.py
@@ -333,7 +333,9 @@ def test_approval_response_excludes_empty_reviewer_notes(auth_client, test_pre_a
     ).first()
 
     assert notification is not None, "Notification should be created"
-    assert "Notes:" not in notification.message, f"Notes section should not appear when empty. Got: {notification.message}"
+    assert (
+        "Notes:" not in notification.message
+    ), f"Notes section should not appear when empty. Got: {notification.message}"
     # Verify base message is present
     assert "has been approved" in notification.message
 
@@ -363,7 +365,9 @@ def test_approval_response_excludes_whitespace_only_reviewer_notes(auth_client, 
     ).first()
 
     assert notification is not None, "Notification should be created"
-    assert "Notes:" not in notification.message, f"Notes section should not appear for whitespace-only notes. Got: {notification.message}"
+    assert (
+        "Notes:" not in notification.message
+    ), f"Notes section should not appear for whitespace-only notes. Got: {notification.message}"
     # Verify base message is present
     assert "has been approved" in notification.message
 

--- a/backend/ops_api/tests/ops/procurement_tracker/test_procurement_tracker_steps_duplicate_notifications.py
+++ b/backend/ops_api/tests/ops/procurement_tracker/test_procurement_tracker_steps_duplicate_notifications.py
@@ -381,7 +381,7 @@ def test_reviewer_notes_prevent_markdown_injection(auth_client, test_pre_award_s
     loaded_db.commit()
 
     # Respond with approval and Markdown injection attempt
-    malicious_notes = "**Bold** text with [link](http://example.com) and ![image](url)"
+    malicious_notes = "**Bold** text with [link](http://example.com) and ```code``` attempt"
     update_data = {
         "approval_status": "APPROVED",
         "reviewer_notes": malicious_notes,
@@ -398,9 +398,43 @@ def test_reviewer_notes_prevent_markdown_injection(auth_client, test_pre_award_s
     ).first()
 
     assert notification is not None, "Notification should be created"
-    # Verify notes are wrapped in code block (prevents Markdown rendering)
-    assert "```" in notification.message, "Notes should be wrapped in code block"
+    # Verify notes are wrapped in 5-backtick code block (prevents Markdown rendering)
+    assert "`````" in notification.message, "Notes should be wrapped in 5-backtick code block"
     # Verify the raw Markdown syntax is preserved as plain text
     assert "**Bold**" in notification.message, "Markdown syntax should be preserved literally"
     assert "[link]" in notification.message, "Link syntax should be preserved literally"
-    assert "![image]" in notification.message, "Image syntax should be preserved literally"
+    assert "```code```" in notification.message, "Triple backticks should be preserved literally"
+
+
+def test_reviewer_notes_backtick_injection_prevented(auth_client, test_pre_award_step, loaded_db):
+    """Test that triple backticks in reviewer notes don't break the code fence."""
+    # Setup: approval requested by user 500
+    test_pre_award_step.pre_award_approval_requested = True
+    test_pre_award_step.pre_award_approval_requested_date = date.today()
+    test_pre_award_step.pre_award_approval_requested_by = 500
+    loaded_db.commit()
+
+    # Try to break the code fence with triple backticks followed by markdown
+    injection_attempt = "Approved\n```\n**This should NOT render as bold**"
+    update_data = {
+        "approval_status": "APPROVED",
+        "reviewer_notes": injection_attempt,
+    }
+    response = auth_client.patch(f"/api/v1/procurement-tracker-steps/{test_pre_award_step.id}", json=update_data)
+    assert response.status_code == 200
+
+    # Query for the notification
+    notification = loaded_db.scalars(
+        select(Notification)
+        .where(Notification.title == "Pre-Award Approval Approved")
+        .where(Notification.recipient_id == test_pre_award_step.pre_award_approval_requested_by)
+        .order_by(Notification.created_on.desc())
+    ).first()
+
+    assert notification is not None, "Notification should be created"
+    # Verify 5-backtick fence is used
+    assert notification.message.count("`````") == 2, "Should have opening and closing 5-backtick fences"
+    # Verify triple backticks are contained within the fence (appear in raw form)
+    assert "```" in notification.message, "Triple backticks should be preserved"
+    # Verify the markdown after triple backticks is also preserved literally
+    assert "**This should NOT render as bold**" in notification.message, "Markdown after backticks should be literal"

--- a/backend/ops_api/tests/ops/procurement_tracker/test_procurement_tracker_steps_duplicate_notifications.py
+++ b/backend/ops_api/tests/ops/procurement_tracker/test_procurement_tracker_steps_duplicate_notifications.py
@@ -245,3 +245,158 @@ def test_approval_response_auto_dismisses_in_review_notifications(auth_client, t
     for notification_id in reviewer_notification_ids:
         notification = loaded_db.get(Notification, notification_id)
         assert notification.is_read, f"Notification {notification_id} should be auto-dismissed (marked as read)"
+
+
+def test_approval_response_includes_reviewer_notes_in_notification(auth_client, test_pre_award_step, loaded_db):
+    """Test that reviewer notes are included in the approval response notification message."""
+    # Setup: approval was requested by user 500
+    test_pre_award_step.pre_award_approval_requested = True
+    test_pre_award_step.pre_award_approval_requested_date = date.today()
+    test_pre_award_step.pre_award_approval_requested_by = 500
+    loaded_db.commit()
+
+    # Respond with approval AND reviewer notes
+    reviewer_notes = "This looks good, all requirements met"
+    update_data = {
+        "approval_status": "APPROVED",
+        "reviewer_notes": reviewer_notes,
+    }
+    response = auth_client.patch(f"/api/v1/procurement-tracker-steps/{test_pre_award_step.id}", json=update_data)
+    assert response.status_code == 200
+
+    # Query for the approval response notification
+    notification = loaded_db.scalars(
+        select(Notification)
+        .where(Notification.title == "Pre-Award Approval Approved")
+        .where(Notification.recipient_id == test_pre_award_step.pre_award_approval_requested_by)
+        .order_by(Notification.created_on.desc())
+    ).first()
+
+    assert notification is not None, "Notification should be created for approval response"
+    assert reviewer_notes in notification.message, f"Reviewer notes should be in message. Got: {notification.message}"
+    assert "Notes:" in notification.message, "Message should include 'Notes:' label"
+    assert "```" in notification.message, "Notes should be wrapped in code block"
+
+
+def test_decline_response_includes_reviewer_notes_in_notification(auth_client, test_pre_award_step, loaded_db):
+    """Test that reviewer notes are included in the decline response notification message."""
+    # Setup: approval was requested by user 500
+    test_pre_award_step.pre_award_approval_requested = True
+    test_pre_award_step.pre_award_approval_requested_date = date.today()
+    test_pre_award_step.pre_award_approval_requested_by = 500
+    loaded_db.commit()
+
+    # Respond with decline AND reviewer notes
+    reviewer_notes = "Missing required documentation"
+    update_data = {
+        "approval_status": "DECLINED",
+        "reviewer_notes": reviewer_notes,
+    }
+    response = auth_client.patch(f"/api/v1/procurement-tracker-steps/{test_pre_award_step.id}", json=update_data)
+    assert response.status_code == 200
+
+    # Query for the decline response notification
+    notification = loaded_db.scalars(
+        select(Notification)
+        .where(Notification.title == "Pre-Award Approval Declined")
+        .where(Notification.recipient_id == test_pre_award_step.pre_award_approval_requested_by)
+        .order_by(Notification.created_on.desc())
+    ).first()
+
+    assert notification is not None, "Notification should be created for decline response"
+    assert reviewer_notes in notification.message, f"Reviewer notes should be in message. Got: {notification.message}"
+    assert "Notes:" in notification.message, "Message should include 'Notes:' label"
+    assert "```" in notification.message, "Notes should be wrapped in code block"
+
+
+def test_approval_response_excludes_empty_reviewer_notes(auth_client, test_pre_award_step, loaded_db):
+    """Test that reviewer notes are NOT included when they are empty."""
+    # Setup: approval requested by user 500
+    test_pre_award_step.pre_award_approval_requested = True
+    test_pre_award_step.pre_award_approval_requested_date = date.today()
+    test_pre_award_step.pre_award_approval_requested_by = 500
+    loaded_db.commit()
+
+    # Respond with approval but NO reviewer notes
+    update_data = {
+        "approval_status": "APPROVED",
+    }
+    response = auth_client.patch(f"/api/v1/procurement-tracker-steps/{test_pre_award_step.id}", json=update_data)
+    assert response.status_code == 200
+
+    # Query for the notification
+    notification = loaded_db.scalars(
+        select(Notification)
+        .where(Notification.title == "Pre-Award Approval Approved")
+        .where(Notification.recipient_id == test_pre_award_step.pre_award_approval_requested_by)
+        .order_by(Notification.created_on.desc())
+    ).first()
+
+    assert notification is not None, "Notification should be created"
+    assert "Notes:" not in notification.message, f"Notes section should not appear when empty. Got: {notification.message}"
+    # Verify base message is present
+    assert "has been approved" in notification.message
+
+
+def test_approval_response_excludes_whitespace_only_reviewer_notes(auth_client, test_pre_award_step, loaded_db):
+    """Test that whitespace-only reviewer notes are treated as empty."""
+    # Setup: approval requested by user 500
+    test_pre_award_step.pre_award_approval_requested = True
+    test_pre_award_step.pre_award_approval_requested_date = date.today()
+    test_pre_award_step.pre_award_approval_requested_by = 500
+    loaded_db.commit()
+
+    # Respond with approval but whitespace-only notes
+    update_data = {
+        "approval_status": "APPROVED",
+        "reviewer_notes": "   \n  ",
+    }
+    response = auth_client.patch(f"/api/v1/procurement-tracker-steps/{test_pre_award_step.id}", json=update_data)
+    assert response.status_code == 200
+
+    # Query for the notification
+    notification = loaded_db.scalars(
+        select(Notification)
+        .where(Notification.title == "Pre-Award Approval Approved")
+        .where(Notification.recipient_id == test_pre_award_step.pre_award_approval_requested_by)
+        .order_by(Notification.created_on.desc())
+    ).first()
+
+    assert notification is not None, "Notification should be created"
+    assert "Notes:" not in notification.message, f"Notes section should not appear for whitespace-only notes. Got: {notification.message}"
+    # Verify base message is present
+    assert "has been approved" in notification.message
+
+
+def test_reviewer_notes_prevent_markdown_injection(auth_client, test_pre_award_step, loaded_db):
+    """Test that Markdown syntax in reviewer notes is escaped and doesn't render."""
+    # Setup: approval requested by user 500
+    test_pre_award_step.pre_award_approval_requested = True
+    test_pre_award_step.pre_award_approval_requested_date = date.today()
+    test_pre_award_step.pre_award_approval_requested_by = 500
+    loaded_db.commit()
+
+    # Respond with approval and Markdown injection attempt
+    malicious_notes = "**Bold** text with [link](http://example.com) and ![image](url)"
+    update_data = {
+        "approval_status": "APPROVED",
+        "reviewer_notes": malicious_notes,
+    }
+    response = auth_client.patch(f"/api/v1/procurement-tracker-steps/{test_pre_award_step.id}", json=update_data)
+    assert response.status_code == 200
+
+    # Query for the notification
+    notification = loaded_db.scalars(
+        select(Notification)
+        .where(Notification.title == "Pre-Award Approval Approved")
+        .where(Notification.recipient_id == test_pre_award_step.pre_award_approval_requested_by)
+        .order_by(Notification.created_on.desc())
+    ).first()
+
+    assert notification is not None, "Notification should be created"
+    # Verify notes are wrapped in code block (prevents Markdown rendering)
+    assert "```" in notification.message, "Notes should be wrapped in code block"
+    # Verify the raw Markdown syntax is preserved as plain text
+    assert "**Bold**" in notification.message, "Markdown syntax should be preserved literally"
+    assert "[link]" in notification.message, "Link syntax should be preserved literally"
+    assert "![image]" in notification.message, "Image syntax should be preserved literally"


### PR DESCRIPTION
## Summary
- Fixes display of reviewer notes in pre-award approval/decline simple alerts
- Backend: Include reviewer notes in notification message sent to requestor
- Frontend: Already had logic to show reviewer notes in immediate alert (no changes needed)

## Changes
**Backend:** `backend/ops_api/ops/services/procurement_tracker_steps.py`
- Modified notification message construction to append reviewer notes when present
- Format: `\n\nNotes: {reviewer_notes}`

## Test Plan
### Manual Testing
1. Request pre-award approval for an agreement
2. As reviewer, navigate to approval page and add notes (e.g., "This looks good. Thanks!")
3. Approve or decline the request
4. **Verify reviewer sees notes** in immediate success/error alert
5. Log in as requestor
6. **Verify requestor sees notes** in the approval/decline notification alert

### Edge Cases Tested
- Empty notes (null/empty string) — no "Notes:" section appears
- Notes with line breaks — preserved correctly
- Both approve and decline scenarios

## Related
Fixes loose ends for procurement tracker step 5 notifications where Notes were not displaying as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)