### PR TITLE
fix: use local budget state for funding received % calculation

### DIFF
--- a/frontend/src/pages/cans/detail/CanFunding.jsx
+++ b/frontend/src/pages/cans/detail/CanFunding.jsx
@@ -293,7 +293,7 @@ const CanFunding = ({
                 ) : (
                     <CANFundingReceivedTable
                         fundingReceived={enteredFundingReceived}
-                        totalFunding={totalFunding}
+                        totalFunding={isEditMode ? budgetForm.submittedAmount : totalFunding}
                         isEditMode={isEditMode}
                         populateFundingReceivedForm={populateFundingReceivedForm}
                         deleteFundingReceived={deleteFundingReceived}

--- a/frontend/src/pages/cans/detail/CanFunding.test.jsx
+++ b/frontend/src/pages/cans/detail/CanFunding.test.jsx
@@ -15,7 +15,7 @@ vi.mock("./CanFunding.hooks.js", () => ({
         setShowModal: vi.fn(),
         showButton: false,
         showModal: false,
-        budgetForm: {},
+        budgetForm: { submittedAmount: 500000, isSubmitted: true },
         handleEnteredBudgetAmount: vi.fn(),
         fundingReceivedForm: { enteredNotes: "", isEditing: false, isSubmitted: false },
         handleEnteredFundingReceivedAmount: vi.fn(),
@@ -37,8 +37,9 @@ vi.mock("../../../components/CANs/CANBudgetByFYCard/CANBudgetByFYCard", () => ({
 vi.mock("../../../components/CANs/CANBudgetForm", () => ({ default: () => <div>Budget form</div> }));
 vi.mock("../../../components/CANs/CANFundingInfoCard", () => ({ default: () => <div>Funding info card</div> }));
 vi.mock("../../../components/CANs/CANFundingReceivedForm", () => ({ default: () => <div>Funding received form</div> }));
+const CANFundingReceivedTableMock = vi.fn(() => <div>Funding received table</div>);
 vi.mock("../../../components/CANs/CANFundingReceivedTable", () => ({
-    default: () => <div>Funding received table</div>
+    default: (props) => CANFundingReceivedTableMock(props)
 }));
 vi.mock("../../../components/UI/Cards/BudgetCard/ReceivedFundingCard", () => ({
     default: () => <div>Received funding card</div>
@@ -50,6 +51,58 @@ vi.mock("../../../components/UI/RoundedBox", () => ({ default: ({ children }) =>
 describe("CanFunding", () => {
     afterEach(() => {
         vi.clearAllMocks();
+    });
+
+    it("passes budgetForm.submittedAmount as totalFunding to the table in edit mode", () => {
+        render(
+            <CanFunding
+                canId={1}
+                canNumber="CAN-001"
+                currentFiscalYearFundingId={11}
+                funding={{ fiscal_year: 2026, active_period: 1 }}
+                fundingBudgets={[]}
+                fiscalYear={2026}
+                totalFunding={0}
+                receivedFunding={100}
+                fundingReceived={[]}
+                isBudgetTeamMember={true}
+                isEditMode={true}
+                toggleEditMode={() => {}}
+                carryForwardFunding={0}
+                welcomeModal={{ showModal: false }}
+                resetWelcomeModal={() => {}}
+                isExpired={false}
+                isTableLoading={false}
+            />
+        );
+
+        expect(CANFundingReceivedTableMock).toHaveBeenCalledWith(expect.objectContaining({ totalFunding: 500000 }));
+    });
+
+    it("passes totalFunding prop to the table when not in edit mode", () => {
+        render(
+            <CanFunding
+                canId={1}
+                canNumber="CAN-001"
+                currentFiscalYearFundingId={11}
+                funding={{ fiscal_year: 2026, active_period: 1 }}
+                fundingBudgets={[]}
+                fiscalYear={2026}
+                totalFunding={1000}
+                receivedFunding={100}
+                fundingReceived={[]}
+                isBudgetTeamMember={false}
+                isEditMode={false}
+                toggleEditMode={() => {}}
+                carryForwardFunding={0}
+                welcomeModal={{ showModal: false }}
+                resetWelcomeModal={() => {}}
+                isExpired={false}
+                isTableLoading={false}
+            />
+        );
+
+        expect(CANFundingReceivedTableMock).toHaveBeenCalledWith(expect.objectContaining({ totalFunding: 1000 }));
     });
 
     it("shows the funding received skeleton while parent data is refetching", () => {


### PR DESCRIPTION
## What changed
- Fixes the "% of total FY budget" column in the Funding Received YTD table showing 0% until save
- In edit mode, passes `budgetForm.submittedAmount` (the user's current budget entry) to `CANFundingReceivedTable` instead of the stale API-sourced `totalFunding` prop
- Matches the existing pattern already used by `ReceivedFundingCard` on the same page

## Issue
#5568

## How to test
1. Sign in as a budget team member, navigate to a CAN's funding tab
1. Click Edit, add a FY budget amount, then add funding received
1. Verify the "% of total FY budget" column shows the correct percentage immediately (not 0%)

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated

