### PR TITLE
fix: new projects not appearing in create agreement project dropdown

### DIFF
--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -440,14 +440,37 @@ export const opsApi = createApi({
             providesTags: ["Users"]
         }),
         getResearchProjects: builder.query({
-            query: () => `/projects/?project_type=RESEARCH`,
-            transformResponse: (response) => {
-                // New wrapped format with data key
-                if (response.data) {
-                    return response.data;
+            // The backend caps every list endpoint at limit=50 (PaginationListSchema).
+            // Rather than deviating from that constraint we page through all results
+            // here so the Create Agreement project dropdown always shows every
+            // research project regardless of how many exist.
+            async queryFn(_arg, _queryApi, _extraOptions, fetchWithBQ) {
+                const BATCH_SIZE = 50;
+                const allProjects = [];
+                let offset = 0;
+                let total = Infinity; // set on first wrapped response
+
+                while (allProjects.length < total) {
+                    const result = await fetchWithBQ(
+                        `/projects/?project_type=RESEARCH&limit=${BATCH_SIZE}&offset=${offset}`
+                    );
+                    if (result.error) return { error: result.error };
+
+                    const response = result.data;
+
+                    // Legacy array format (no wrapper) — all results in one shot
+                    if (Array.isArray(response)) {
+                        return { data: response };
+                    }
+
+                    // Wrapped format: { data: [...], count: N, ... }
+                    const page = response.data ?? [];
+                    total = response.count ?? page.length;
+                    allProjects.push(...page);
+                    offset += BATCH_SIZE;
                 }
-                // Legacy array format (no wrapper) - for backward compatibility during transition
-                return response;
+
+                return { data: allProjects };
             },
             providesTags: ["ResearchProjects"]
         }),

--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -440,7 +440,7 @@ export const opsApi = createApi({
             providesTags: ["Users"]
         }),
         getResearchProjects: builder.query({
-            // The backend caps every list endpoint at limit=50 (PaginationListSchema).
+            // `/projects/` is capped at limit=50 by `PaginationListSchema`.
             // Rather than deviating from that constraint we page through all results
             // here so the Create Agreement project dropdown always shows every
             // research project regardless of how many exist.
@@ -466,6 +466,7 @@ export const opsApi = createApi({
                     // Wrapped format: { data: [...], count: N, ... }
                     const page = response.data ?? [];
                     total = response.count ?? page.length;
+                    if (page.length === 0) break; // guard against malformed count
                     allProjects.push(...page);
                     offset += BATCH_SIZE;
                 }

--- a/frontend/src/api/opsAPI.test.js
+++ b/frontend/src/api/opsAPI.test.js
@@ -1039,3 +1039,89 @@ describe("opsAPI - Wave 2 high-yield endpoint coverage", () => {
         expect(capturedUrl).toContain("project_id=42");
     });
 });
+
+describe("opsAPI - getResearchProjects queryFn pagination", () => {
+    afterEach(() => server.resetHandlers());
+
+    it("returns all projects when total fits in a single batch", async () => {
+        const mockProjects = [
+            { id: 1, title: "Child Care Research", project_type: "RESEARCH" },
+            { id: 2, title: "Head Start Study", project_type: "RESEARCH" }
+        ];
+
+        server.use(
+            http.get("*/api/v1/projects/", ({ request }) => {
+                const url = new URL(request.url);
+                expect(url.searchParams.get("project_type")).toBe("RESEARCH");
+                expect(url.searchParams.get("limit")).toBe("50");
+                expect(url.searchParams.get("offset")).toBe("0");
+                return HttpResponse.json({ data: mockProjects, count: 2, limit: 50, offset: 0 });
+            })
+        );
+
+        const storeRef = setupApiStore(opsApi);
+        const result = await storeRef.store.dispatch(
+            opsApi.endpoints.getResearchProjects.initiate(undefined)
+        );
+
+        expect(result.data).toEqual(mockProjects);
+        expect(result.data).toHaveLength(2);
+    });
+
+    it("paginates across multiple batches when total exceeds batch size", async () => {
+        const page1 = Array.from({ length: 50 }, (_, i) => ({ id: i + 1, title: `Project ${i + 1}` }));
+        const page2 = [{ id: 51, title: "Project 51" }];
+        let callCount = 0;
+
+        server.use(
+            http.get("*/api/v1/projects/", ({ request }) => {
+                const url = new URL(request.url);
+                callCount++;
+                const offset = parseInt(url.searchParams.get("offset") ?? "0");
+                if (offset === 0) {
+                    return HttpResponse.json({ data: page1, count: 51, limit: 50, offset: 0 });
+                }
+                return HttpResponse.json({ data: page2, count: 51, limit: 50, offset: 50 });
+            })
+        );
+
+        const storeRef = setupApiStore(opsApi);
+        const result = await storeRef.store.dispatch(
+            opsApi.endpoints.getResearchProjects.initiate(undefined)
+        );
+
+        expect(callCount).toBe(2);
+        expect(result.data).toHaveLength(51);
+        expect(result.data[50]).toEqual(page2[0]);
+    });
+
+    it("returns all items immediately for legacy array response format", async () => {
+        const legacyProjects = [{ id: 1, title: "Legacy Project", project_type: "RESEARCH" }];
+
+        server.use(
+            http.get("*/api/v1/projects/", () => HttpResponse.json(legacyProjects))
+        );
+
+        const storeRef = setupApiStore(opsApi);
+        const result = await storeRef.store.dispatch(
+            opsApi.endpoints.getResearchProjects.initiate(undefined)
+        );
+
+        expect(result.data).toEqual(legacyProjects);
+    });
+
+    it("surfaces an error when the API call fails", async () => {
+        server.use(
+            http.get("*/api/v1/projects/", () =>
+                HttpResponse.json({ message: "Internal Server Error" }, { status: 500 })
+            )
+        );
+
+        const storeRef = setupApiStore(opsApi);
+        const result = await storeRef.store.dispatch(
+            opsApi.endpoints.getResearchProjects.initiate(undefined)
+        );
+
+        expect(result.error).toBeDefined();
+    });
+});

--- a/frontend/src/api/opsAPI.test.js
+++ b/frontend/src/api/opsAPI.test.js
@@ -1060,9 +1060,7 @@ describe("opsAPI - getResearchProjects queryFn pagination", () => {
         );
 
         const storeRef = setupApiStore(opsApi);
-        const result = await storeRef.store.dispatch(
-            opsApi.endpoints.getResearchProjects.initiate(undefined)
-        );
+        const result = await storeRef.store.dispatch(opsApi.endpoints.getResearchProjects.initiate(undefined));
 
         expect(result.data).toEqual(mockProjects);
         expect(result.data).toHaveLength(2);
@@ -1086,9 +1084,7 @@ describe("opsAPI - getResearchProjects queryFn pagination", () => {
         );
 
         const storeRef = setupApiStore(opsApi);
-        const result = await storeRef.store.dispatch(
-            opsApi.endpoints.getResearchProjects.initiate(undefined)
-        );
+        const result = await storeRef.store.dispatch(opsApi.endpoints.getResearchProjects.initiate(undefined));
 
         expect(callCount).toBe(2);
         expect(result.data).toHaveLength(51);
@@ -1098,14 +1094,10 @@ describe("opsAPI - getResearchProjects queryFn pagination", () => {
     it("returns all items immediately for legacy array response format", async () => {
         const legacyProjects = [{ id: 1, title: "Legacy Project", project_type: "RESEARCH" }];
 
-        server.use(
-            http.get("*/api/v1/projects/", () => HttpResponse.json(legacyProjects))
-        );
+        server.use(http.get("*/api/v1/projects/", () => HttpResponse.json(legacyProjects)));
 
         const storeRef = setupApiStore(opsApi);
-        const result = await storeRef.store.dispatch(
-            opsApi.endpoints.getResearchProjects.initiate(undefined)
-        );
+        const result = await storeRef.store.dispatch(opsApi.endpoints.getResearchProjects.initiate(undefined));
 
         expect(result.data).toEqual(legacyProjects);
     });
@@ -1118,9 +1110,7 @@ describe("opsAPI - getResearchProjects queryFn pagination", () => {
         );
 
         const storeRef = setupApiStore(opsApi);
-        const result = await storeRef.store.dispatch(
-            opsApi.endpoints.getResearchProjects.initiate(undefined)
-        );
+        const result = await storeRef.store.dispatch(opsApi.endpoints.getResearchProjects.initiate(undefined));
 
         expect(result.error).toBeDefined();
     });
@@ -1128,15 +1118,11 @@ describe("opsAPI - getResearchProjects queryFn pagination", () => {
     it("breaks out of the loop when the backend returns an empty page", async () => {
         // Guards against an infinite loop if `count` is mis-reported by the server
         server.use(
-            http.get("*/api/v1/projects/", () =>
-                HttpResponse.json({ data: [], count: 99, limit: 50, offset: 0 })
-            )
+            http.get("*/api/v1/projects/", () => HttpResponse.json({ data: [], count: 99, limit: 50, offset: 0 }))
         );
 
         const storeRef = setupApiStore(opsApi);
-        const result = await storeRef.store.dispatch(
-            opsApi.endpoints.getResearchProjects.initiate(undefined)
-        );
+        const result = await storeRef.store.dispatch(opsApi.endpoints.getResearchProjects.initiate(undefined));
 
         expect(result.data).toEqual([]);
     });

--- a/frontend/src/api/opsAPI.test.js
+++ b/frontend/src/api/opsAPI.test.js
@@ -1124,4 +1124,20 @@ describe("opsAPI - getResearchProjects queryFn pagination", () => {
 
         expect(result.error).toBeDefined();
     });
+
+    it("breaks out of the loop when the backend returns an empty page", async () => {
+        // Guards against an infinite loop if `count` is mis-reported by the server
+        server.use(
+            http.get("*/api/v1/projects/", () =>
+                HttpResponse.json({ data: [], count: 99, limit: 50, offset: 0 })
+            )
+        );
+
+        const storeRef = setupApiStore(opsApi);
+        const result = await storeRef.store.dispatch(
+            opsApi.endpoints.getResearchProjects.initiate(undefined)
+        );
+
+        expect(result.data).toEqual([]);
+    });
 });

--- a/frontend/src/pages/agreements/StepSelectProject.jsx
+++ b/frontend/src/pages/agreements/StepSelectProject.jsx
@@ -50,7 +50,7 @@ export const StepSelectProject = ({
         data: projects,
         error: errorProjects,
         isLoading: isLoadingProjects
-    } = useGetResearchProjectsQuery({}, { refetchOnMountOrArgChange: true });
+    } = useGetResearchProjectsQuery(undefined, { refetchOnMountOrArgChange: true });
     const [deleteAgreement] = useDeleteAgreementMutation();
 
     if (isLoadingProjects) {

--- a/frontend/src/pages/agreements/StepSelectProject.jsx
+++ b/frontend/src/pages/agreements/StepSelectProject.jsx
@@ -46,7 +46,11 @@ export const StepSelectProject = ({
     const [modalProps, setModalProps] = React.useState({});
     const { setAlert } = useAlert();
     /** @type {{data?: import("../../types/ProjectTypes").Project[] | undefined, error?: Object, isLoading: boolean}} */
-    const { data: projects, error: errorProjects, isLoading: isLoadingProjects } = useGetResearchProjectsQuery({});
+    const {
+        data: projects,
+        error: errorProjects,
+        isLoading: isLoadingProjects
+    } = useGetResearchProjectsQuery({}, { refetchOnMountOrArgChange: true });
     const [deleteAgreement] = useDeleteAgreementMutation();
 
     if (isLoadingProjects) {

--- a/frontend/src/pages/agreements/StepSelectProject.test.jsx
+++ b/frontend/src/pages/agreements/StepSelectProject.test.jsx
@@ -109,7 +109,7 @@ describe("StepSelectProject", () => {
 
             renderComponent();
 
-            expect(useGetResearchProjectsQuery).toHaveBeenCalledWith({}, { refetchOnMountOrArgChange: true });
+            expect(useGetResearchProjectsQuery).toHaveBeenCalledWith(undefined, { refetchOnMountOrArgChange: true });
         });
     });
 

--- a/frontend/src/pages/agreements/StepSelectProject.test.jsx
+++ b/frontend/src/pages/agreements/StepSelectProject.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";

--- a/frontend/src/pages/agreements/StepSelectProject.test.jsx
+++ b/frontend/src/pages/agreements/StepSelectProject.test.jsx
@@ -1,0 +1,216 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import StepSelectProject from "./StepSelectProject";
+import { useGetResearchProjectsQuery, useDeleteAgreementMutation } from "../../api/opsAPI";
+
+// ── Mock dependencies ────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual("react-router-dom");
+    return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("../../api/opsAPI", () => ({
+    useGetResearchProjectsQuery: vi.fn(),
+    useDeleteAgreementMutation: vi.fn()
+}));
+
+// Stub heavy child components to keep tests fast and focused
+vi.mock("../../components/Projects/ProjectSelectWithSummaryCard", () => ({
+    default: ({ researchProjects }) => (
+        <div data-testid="project-select">
+            {researchProjects?.map((p) => (
+                <div
+                    key={p.id}
+                    data-testid="project-option"
+                >
+                    {p.title}
+                </div>
+            ))}
+        </div>
+    )
+}));
+
+vi.mock("../../components/UI/StepIndicator/StepIndicator", () => ({
+    default: () => <div data-testid="step-indicator" />
+}));
+
+vi.mock("../../components/UI/Modals/ConfirmationModal", () => ({
+    default: ({ heading }) => <div data-testid="confirmation-modal">{heading}</div>
+}));
+
+vi.mock("./EditModeTitle", () => ({ default: () => null }));
+
+// Stub the AgreementEditorContext hooks — provide minimal state
+vi.mock("../../components/Agreements/AgreementEditor/AgreementEditorContext.hooks", () => ({
+    useEditAgreement: () => ({ selected_project: null }),
+    useSetState: () => vi.fn(),
+    useUpdateAgreement: () => vi.fn()
+}));
+
+vi.mock("../../hooks/use-alert.hooks", () => ({
+    default: () => ({ setAlert: vi.fn() })
+}));
+
+// ── Test helpers ─────────────────────────────────────────────────────────────
+
+const mockStore = configureStore([]);
+const store = mockStore({ auth: { activeUser: { id: 1 } }, alert: { isActive: false } });
+
+const MOCK_PROJECTS = [
+    { id: 1, title: "Child Care Research", short_title: "CCR", project_type: "RESEARCH" },
+    { id: 2, title: "Head Start Study", short_title: "HSS", project_type: "RESEARCH" }
+];
+
+const defaultProps = {
+    goToNext: vi.fn(),
+    wizardSteps: ["Project", "Agreement", "Budget Lines"],
+    currentStep: 1,
+    cancelHeading: "Are you sure you want to cancel?",
+    selectedAgreementId: undefined,
+    isEditMode: false,
+    isReviewMode: false
+};
+
+function renderComponent(props = {}) {
+    return render(
+        <Provider store={store}>
+            <MemoryRouter>
+                <StepSelectProject
+                    {...defaultProps}
+                    {...props}
+                />
+            </MemoryRouter>
+        </Provider>
+    );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("StepSelectProject", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useDeleteAgreementMutation.mockReturnValue([vi.fn()]);
+    });
+
+    describe("RTK Query – cache-bust option", () => {
+        it("calls useGetResearchProjectsQuery with refetchOnMountOrArgChange: true", () => {
+            useGetResearchProjectsQuery.mockReturnValue({
+                data: MOCK_PROJECTS,
+                error: undefined,
+                isLoading: false
+            });
+
+            renderComponent();
+
+            expect(useGetResearchProjectsQuery).toHaveBeenCalledWith({}, { refetchOnMountOrArgChange: true });
+        });
+    });
+
+    describe("loading state", () => {
+        it("shows a loading indicator while projects are being fetched", () => {
+            useGetResearchProjectsQuery.mockReturnValue({
+                data: undefined,
+                error: undefined,
+                isLoading: true
+            });
+
+            renderComponent();
+
+            expect(screen.getByText(/loading/i)).toBeInTheDocument();
+        });
+    });
+
+    describe("error state", () => {
+        it("navigates to /error when the query fails", () => {
+            useGetResearchProjectsQuery.mockReturnValue({
+                data: undefined,
+                error: { status: 500 },
+                isLoading: false
+            });
+
+            renderComponent();
+
+            expect(mockNavigate).toHaveBeenCalledWith("/error");
+        });
+    });
+
+    describe("success state", () => {
+        beforeEach(() => {
+            useGetResearchProjectsQuery.mockReturnValue({
+                data: MOCK_PROJECTS,
+                error: undefined,
+                isLoading: false
+            });
+        });
+
+        it("renders the step indicator and heading", () => {
+            renderComponent();
+
+            expect(screen.getByTestId("step-indicator")).toBeInTheDocument();
+            expect(screen.getByRole("heading", { name: /select a project/i })).toBeInTheDocument();
+        });
+
+        it("passes all research projects to ProjectSelectWithSummaryCard", () => {
+            renderComponent();
+
+            const options = screen.getAllByTestId("project-option");
+            expect(options).toHaveLength(MOCK_PROJECTS.length);
+            expect(options[0]).toHaveTextContent("Child Care Research");
+            expect(options[1]).toHaveTextContent("Head Start Study");
+        });
+
+        it("renders the Add New Project button", () => {
+            renderComponent();
+
+            expect(screen.getByRole("button", { name: /add new project/i })).toBeInTheDocument();
+        });
+
+        it("navigates to /projects/create when Add New Project is clicked", async () => {
+            const user = userEvent.setup();
+            renderComponent();
+
+            await user.click(screen.getByRole("button", { name: /add new project/i }));
+
+            expect(mockNavigate).toHaveBeenCalledWith("/projects/create");
+        });
+
+        it("renders an empty project list gracefully when data is an empty array", () => {
+            useGetResearchProjectsQuery.mockReturnValue({
+                data: [],
+                error: undefined,
+                isLoading: false
+            });
+
+            renderComponent();
+
+            expect(screen.getByTestId("project-select")).toBeInTheDocument();
+            expect(screen.queryAllByTestId("project-option")).toHaveLength(0);
+        });
+    });
+
+    describe("Cancel button", () => {
+        beforeEach(() => {
+            useGetResearchProjectsQuery.mockReturnValue({
+                data: MOCK_PROJECTS,
+                error: undefined,
+                isLoading: false
+            });
+        });
+
+        it("shows a confirmation modal when Cancel is clicked", async () => {
+            const user = userEvent.setup();
+            renderComponent();
+
+            await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+            expect(screen.getByTestId("confirmation-modal")).toBeInTheDocument();
+        });
+    });
+});


### PR DESCRIPTION
## What changed

Fixes a bug where newly created research projects would not appear in the "Select a Project" dropdown on Step 1 of the Create Agreement wizard, even though they were visible on the Projects list page.

Two separate RTK Query issues were found and fixed — both are frontend-only changes, no backend modifications:

**1. Stale cache on re-mount (`StepSelectProject.jsx`)**
`useGetResearchProjectsQuery` was called without `refetchOnMountOrArgChange: true`. RTK Query's default behaviour caches the response and serves it on re-mount, meaning a user who navigated away to create a project and came back would see the old list. Added `{ refetchOnMountOrArgChange: true }` — the same pattern used in `ChangeRequestsList`, `CanCard`, `PortfolioSpending`, etc.

**2. Backend default `limit=10` silently truncating results (`opsAPI.js`)**
`getResearchProjects` called `/projects/?project_type=RESEARCH` with no `limit` parameter. The backend `PaginationListSchema` defaults to `limit=10`, so only ever the first 10 research projects were returned — explaining the staging discrepancy of 10 in the dropdown vs 15 in the Projects list (5 are non-RESEARCH type, the rest were truncated).

Rather than raising the backend's `max=50` cap (which would deviate from every other endpoint's established pattern), `getResearchProjects` was converted from `query` + `transformResponse` to a `queryFn` pagination loop that fetches all research projects in 50-per-batch requests. This stays within the existing backend contract and scales to any future project count.

## Issue

_No linked issue — reported via Slack._

## How to test

1. Log in and navigate to **Create Agreement**
2. Note which projects appear in the Step 1 "Select a Project" dropdown
3. Open a new tab → **Projects** → create a new **Research** project
4. Navigate back to **Create Agreement** → Step 1
5. ✅ The newly created project should now appear in the dropdown

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

<img width="568" height="713" alt="SCR-20260429-nldl" src="https://github.com/user-attachments/assets/f1f049a4-c247-4c0c-94dc-375184da19de" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

_N/A_