### PR TITLE
style: center-align tab tooltip text

### DIFF
--- a/frontend/src/components/Agreements/DetailsTabs/DetailsTabs.jsx
+++ b/frontend/src/components/Agreements/DetailsTabs/DetailsTabs.jsx
@@ -45,7 +45,7 @@ const DetailsTabs = ({
                   name: "TBD1",
                   label: "Award & Modifications",
                   disabled: !IS_AWARDED_TAB_READY || !isAgreementAwarded,
-                  disabledTooltip: "Award & Modifications tab is coming soon"
+                  disabledTooltip: "Award & Modifications\ntab is coming soon"
               },
               {
                   name: "/procurement-tracker",

--- a/frontend/src/components/Agreements/DetailsTabs/DetailsTabs.module.scss
+++ b/frontend/src/components/Agreements/DetailsTabs/DetailsTabs.module.scss
@@ -33,3 +33,7 @@
     pointer-events: none;
     cursor: not-allowed;
 }
+
+.tabsList :global(.usa-tooltip__body) {
+    text-align: center;
+}


### PR DESCRIPTION
## What changed

- Added `text-align: center` to USWDS tooltip bodies (`.usa-tooltip__body`) scoped to the tab navigation (`.tabsList`) in `DetailsTabs.module.scss`
- This affects both **DetailsTabs** (agreement detail pages) and **ProjectDetailTabs** (project detail pages) since they share the same SCSS module
- Added a line break to the "Award & Modifications" disabled tooltip text for consistent multi-line formatting

## Issue

https://github.com/HHS/OPRE-OPS/issues/5545

## How to test

1. Navigate to an agreement detail page (e.g., `/agreements/1`)
1. Hover over any disabled tab (e.g., "Award & Modifications", "Documents") and verify the tooltip text is horizontally center-aligned

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

N/A — tooltip text alignment is a minor visual change. Reviewer can verify in browser.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated