### PR TITLE
Update vest to version 6.3.2

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -36,7 +36,7 @@
         "remark-gfm": "4.0.1",
         "sass": "1.98.0",
         "styled-components": "6.3.12",
-        "vest": "6.2.8",
+        "vest": "6.3.2",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
       },
       "devDependencies": {
@@ -902,7 +902,7 @@
 
     "config-chain": ["config-chain@1.1.13", "", { "dependencies": { "ini": "^1.3.4", "proto-list": "~1.2.1" } }, "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ=="],
 
-    "context": ["context@4.0.15", "", { "dependencies": { "vest-utils": "^2.0.15" } }, "sha512-Rketwf6ycGUdEs248S/jNvlWNEWkGzKIzPIjUYMRzkIhEfUOfxRyI1UnsYWytjmE4/oL5geDZRovhnAGyI9HYg=="],
+    "context": ["context@4.0.17", "", { "dependencies": { "vest-utils": "^2.0.17" } }, "sha512-SM/Rmr9egp0N3+t0kfIFz1Dayfcl+8bussTdW0lw9gU+KUe3v+QPVyxvr+KzVx13U5Ac0dCdjGacWION6NuRUQ=="],
 
     "conventional-changelog-angular": ["conventional-changelog-angular@8.3.0", "", { "dependencies": { "compare-func": "^2.0.0" } }, "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA=="],
 
@@ -1786,7 +1786,7 @@
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "n4s": ["n4s@6.1.12", "", { "dependencies": { "context": "^4.0.15", "vest-utils": "^2.0.15" } }, "sha512-1m9lwgy9OyKyhOC0CmaGEp5HLih4nrLQ6zDQwsxnE0jYfrzqiJ7Vb2PEZx4BIicnhQ9pfI60NVCNSkVgELNNww=="],
+    "n4s": ["n4s@6.2.1", "", { "dependencies": { "context": "^4.0.17", "vest-utils": "^2.0.17" } }, "sha512-j1kYy6fD0wfIsvUiaSnKGQxKJ9ZWJDwwbX8muh2/Y1j+qDADFc+e/Ggy/Hvj3dYU3zQsvuSpViOsNY/nkNCDZQ=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -2420,15 +2420,13 @@
 
     "varint": ["varint@6.0.0", "", {}, "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="],
 
-    "vast": ["vast@2.0.15", "", { "dependencies": { "vest-utils": "^2.0.15" } }, "sha512-Ppo6EOTnSGl3Ja5jaBOgwwet+xy6geazH+pxDKBVLUBSoBTdXibnt+RItr3T4ZyiSnQncRBe95820pOt8tL6SQ=="],
-
     "verror": ["verror@1.10.0", "", { "dependencies": { "assert-plus": "^1.0.0", "core-util-is": "1.0.2", "extsprintf": "^1.2.0" } }, "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw=="],
 
-    "vest": ["vest@6.2.8", "", { "dependencies": { "context": "^4.0.15", "n4s": "^6.1.12", "vast": "^2.0.15", "vest-utils": "^2.0.15", "vestjs-runtime": "^2.0.15" } }, "sha512-vGJyXyNSUEiTgVL3BvYKWmEVJ+WNMbpbAexkcIVvlWGKhKm4haaviQ7aeSonLgMFgae2zv5I+rqSxu61p6bnAg=="],
+    "vest": ["vest@6.3.2", "", { "dependencies": { "context": "^4.0.17", "n4s": "^6.2.1", "vest-utils": "^2.0.17", "vestjs-runtime": "^2.0.17" } }, "sha512-gpXsKohvbntw2Z4VKNw04tax3EG4Av7z/8JyAe5qmpRUn2mxzPUh2OhmEf485i8v+oiCH49R+R6owVHYYlreGw=="],
 
-    "vest-utils": ["vest-utils@2.0.15", "", {}, "sha512-fTcBnUfKmMRDqDRMlGeI9iwzGyn/CNgQLK4SjOZQN121arwxaKbJ8swZv9axsX+gUiANpsD1aALb20Yv7sQwsQ=="],
+    "vest-utils": ["vest-utils@2.0.17", "", {}, "sha512-12gNz4I3oXKO12sp4B0UBgY1b/m4Zmd7e7x1EDQkIDf/N+DHCOk1h16YGM6g/zZS1ZoJMvL35SADcEsZ+YMN3g=="],
 
-    "vestjs-runtime": ["vestjs-runtime@2.0.15", "", { "dependencies": { "context": "^4.0.15", "vest-utils": "^2.0.15" } }, "sha512-wNn0P4PYoofVztyN8MDkf+dcqHiBDif8XjJ9zV63iXxyZ8WuKHr4YaGtR7TfZmtj5W7xUZ9hxatwID2oZtPHjg=="],
+    "vestjs-runtime": ["vestjs-runtime@2.0.17", "", { "dependencies": { "context": "^4.0.17", "vest-utils": "^2.0.17" } }, "sha512-6U2jLwvqtVSOE/kS0YFDZFLBT6a5TJEod787MVE4w691M32bW0y8uWZWquIJ7a96929/p/afH5lcVt4XGef1YQ=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
         "remark-gfm": "4.0.1",
         "sass": "1.98.0",
         "styled-components": "6.3.12",
-        "vest": "6.2.8",
+        "vest": "6.3.2",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
     },
     "overrides": {


### PR DESCRIPTION
## What changed

Updates vest to version 6.3.2 following the recent renovate upgrade of vest-utils

The lock file maintenance updated vest-utils to a version that removed the tinyState export, but the vest package (v6.2.8) still imports it internally. This is a transitive dependency mismatch. Vest expects vest-utils to export tinyState, but the newer vest-utils no longer does.  

## Issue

Should help #5480 getting unblocked among others

## How to test

CI tests pass. 

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

_If relevant, e.g. for a front-end feature_

## Definition of Done Checklist
~- [ ] OESA: Code refactored for clarity~
~- [ ] OESA: Dependency rules followed~
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~


## Links
