### PR TITLE
feat: adding abbreviation to portfolio on project funding endpoint

### DIFF
--- a/backend/models/projects.py
+++ b/backend/models/projects.py
@@ -252,7 +252,7 @@ class Project(BaseModel):
         # --- funding_by_portfolio ---
         portfolio_totals: dict[int, Decimal] = defaultdict(lambda: Decimal("0"))
         portfolio_names: dict[int, str] = {}
-        portfolio_abbr: dict[int, str] = {}
+        portfolio_abbr: dict[int, str | None] = {}
         for can in unique_cans:
             if can.portfolio:
                 for fb in can.funding_budgets:

--- a/backend/models/projects.py
+++ b/backend/models/projects.py
@@ -137,7 +137,8 @@ class Project(BaseModel):
                 key=lambda x: x["name"],
             ),
             "project_officers": sorted(
-                [{"id": user_id, "name": name} for user_id, name in project_officer_dict.items()], key=lambda x: x["name"]
+                [{"id": user_id, "name": name} for user_id, name in project_officer_dict.items()],
+                key=lambda x: x["name"],
             ),
             "alternate_project_officers": sorted(
                 [{"id": user_id, "name": name} for user_id, name in alternate_project_officer_dict.items()],
@@ -251,15 +252,22 @@ class Project(BaseModel):
         # --- funding_by_portfolio ---
         portfolio_totals: dict[int, Decimal] = defaultdict(lambda: Decimal("0"))
         portfolio_names: dict[int, str] = {}
+        portfolio_abbr: dict[int, str] = {}
         for can in unique_cans:
             if can.portfolio:
                 for fb in can.funding_budgets:
                     if fb.fiscal_year == fiscal_year:
                         portfolio_totals[can.portfolio_id] += fb.budget or Decimal("0")
                         portfolio_names[can.portfolio_id] = can.portfolio.name
+                        portfolio_abbr[can.portfolio_id] = can.portfolio.abbreviation
 
         funding_by_portfolio = [
-            {"portfolio_id": pid, "portfolio": portfolio_names[pid], "amount": float(amt)}
+            {
+                "portfolio_id": pid,
+                "portfolio": portfolio_names[pid],
+                "amount": float(amt),
+                "abbreviation": portfolio_abbr[pid],
+            }
             for pid, amt in portfolio_totals.items()
         ]
 

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -5908,7 +5908,6 @@ components:
               - portfolio_id
               - portfolio
               - amount
-              - abbreviation
             properties:
               portfolio_id:
                 type: integer
@@ -5922,6 +5921,7 @@ components:
                 example: 123.456
               abbreviation:
                 type: string
+                nullable: true
                 example: "CW"
         funding_by_can:
           type: object

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -3364,6 +3364,14 @@ paths:
             format: int32
             minimum: 1
             default: 1
+        - in: query
+          name: fiscal_year
+          description: Fiscal year for funding summary (defaults to current fiscal year if not provided)
+          required: false
+          schema:
+            type: integer
+            format: int32
+            example: 2025
       responses:
         "200":
           description: OK
@@ -5900,6 +5908,7 @@ components:
               - portfolio_id
               - portfolio
               - amount
+              - abbreviation
             properties:
               portfolio_id:
                 type: integer
@@ -5911,6 +5920,9 @@ components:
                 type: number
                 format: double
                 example: 123.456
+              abbreviation:
+                type: string
+                example: "CW"
         funding_by_can:
           type: object
           required:
@@ -5972,9 +5984,11 @@ components:
           example: 1
         portfolio:
           type: string
+          nullable: true
           example: "Child Welfare"
         active_period:
           type: integer
+          nullable: true
           description: Active period in years
           example: 1
         fy_funding:

--- a/backend/ops_api/ops/schemas/projects.py
+++ b/backend/ops_api/ops/schemas/projects.py
@@ -218,6 +218,7 @@ class ProjectFundingByPortfolioSchema(Schema):
     portfolio_id = fields.Int(required=True)
     portfolio = fields.String(required=True)
     amount = fields.Float(required=True)
+    abbreviation = fields.String(required=True)
 
 
 class ProjectFundingByCANSchema(Schema):

--- a/backend/ops_api/ops/schemas/projects.py
+++ b/backend/ops_api/ops/schemas/projects.py
@@ -218,7 +218,7 @@ class ProjectFundingByPortfolioSchema(Schema):
     portfolio_id = fields.Int(required=True)
     portfolio = fields.String(required=True)
     amount = fields.Float(required=True)
-    abbreviation = fields.String(required=True)
+    abbreviation = fields.String(allow_none=True)
 
 
 class ProjectFundingByCANSchema(Schema):

--- a/backend/ops_api/tests/ops/project/test_project.py
+++ b/backend/ops_api/tests/ops/project/test_project.py
@@ -2081,11 +2081,13 @@ class TestProjectFunding:
         p1 = by_portfolio[funding_test_data["portfolio_1"].id]
         assert p1["amount"] == 1000000.00
         assert p1["portfolio"] == funding_test_data["portfolio_1"].name
+        assert p1["abbreviation"] == funding_test_data["portfolio_1"].abbreviation
 
         # Portfolio 6: CAN2 has $300,000 budget in FY 2025
         p6 = by_portfolio[funding_test_data["portfolio_6"].id]
         assert p6["amount"] == 300000.00
         assert p6["portfolio"] == funding_test_data["portfolio_6"].name
+        assert p6["abbreviation"] == funding_test_data["portfolio_6"].abbreviation
 
     def test_get_project_funding_by_can_classification(self, loaded_db, funding_test_data):
         """funding_by_can correctly classifies carry-forward vs new funding."""


### PR DESCRIPTION
## What changed

Adding the Portfolio Abbreviation to the Project Funding api return object. 

## Issue

[OPS-5564](https://github.com/HHS/OPRE-OPS/issues/5564)

## How to test

1. Run all backend unit tests

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated
