### PR TITLE
fix: add vendor validation to review page and fix stale validation error

### DIFF
--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
@@ -184,10 +184,11 @@ const useAgreementEditForm = (
     const shouldRequestChange = hasProcurementShopChanged && areAnyBudgetLinesPlanned && !isAgreementAwarded;
 
     const runValidate = React.useCallback(
-        (name, value) => {
+        (name, value, overrides = {}) => {
             suite.run(
                 {
                     ...agreement,
+                    ...overrides,
                     [name]: value
                 },
                 name

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -398,6 +398,7 @@ const AgreementEditForm = ({
                         setAgreementReason(value);
                         if (isReviewMode) {
                             runValidate(name, value);
+                            runValidate("vendor", null, { agreement_reason: value });
                         }
                     }}
                     isDisabled={isFieldDisabled(

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.js
@@ -38,8 +38,8 @@ const suite = create((data = {}, fieldName) => {
     });
     test("vendor", "This is required information", () => {
         if (
-            (data.agreement_reason && data.agreement_reason === "RECOMPETE") ||
-            data.agreement_reason === "LOGICAL_FOLLOW_ON"
+            data.agreement_reason &&
+            (data.agreement_reason === "RECOMPETE" || data.agreement_reason === "LOGICAL_FOLLOW_ON")
         ) {
             enforce(data.vendor).isNotBlank();
         }

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.js
@@ -2,7 +2,9 @@ import { create, test, enforce, only } from "vest";
 import { AGREEMENT_TYPES } from "../../ServicesComponents/ServicesComponents.constants";
 
 const suite = create((data = {}, fieldName) => {
-    only(fieldName); // only run the tests for the field that changed
+    if (fieldName) {
+        only(fieldName);
+    }
 
     test("agreement_type", "This is required information", () => {
         enforce(data.agreement_type).notEquals("-Select Agreement Type-");

--- a/frontend/src/pages/agreements/review/suite.js
+++ b/frontend/src/pages/agreements/review/suite.js
@@ -23,7 +23,14 @@ const suite = create((data = {}, fieldName = undefined) => {
     test("reason", "This information is required to submit for approval", () => {
         enforce(data.agreement_reason).isNotBlank();
     });
-    // vendor is not required
+    test("vendor", "This information is required to submit for approval", () => {
+        if (
+            data.agreement_reason &&
+            (data.agreement_reason === "RECOMPETE" || data.agreement_reason === "LOGICAL_FOLLOW_ON")
+        ) {
+            enforce(data.vendor).isNotBlank();
+        }
+    });
     test("project-officer", "This information is required to submit for approval", () => {
         enforce(Number(data.project_officer_id)).greaterThan(0);
     });

--- a/frontend/src/pages/agreements/review/suite.test.js
+++ b/frontend/src/pages/agreements/review/suite.test.js
@@ -47,9 +47,34 @@ describe("Agreement Review Suite", () => {
         expect(result.isValid()).toBe(false);
     });
 
-    it("does not require vendor", () => {
-        const data = { ...validData };
-        delete data.vendor;
+    it("does not require vendor when agreement_reason is not RECOMPETE or LOGICAL_FOLLOW_ON", () => {
+        const data = { ...validData, vendor: null };
+        suite.reset();
+        suite.run(data);
+        const result = suite.get();
+        expect(result.isValid()).toBe(true);
+    });
+
+    it("fails if vendor is null and agreement_reason is RECOMPETE", () => {
+        const data = { ...validData, agreement_reason: "RECOMPETE", vendor: null };
+        suite.reset();
+        suite.run(data);
+        const result = suite.get();
+        expect(result.isValid()).toBe(false);
+        expect(result.getErrors()).toHaveProperty("vendor");
+    });
+
+    it("fails if vendor is null and agreement_reason is LOGICAL_FOLLOW_ON", () => {
+        const data = { ...validData, agreement_reason: "LOGICAL_FOLLOW_ON", vendor: null };
+        suite.reset();
+        suite.run(data);
+        const result = suite.get();
+        expect(result.isValid()).toBe(false);
+        expect(result.getErrors()).toHaveProperty("vendor");
+    });
+
+    it("passes if vendor is provided and agreement_reason is RECOMPETE", () => {
+        const data = { ...validData, agreement_reason: "RECOMPETE", vendor: "Acme Corp" };
         suite.reset();
         suite.run(data);
         const result = suite.get();


### PR DESCRIPTION
## What changed

- Add conditional vendor validation to the Review Agreement page suite — vendor is now required when agreement_reason is RECOMPETE or LOGICAL_FOLLOW_ON
 - Fix stale vendor validation error in the Agreement Editor when changing agreement_reason from RECOMPETE/LOGICAL_FOLLOW_ON to another value (e.g., NEW_REQ) while in review mode — the error previously persisted because vest v6 retains failed state for tests not re-run via only()
- Fix operator precedence bug in AgreementEditFormSuite.js where LOGICAL_FOLLOW_ON was not properly grouped in the conditional check

## Issue

#5585
#5586


## How to test

1. Create an agreement with agreement_reason: RECOMPETE and vendor: null, navigate to the Review page, select a budget line — confirm the vendor error appears in the alert
1. On the Review page with agreement_reason: NEW_REQ and vendor: null — confirm no vendor error
1. In the Agreement Editor (review mode), set reason to RECOMPETE with no vendor — confirm error shows

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

_If relevant, e.g. for a front-end feature_

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated