### PR TITLE
fix(ci): skip Storybook build in E2E stack to prevent >1h CI hangs

### DIFF
--- a/.github/workflows/dev_fe_build_and_deploy.yml
+++ b/.github/workflows/dev_fe_build_and_deploy.yml
@@ -31,7 +31,7 @@ jobs:
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.DOCKER_FILE }}
           image_tags: "${{ github.sha }},${{ env.ENVIRONMENT }}"
-          build_args: "VITE_BACKEND_DOMAIN=https://${{ env.ENVIRONMENT }}.${{ env.DOMAIN_NAME }}, MODE=${{ env.ENVIRONMENT }}, VITE_ENABLE_MSW=false"
+          build_args: "VITE_BACKEND_DOMAIN=https://${{ env.ENVIRONMENT }}.${{ env.DOMAIN_NAME }}, MODE=${{ env.ENVIRONMENT }}, VITE_ENABLE_MSW=false, BUILD_STORYBOOK=true"
 
   deploy-frontend:
     needs: build-frontend

--- a/.github/workflows/stg_fe_build_and_deploy.yml
+++ b/.github/workflows/stg_fe_build_and_deploy.yml
@@ -31,7 +31,7 @@ jobs:
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.DOCKER_FILE }}
           image_tags: "${{ github.sha }},${{ env.ENVIRONMENT }}"
-          build_args: "VITE_BACKEND_DOMAIN=https://${{ env.ENVIRONMENT }}.${{ env.DOMAIN_NAME }}, MODE=${{ env.ENVIRONMENT }}, VITE_ENABLE_MSW=false"
+          build_args: "VITE_BACKEND_DOMAIN=https://${{ env.ENVIRONMENT }}.${{ env.DOMAIN_NAME }}, MODE=${{ env.ENVIRONMENT }}, VITE_ENABLE_MSW=false, BUILD_STORYBOOK=true"
 
   deploy-frontend:
     needs: build-frontend

--- a/.github/workflows/storybook_build.yml
+++ b/.github/workflows/storybook_build.yml
@@ -21,6 +21,7 @@ jobs:
   storybook-build:
     name: Storybook Build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -28,4 +29,4 @@ jobs:
 
       - name: Build Storybook
         working-directory: ./frontend
-        run: bun run build-storybook --quiet
+        run: CI=true timeout 600 bun run build-storybook

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ bun run test:e2e:interactive
 # Run Storybook (component documentation, dev server on port 6006)
 bun run storybook
 
-# Build Storybook static output (omitted automatically when MODE=production)
+# Build Storybook static output (only when BUILD_STORYBOOK=true; dev/stg deploy workflows opt in)
 bun run build-storybook
 
 # Linting
@@ -303,7 +303,7 @@ The frontend follows modern React patterns with Redux for state management:
 
 ## Storybook Component Documentation
 
-Storybook provides an interactive component library for browsing and developing UI components in isolation. It runs on port 6006 locally and is served at `/storybook` on dev and staging environments. It is **not available in production** (build output is omitted when `MODE=production`).
+Storybook provides an interactive component library for browsing and developing UI components in isolation. It runs on port 6006 locally and is served at `/storybook` on dev and staging environments. It is **not available in production** (the `Dockerfile.azure` build stage only compiles Storybook when the `BUILD_STORYBOOK=true` build arg is passed; dev and stg deploy workflows opt in, production does not).
 
 ### Story File Convention
 

--- a/docker-compose.static.yml
+++ b/docker-compose.static.yml
@@ -82,6 +82,7 @@ services:
       args:
         VITE_BACKEND_DOMAIN: ${BACKEND_DOMAIN:-http://localhost:8080}
         MODE: dev  # set this to production to create a production build
+        BUILD_STORYBOOK: "false"  # never build Storybook in the E2E stack — it causes >1h CI hangs
 
     ports:
       - "${FRONTEND_PORT:-3000}:3000"

--- a/docs/adr/031-storybook-for-component-documentation.md
+++ b/docs/adr/031-storybook-for-component-documentation.md
@@ -47,8 +47,9 @@ Storybook will be served at the `/storybook` sub-path of the existing frontend n
 staging environments only**. Production will not include storybook assets.
 
 **Implementation**: The `Dockerfile.azure` build stage conditionally runs `bun run build-storybook --output-dir
-build/storybook` only when `MODE != production`. In production, the `build/storybook/` directory simply does not exist,
-so nginx returns a 404 via its existing `try_files` directive. No nginx configuration changes are required.
+build/storybook` only when the `BUILD_STORYBOOK` build arg is set to `true` (default: `false`). Only the dev and
+staging deploy workflows pass `BUILD_STORYBOOK=true`; production and E2E builds leave it unset. When the directory
+does not exist, nginx returns a 404 via its existing `try_files` directive.
 
 **Local development**: Storybook runs as a standalone Vite dev server on port 6006 via `bun run storybook`, optionally
 as a Docker Compose service under the `storybook` profile.

--- a/docs/developers/frontend/storybook-ci-hang-investigation.md
+++ b/docs/developers/frontend/storybook-ci-hang-investigation.md
@@ -1,0 +1,175 @@
+# Storybook CI Hang Investigation & Fix
+
+**Date:** 2026-04-23
+**Affected workflows:** `Continuous Integration` (all PR branches)
+**Symptoms:** E2E test matrix jobs hanging for >1 hour; normal CI wall-time is ~20 min
+**Fixed by:** `hotfix/storybook-ci-hang` → PR #XXXX
+
+---
+
+## Symptom
+
+PR CI runs were hanging with the following build step stuck indefinitely:
+
+```
+#37 [frontend-static build 8/8] RUN VITE_BACKEND_DOMAIN=http://localhost:8080 \
+    VITE_ENABLE_MSW=${VITE_ENABLE_MSW} NODE_ENV=dev bun run build --mode dev && \
+    if [ "dev" != "production" ]; then \
+      CI=true bun run build-storybook --output-dir build/storybook --quiet; \
+    fi
+```
+
+The job never failed — it just sat there until GitHub's 6-hour runner limit eventually killed it.
+
+---
+
+## Investigation
+
+### Step 1 — Narrow the workflow
+
+`dev_fe_build_and_deploy` (the direct push-to-main Docker build) was completing in **2–3 minutes** with no issues. The hang only reproduced on pull-request CI runs — specifically the `Continuous Integration` workflow.
+
+### Step 2 — Identify the stuck job
+
+Querying the GitHub Actions API for the in-progress run `24835948034` showed that out of ~40 parallel E2E shards, exactly two were stuck:
+
+| Stuck job | Step hung on |
+|---|---|
+| `End-to-End Testing (procurementShopChangeRequest.cy.js)` | **Launch Stack** (step 6 of 15) |
+| `End-to-End Testing (reviewChangeRequestResponse.cy.js)` | **Launch Stack** (step 6 of 15) |
+
+All other shards had already completed. Everything downstream of Launch Stack (Cypress itself, artifact upload, log capture) was pending.
+
+### Step 3 — Trace Launch Stack to Dockerfile.azure
+
+The `run-full-stack` composite action runs:
+
+```bash
+docker compose -f docker-compose.static.yml --profile setup up --build -d
+```
+
+`docker-compose.static.yml` passes `MODE: dev` to `Dockerfile.azure`, which triggered the `if [ "${MODE}" != "production" ]` branch and ran `bun run build-storybook`.
+
+### Step 4 — Why dev_fe doesn't reproduce it
+
+`dev_fe_build_and_deploy` uses the `build-and-push` action, which pulls `--cache-from ghcr.io/.../latest` and `ghcr.io/.../deps`. The storybook build layer is a cache hit, so Docker skips it entirely. The E2E `docker compose up --build` has **no registry cache** — every shard builds Storybook from scratch, cold, concurrently.
+
+### Step 5 — Root cause
+
+GitHub Actions runners are 2 vCPU / 7 GB RAM. Each E2E shard launches the full stack:
+`postgres` + `data-import` + `backend` + `frontend-static` (Docker build) — all in the same runner, simultaneously.
+
+When `bun run build-storybook` executes inside the Docker build, Vite spawns worker threads for the manager bundle and the preview bundle in parallel. Under memory pressure (postgres + flask already resident), one of the Vite worker threads intermittently OOMs or stalls waiting for a system resource. Because the command was wrapped in `--quiet`, **no output was emitted**, so GitHub Actions received no stdout/stderr and didn't detect the hang.
+
+Without a `timeout`, the job sat at the GitHub-default maximum of **360 minutes**.
+
+### Step 6 — Why PR #5569 didn't fix it
+
+PR #5569 added `CI=true` to disable Storybook's interactive telemetry prompts and removed the `addon-onboarding` addon. Neither addressed the underlying issue:
+
+- `CI=true` suppresses the interactive prompt but doesn't prevent Vite worker OOM.
+- `addon-onboarding` removal had no effect on memory usage.
+- `--quiet` was retained, keeping the hang invisible.
+
+---
+
+## Fix
+
+### 1. `frontend/Dockerfile.azure` — new `BUILD_STORYBOOK` build arg
+
+Replaced the `MODE != production` gate with an explicit opt-in arg that **defaults to `false`**:
+
+```dockerfile
+ARG BUILD_STORYBOOK=false
+
+RUN ... bun run build --mode ${MODE} && \
+    if [ "${BUILD_STORYBOOK}" = "true" ]; then \
+      CI=true timeout 600 bun run build-storybook --output-dir build/storybook; \
+    fi
+```
+
+Changes:
+- `--quiet` **removed** — verbose output is essential for diagnosing future hangs.
+- `timeout 600` added — fails the Docker layer after 10 minutes instead of silently hanging for hours.
+- Gate is now independent of `MODE`, so a future `MODE=staging` or similar won't accidentally re-enable it.
+
+### 2. `docker-compose.static.yml` — explicit `BUILD_STORYBOOK: "false"`
+
+```yaml
+args:
+  VITE_BACKEND_DOMAIN: ${BACKEND_DOMAIN:-http://localhost:8080}
+  MODE: dev
+  BUILD_STORYBOOK: "false"  # never build Storybook in the E2E stack
+```
+
+E2E CI and local `docker compose -f docker-compose.static.yml up` no longer build Storybook. Storybook is not served in that stack and was never needed there.
+
+### 3. `dev_fe_build_and_deploy.yml` and `stg_fe_build_and_deploy.yml` — opt in
+
+```yaml
+build_args: "..., BUILD_STORYBOOK=true"
+```
+
+Only the two deploy workflows that actually serve `/storybook` opt in. `prod_fe_build_and_deploy.yml` is intentionally left without `BUILD_STORYBOOK` — production has no storybook endpoint.
+
+### 4. `storybook_build.yml` — drop `--quiet`, add timeout
+
+```yaml
+timeout-minutes: 15    # job-level hard cap
+
+- name: Build Storybook
+  run: CI=true timeout 600 bun run build-storybook
+```
+
+The dedicated Storybook PR check now surfaces build output and fails fast.
+
+---
+
+## Storybook build matrix — who builds what
+
+| Context | `BUILD_STORYBOOK` | Storybook built? |
+|---|---|---|
+| E2E `docker compose -f docker-compose.static.yml` | `false` (explicit) | ❌ |
+| `docker compose up` (local dev) | `false` (default) | ❌ |
+| `prod_fe_build_and_deploy` | `false` (default) | ❌ |
+| `dev_fe_build_and_deploy` | `true` (explicit) | ✅ served at `/storybook` |
+| `stg_fe_build_and_deploy` | `true` (explicit) | ✅ served at `/storybook` |
+| `storybook_build.yml` (PR check) | n/a (host, not Docker) | ✅ verify-only, not deployed |
+
+---
+
+## Local verification
+
+To confirm the fix locally before merging:
+
+```bash
+# 1. Cold build without Storybook (mimics E2E path) — should finish in ~2 min
+docker build \
+  --build-arg MODE=dev \
+  --build-arg VITE_BACKEND_DOMAIN=http://localhost:8080 \
+  --build-arg VITE_ENABLE_MSW=false \
+  --build-arg BUILD_STORYBOOK=false \
+  -f frontend/Dockerfile.azure frontend/
+# Expected: no "build-storybook" output in layer 8/8
+
+# 2. Build with Storybook (mimics dev deploy) — should finish in ~5–15 min
+docker build \
+  --build-arg MODE=dev \
+  --build-arg VITE_BACKEND_DOMAIN=http://localhost:8080 \
+  --build-arg VITE_ENABLE_MSW=false \
+  --build-arg BUILD_STORYBOOK=true \
+  -f frontend/Dockerfile.azure frontend/
+# Expected: Storybook build output visible, no --quiet suppression
+
+# 3. E2E full stack (smoke test the compose change)
+docker compose -f docker-compose.static.yml --profile setup up --build -d
+# Expected: frontend-static build completes quickly, no storybook step
+```
+
+---
+
+## Related
+
+- PR #5569 — prior (partial) fix attempt: added `CI=true`, removed `addon-onboarding`, added nginx `/storybook` location
+- PR #5531 — introduced Storybook 10 infrastructure (Phase 0)
+- ADR 031 — [`docs/adr/031-storybook-for-component-documentation.md`](../../adr/031-storybook-for-component-documentation.md)

--- a/docs/developers/frontend/storybook-ci-hang-investigation.md
+++ b/docs/developers/frontend/storybook-ci-hang-investigation.md
@@ -3,7 +3,7 @@
 **Date:** 2026-04-23
 **Affected workflows:** `Continuous Integration` (all PR branches)
 **Symptoms:** E2E test matrix jobs hanging for >1 hour; normal CI wall-time is ~20 min
-**Fixed by:** `hotfix/storybook-ci-hang` → PR #XXXX
+**Fixed by:** `hotfix/storybook-ci-hang` → [PR #5573](https://github.com/HHS/OPRE-OPS/pull/5573)
 
 ---
 
@@ -92,6 +92,7 @@ Changes:
 - `--quiet` **removed** — verbose output is essential for diagnosing future hangs.
 - `timeout 600` added — fails the Docker layer after 10 minutes instead of silently hanging for hours.
 - Gate is now independent of `MODE`, so a future `MODE=staging` or similar won't accidentally re-enable it.
+- Stale references to `MODE != production` in `docs/adr/031-storybook-for-component-documentation.md` and `AGENTS.md` have been updated to reflect the new `BUILD_STORYBOOK` arg.
 
 ### 2. `docker-compose.static.yml` — explicit `BUILD_STORYBOOK: "false"`
 

--- a/frontend/Dockerfile.azure
+++ b/frontend/Dockerfile.azure
@@ -35,13 +35,20 @@ COPY .storybook .storybook
 ARG MODE
 ARG VITE_BACKEND_DOMAIN
 ARG VITE_ENABLE_MSW
+# BUILD_STORYBOOK controls whether the Storybook static site is compiled into
+# build/storybook.  Default is false so that E2E and other non-serving builds
+# skip the Storybook step entirely — it is the root cause of >1 h CI hangs
+# when the build runs uncached on constrained GitHub Actions runners.
+# Set BUILD_STORYBOOK=true only in the dev / staging deploy workflows.
+ARG BUILD_STORYBOOK=false
 COPY vite-env/env.${MODE}.local .env
 # Build the app, then conditionally build Storybook into build/storybook.
-# Storybook is omitted in production so /storybook returns a natural 404
-# from nginx's try_files miss.
+# A 10-minute timeout guards against silent hangs (Vite worker OOM, network
+# calls from the Chromatic addon, etc.) so the job fails fast instead of
+# consuming the runner's full 6-hour budget.
 RUN VITE_BACKEND_DOMAIN=${VITE_BACKEND_DOMAIN} VITE_ENABLE_MSW=${VITE_ENABLE_MSW} NODE_ENV=${MODE} bun run build --mode ${MODE} && \
-    if [ "${MODE}" != "production" ]; then \
-      CI=true bun run build-storybook --output-dir build/storybook --quiet; \
+    if [ "${BUILD_STORYBOOK}" = "true" ]; then \
+      CI=true timeout 600 bun run build-storybook --output-dir build/storybook; \
     fi
 
 # ---- Release Stage ----


### PR DESCRIPTION
## What changed

Storybook was being built unconditionally inside the `frontend-static` Docker image for every E2E CI shard because `Dockerfile.azure` gated the `build-storybook` step on `MODE != production`, and `docker-compose.static.yml` always passes `MODE=dev`.

This PR replaces the `MODE`-based gate with an explicit `BUILD_STORYBOOK` build arg (default `false`) and enables it only in the two deploy workflows that actually serve `/storybook` (`dev` and `stg`). It also drops `--quiet` everywhere Storybook is built and adds a `timeout 600` guard so any future hang fails fast with visible output instead of silently consuming the full 6-hour runner budget.

**Files changed:**
- `frontend/Dockerfile.azure` — new `ARG BUILD_STORYBOOK=false`; storybook step only runs when `true`; `--quiet` removed; `timeout 600` added
- `docker-compose.static.yml` — explicit `BUILD_STORYBOOK: "false"` to permanently exclude from E2E stack
- `.github/workflows/dev_fe_build_and_deploy.yml` — opts in with `BUILD_STORYBOOK=true`
- `.github/workflows/stg_fe_build_and_deploy.yml` — opts in with `BUILD_STORYBOOK=true`
- `.github/workflows/storybook_build.yml` — drops `--quiet`, adds `CI=true timeout 600`, adds `timeout-minutes: 15` at job level
- `docs/developers/frontend/storybook-ci-hang-investigation.md` — full investigation write-up

## Issue

Root cause investigation documented in `docs/developers/frontend/storybook-ci-hang-investigation.md`.
Follows up on #5569 (prior partial fix that added `CI=true` and removed `addon-onboarding` but did not prevent the hang).

## How to test

**Verify E2E path skips Storybook (fast, no storybook output):**
```bash
docker build \
  --build-arg MODE=dev \
  --build-arg VITE_BACKEND_DOMAIN=http://localhost:8080 \
  --build-arg VITE_ENABLE_MSW=false \
  --build-arg BUILD_STORYBOOK=false \
  --no-cache \
  -f frontend/Dockerfile.azure frontend/
# Expected: layer 8/8 contains no "storybook build" output; completes in ~60–90s
```

**Verify dev deploy path still builds Storybook:**
```bash
docker build \
  --build-arg MODE=dev \
  --build-arg VITE_BACKEND_DOMAIN=http://localhost:8080 \
  --build-arg VITE_ENABLE_MSW=false \
  --build-arg BUILD_STORYBOOK=true \
  --no-cache \
  -f frontend/Dockerfile.azure frontend/
# Expected: Storybook build output visible (fonts, iframe.html, assets); completes in ~3–5min
```

**Verify CI wall-time returns to normal (~20 min) by observing a PR run after merge.**

Local test results:
| Path | Time | Storybook? |
|---|---|---|
| `BUILD_STORYBOOK=false` cold | **66s** | ❌ skipped |
| `BUILD_STORYBOOK=true` cold | **3m35s** | ✅ built with visible output |

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

_N/A — CI/infrastructure change only_

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

- Investigation write-up: [`docs/developers/frontend/storybook-ci-hang-investigation.md`](docs/developers/frontend/storybook-ci-hang-investigation.md)
- ADR 031 (Storybook): [`docs/adr/031-storybook-for-component-documentation.md`](docs/adr/031-storybook-for-component-documentation.md)
- Prior partial fix: #5569
- Storybook Phase 0: #5531