### PR TITLE
fix: re-add missing pre_award approval response columns

### DIFF
--- a/backend/alembic/versions/2026_04_27_1000-f1a2b3c4d5e6_re_add_missing_pre_award_approval_response_fields.py
+++ b/backend/alembic/versions/2026_04_27_1000-f1a2b3c4d5e6_re_add_missing_pre_award_approval_response_fields.py
@@ -63,12 +63,13 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column('procurement_tracker_step_version', 'pre_award_approval_reviewer_notes')
-    op.drop_column('procurement_tracker_step_version', 'pre_award_approval_responded_date')
-    op.drop_column('procurement_tracker_step_version', 'pre_award_approval_responded_by')
-    op.drop_column('procurement_tracker_step_version', 'pre_award_approval_status')
-    op.drop_constraint('fk_pre_award_responded_by', 'procurement_tracker_step', type_='foreignkey')
-    op.drop_column('procurement_tracker_step', 'pre_award_approval_reviewer_notes')
-    op.drop_column('procurement_tracker_step', 'pre_award_approval_responded_date')
-    op.drop_column('procurement_tracker_step', 'pre_award_approval_responded_by')
-    op.drop_column('procurement_tracker_step', 'pre_award_approval_status')
+    # This is a repair migration whose upgrade() is intentionally idempotent:
+    # in some environments these columns/constraints already existed from the
+    # earlier migration history, and this revision simply backfills missing DDL
+    # where needed. Dropping them here would be destructive on rollback because
+    # it could remove schema objects that pre-dated this revision.
+    #
+    # Keep downgrade non-destructive so rolling back this repair revision does
+    # not leave dev/staging environments inconsistent with earlier applied
+    # revisions.
+    pass

--- a/backend/alembic/versions/2026_04_27_1000-f1a2b3c4d5e6_re_add_missing_pre_award_approval_response_fields.py
+++ b/backend/alembic/versions/2026_04_27_1000-f1a2b3c4d5e6_re_add_missing_pre_award_approval_response_fields.py
@@ -1,0 +1,74 @@
+"""Re-add missing pre_award approval response fields to procurement tracker step
+
+The original migration d6e7f8a9b0c1 was marked as applied in production
+but the DDL never executed, leaving 4 columns missing from the
+procurement_tracker_step table. This migration is idempotent — it skips
+columns that already exist (dev/staging) and adds them where missing (prod).
+
+Revision ID: f1a2b3c4d5e6
+Revises: ae2ee26e19d5
+Create Date: 2026-04-27 10:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1a2b3c4d5e6'
+down_revision: Union[str, None] = 'ae2ee26e19d5'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _column_exists(table: str, column: str) -> bool:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = :table AND column_name = :column"
+        ),
+        {"table": table, "column": column},
+    )
+    return result.scalar() is not None
+
+
+def upgrade() -> None:
+    # procurement_tracker_step columns
+    if not _column_exists("procurement_tracker_step", "pre_award_approval_status"):
+        op.add_column('procurement_tracker_step', sa.Column('pre_award_approval_status', sa.String(length=20), nullable=True))
+    if not _column_exists("procurement_tracker_step", "pre_award_approval_responded_by"):
+        op.add_column('procurement_tracker_step', sa.Column('pre_award_approval_responded_by', sa.Integer(), nullable=True))
+        op.create_foreign_key(
+            'fk_pre_award_responded_by',
+            'procurement_tracker_step', 'ops_user',
+            ['pre_award_approval_responded_by'], ['id']
+        )
+    if not _column_exists("procurement_tracker_step", "pre_award_approval_responded_date"):
+        op.add_column('procurement_tracker_step', sa.Column('pre_award_approval_responded_date', sa.Date(), nullable=True))
+    if not _column_exists("procurement_tracker_step", "pre_award_approval_reviewer_notes"):
+        op.add_column('procurement_tracker_step', sa.Column('pre_award_approval_reviewer_notes', sa.Text(), nullable=True))
+
+    # procurement_tracker_step_version columns
+    if not _column_exists("procurement_tracker_step_version", "pre_award_approval_status"):
+        op.add_column('procurement_tracker_step_version', sa.Column('pre_award_approval_status', sa.String(length=20), autoincrement=False, nullable=True))
+    if not _column_exists("procurement_tracker_step_version", "pre_award_approval_responded_by"):
+        op.add_column('procurement_tracker_step_version', sa.Column('pre_award_approval_responded_by', sa.Integer(), autoincrement=False, nullable=True))
+    if not _column_exists("procurement_tracker_step_version", "pre_award_approval_responded_date"):
+        op.add_column('procurement_tracker_step_version', sa.Column('pre_award_approval_responded_date', sa.Date(), autoincrement=False, nullable=True))
+    if not _column_exists("procurement_tracker_step_version", "pre_award_approval_reviewer_notes"):
+        op.add_column('procurement_tracker_step_version', sa.Column('pre_award_approval_reviewer_notes', sa.Text(), autoincrement=False, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('procurement_tracker_step_version', 'pre_award_approval_reviewer_notes')
+    op.drop_column('procurement_tracker_step_version', 'pre_award_approval_responded_date')
+    op.drop_column('procurement_tracker_step_version', 'pre_award_approval_responded_by')
+    op.drop_column('procurement_tracker_step_version', 'pre_award_approval_status')
+    op.drop_constraint('fk_pre_award_responded_by', 'procurement_tracker_step', type_='foreignkey')
+    op.drop_column('procurement_tracker_step', 'pre_award_approval_reviewer_notes')
+    op.drop_column('procurement_tracker_step', 'pre_award_approval_responded_date')
+    op.drop_column('procurement_tracker_step', 'pre_award_approval_responded_by')
+    op.drop_column('procurement_tracker_step', 'pre_award_approval_status')


### PR DESCRIPTION
## What changed

- The "For Review" tab on the Agreements page returns a 500 error in production because 4 columns are missing from the procurement_tracker_step table: pre_award_approval_status, pre_award_approval_responded_by, pre_award_approval_responded_date, pre_award_approval_reviewer_notes
- Adds an idempotent migration that checks for each column before adding it, so it safely runs on all environments (skips in dev/staging where columns exist, adds in production where they're missing)

## Issue

#5559 

## How to test

Visit the Agreements "For Review" tab — should load without error

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated