### PR TITLE
fix: restrict For Review tab to REVIEWER_APPROVER and SUPER_USER roles

### DIFF
--- a/frontend/src/pages/agreements/list/AgreementTabs.test.jsx
+++ b/frontend/src/pages/agreements/list/AgreementTabs.test.jsx
@@ -77,6 +77,38 @@ describe("AgreementTabs", () => {
         expect(screen.queryByText("For Review")).not.toBeInTheDocument();
     });
 
+    test("does render for super users", () => {
+        useSelector.mockReturnValue([{ id: 2, name: "SUPER_USER" }]);
+
+        render(
+            <Provider store={store}>
+                <BrowserRouter>
+                    <AgreementTabs />
+                </BrowserRouter>
+            </Provider>
+        );
+
+        expect(screen.getByText("All Agreements")).toBeInTheDocument();
+        expect(screen.getByText("My Agreements")).toBeInTheDocument();
+        expect(screen.getByText("For Review")).toBeInTheDocument();
+    });
+
+    test("does render for reviewer approver", () => {
+        useSelector.mockReturnValue([{ id: 2, name: "REVIEWER_APPROVER" }]);
+
+        render(
+            <Provider store={store}>
+                <BrowserRouter>
+                    <AgreementTabs />
+                </BrowserRouter>
+            </Provider>
+        );
+
+        expect(screen.getByText("All Agreements")).toBeInTheDocument();
+        expect(screen.getByText("My Agreements")).toBeInTheDocument();
+        expect(screen.getByText("For Review")).toBeInTheDocument();
+    });
+
     test("applies correct class based on location", () => {
         useLocation.mockReturnValueOnce({
             search: "?filter=my-agreements"

--- a/frontend/src/pages/agreements/list/AgreementsTabs.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsTabs.jsx
@@ -16,7 +16,10 @@ const AgreementTabs = () => {
     const { search } = useLocation();
     const changeRequestsTotal = useChangeRequestTotal();
     const userRoles = useSelector((state) => state.auth?.activeUser?.roles) ?? [];
-    const displayReviewTab = !userRoles.every((role) => role?.name === USER_ROLES.VIEWER_EDITOR);
+    // Only display the "For Review" tab if the user has the REVIEWER_APPROVER or SUPER_USER role
+    const displayReviewTab = userRoles.some(
+        (role) => role?.name === USER_ROLES.REVIEWER_APPROVER || role?.name === USER_ROLES.SUPER_USER
+    );
 
     const paths = [
         {


### PR DESCRIPTION
## What changed

Restricts the "For Review" tab on the Agreements page to only display for users with `REVIEWER_APPROVER` or `SUPER_USER` roles. Previously, the tab was shown to all users except those with only the `VIEWER_EDITOR` role.

**frontend/src/pages/agreements/list/AgreementsTabs.jsx**
- Changed `displayReviewTab` logic from `!userRoles.every((role) => role?.name === USER_ROLES.VIEWER_EDITOR)` to `userRoles.some((role) => role?.name === USER_ROLES.REVIEWER_APPROVER || role?.name === USER_ROLES.SUPER_USER)`
- Added comment explaining the role restriction
- Now uses clearer positive logic with `.some()` instead of double-negative with `.every()`

**frontend/src/pages/agreements/list/AgreementTabs.test.jsx**
- Added test: "does render for super users" - verifies SUPER_USER can see the tab
- Added test: "does render for reviewer approver" - verifies REVIEWER_APPROVER can see the tab
- Existing test continues to verify VIEWER_EDITOR cannot see the tab

## Issue

https://github.com/HHS/OPRE-OPS/issues/5615

## How to test

**Unit tests:**
```bash
cd frontend
bun run test -- --watch=false src/pages/agreements/list/AgreementTabs.test.jsx
```

**Manual verification:**
1. Log in as a user with only `VIEWER_EDITOR` role
2. Navigate to `/agreements` — verify "For Review" tab does not appear
3. Log in as a user with `REVIEWER_APPROVER` role
4. Navigate to `/agreements` — verify "For Review" tab appears
5. Log in as a user with `SUPER_USER` role
6. Navigate to `/agreements` — verify "For Review" tab appears

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

<img width="1008" height="393" alt="Screenshot 2026-05-07 at 4 05 48 PM" src="https://github.com/user-attachments/assets/81533e9d-ea57-4126-bdc2-4eb45477a9dd" />

Budget Team User
<img width="1059" height="447" alt="Screenshot 2026-05-07 at 4 05 38 PM" src="https://github.com/user-attachments/assets/9d467ea6-42e7-4374-af8b-6b3b9d468a1c" />

Reviewer/Approver
<img width="1019" height="423" alt="Screenshot 2026-05-07 at 4 05 28 PM" src="https://github.com/user-attachments/assets/3cf08359-3291-4817-89d8-453f4070d0b7" />
Super User

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated (N/A — no forms changed)

## Links

N/A