### PR TITLE
feat: add 'All' fiscal year option to CAN list

### DIFF
--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -299,8 +299,10 @@ export const opsApi = createApi({
         getCanFilterOptions: builder.query({
             query: ({ fiscalYear }) => {
                 const queryParams = [];
-                if (fiscalYear) {
-                    queryParams.push(`fiscal_year=${fiscalYear}`);
+                if (fiscalYear && fiscalYear.length > 0) {
+                    fiscalYear.forEach((year) => {
+                        queryParams.push(`fiscal_year=${year}`);
+                    });
                 }
                 const queryString = queryParams.length > 0 ? `?${queryParams.join("&")}` : "";
                 return `/cans-filters/${queryString}`;
@@ -741,8 +743,10 @@ export const opsApi = createApi({
                 budgetMax
             }) => {
                 let queryParams = [];
-                if (fiscalYear) {
-                    queryParams.push(`fiscal_year=${fiscalYear}`);
+                if (fiscalYear && fiscalYear.length > 0) {
+                    fiscalYear.forEach((year) => {
+                        queryParams.push(`fiscal_year=${year}`);
+                    });
                 }
                 if (sortConditions) {
                     queryParams.push(`sort_conditions=${sortConditions}`);

--- a/frontend/src/api/opsAPI.test.js
+++ b/frontend/src/api/opsAPI.test.js
@@ -918,7 +918,7 @@ describe("opsAPI - Wave 2 high-yield endpoint coverage", () => {
         );
 
         const storeRef = setupApiStore(opsApi);
-        await storeRef.store.dispatch(opsApi.endpoints.getCanFilterOptions.initiate({ fiscalYear: 2026 }));
+        await storeRef.store.dispatch(opsApi.endpoints.getCanFilterOptions.initiate({ fiscalYear: [2026] }));
 
         expect(capturedUrl).toContain("fiscal_year=2026");
     });

--- a/frontend/src/pages/cans/list/CANFiscalYearSelect/CANFiscalYearSelect.jsx
+++ b/frontend/src/pages/cans/list/CANFiscalYearSelect/CANFiscalYearSelect.jsx
@@ -13,6 +13,7 @@ const CANFiscalYearSelect = ({ fiscalYear, setSelectedFiscalYear }) => {
         <FiscalYear
             fiscalYear={fiscalYear}
             handleChangeFiscalYear={setSelectedFiscalYear}
+            showAllOption={true}
         />
     );
 };

--- a/frontend/src/pages/cans/list/CanList.jsx
+++ b/frontend/src/pages/cans/list/CanList.jsx
@@ -26,7 +26,6 @@ const CanList = () => {
     const navigate = useNavigate();
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions();
     const [selectedFiscalYear, setSelectedFiscalYear] = React.useState(getCurrentFiscalYear());
-    const fiscalYear = Number(selectedFiscalYear);
     const [currentPage, setCurrentPage] = React.useState(1); // 1-indexed for UI
     const [pageSize] = React.useState(ITEMS_PER_PAGE);
     const [filters, setFilters] = React.useState({
@@ -36,6 +35,18 @@ const CanList = () => {
         can: [],
         budget: []
     });
+
+    // Determine fiscal year filter - send empty array when "All" is selected
+    const getFiscalYearFilter = () => {
+        if (selectedFiscalYear === "All") {
+            return [];
+        }
+        return [Number(selectedFiscalYear)];
+    };
+
+    const fiscalYearFilter = getFiscalYearFilter();
+    // For components that need a numeric fiscal year (summary cards, display)
+    const fiscalYear = fiscalYearFilter.length > 0 ? fiscalYearFilter[0] : Number(getCurrentFiscalYear());
 
     // Extract filter values for API
     const activePeriodIds = filters.activePeriod?.map((ap) => ap.id) || [];
@@ -55,7 +66,7 @@ const CanList = () => {
         isLoading,
         isFetching
     } = useGetCansQuery({
-        fiscalYear: selectedFiscalYear,
+        fiscalYear: fiscalYearFilter,
         sortConditions: sortCondition,
         sortDescending,
         page: currentPage - 1, // Convert to 0-indexed for API
@@ -75,7 +86,7 @@ const CanList = () => {
         isLoading: filterOptionsLoading,
         isFetching: filterOptionsFetching
     } = useGetCanFilterOptionsQuery({
-        fiscalYear: selectedFiscalYear
+        fiscalYear: fiscalYearFilter
     });
 
     // Extract cans array and metadata from wrapped response

--- a/frontend/src/pages/cans/list/CanList.jsx
+++ b/frontend/src/pages/cans/list/CanList.jsx
@@ -46,7 +46,7 @@ const CanList = () => {
 
     const fiscalYearFilter = getFiscalYearFilter();
     // For components that need a numeric fiscal year (summary cards, display)
-    const fiscalYear = fiscalYearFilter.length > 0 ? fiscalYearFilter[0] : Number(getCurrentFiscalYear());
+    const fiscalYear = fiscalYearFilter.length > 0 ? fiscalYearFilter[0] : undefined;
 
     // Extract filter values for API
     const activePeriodIds = filters.activePeriod?.map((ap) => ap.id) || [];
@@ -208,7 +208,7 @@ const CanList = () => {
                 SummaryCardsSection={
                     !isTableLoading && (
                         <CANSummaryCards
-                            fiscalYear={fiscalYear}
+                            fiscalYear={selectedFiscalYear === "All" ? "All FYs" : fiscalYear}
                             totalBudget={fundingSummaryData?.funding?.total_funding}
                             newFunding={fundingSummaryData?.funding?.new_funding}
                             carryForward={fundingSummaryData?.funding?.carry_forward_funding}

--- a/frontend/src/pages/cans/list/CanList.test.jsx
+++ b/frontend/src/pages/cans/list/CanList.test.jsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import CanList from "./CanList";
 import { useGetCanFilterOptionsQuery, useGetCansFundingQuery, useGetCansQuery } from "../../../api/opsAPI";
@@ -38,7 +39,16 @@ vi.mock("./CANFilterTags", () => ({
 }));
 
 vi.mock("./CANFiscalYearSelect", () => ({
-    default: () => <div data-testid="can-fiscal-year-select">FY</div>
+    default: ({ fiscalYear, setSelectedFiscalYear }) => (
+        <select
+            data-testid="can-fiscal-year-select"
+            value={fiscalYear}
+            onChange={(e) => setSelectedFiscalYear(e.target.value)}
+        >
+            <option value={fiscalYear}>{fiscalYear}</option>
+            <option value="All">All</option>
+        </select>
+    )
 }));
 
 vi.mock("../../../components/UI/Table/Table.hooks", () => ({
@@ -108,5 +118,43 @@ describe("CanList", () => {
 
         expect(screen.getByTestId("can-table")).toBeInTheDocument();
         expect(screen.getByTestId("can-summary-cards")).toBeInTheDocument();
+    });
+
+    it("sends empty fiscalYear array when 'All' is selected, resulting in no fiscal_year query param", async () => {
+        const user = userEvent.setup();
+
+        render(<CanList />);
+
+        // Initially, should call with current fiscal year as array
+        expect(useGetCansQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                fiscalYear: expect.any(Array)
+            })
+        );
+
+        // Get the initial call's fiscalYear to verify it's not empty
+        const initialCall = useGetCansQuery.mock.calls[0][0];
+        expect(initialCall.fiscalYear).toHaveLength(1);
+
+        // Change fiscal year to "All"
+        const fiscalYearSelect = screen.getByTestId("can-fiscal-year-select");
+        await user.selectOptions(fiscalYearSelect, "All");
+
+        // Wait for the component to re-render with new params
+        await waitFor(() => {
+            // Find the most recent call
+            const calls = useGetCansQuery.mock.calls;
+            const lastCall = calls[calls.length - 1][0];
+
+            // Verify fiscalYear is an empty array (which results in no query param)
+            expect(lastCall.fiscalYear).toEqual([]);
+        });
+
+        // Also verify the filter options query receives empty array
+        await waitFor(() => {
+            const calls = useGetCanFilterOptionsQuery.mock.calls;
+            const lastCall = calls[calls.length - 1][0];
+            expect(lastCall.fiscalYear).toEqual([]);
+        });
     });
 });

--- a/frontend/src/pages/cans/list/CanList.test.jsx
+++ b/frontend/src/pages/cans/list/CanList.test.jsx
@@ -156,5 +156,11 @@ describe("CanList", () => {
             const lastCall = calls[calls.length - 1][0];
             expect(lastCall.fiscalYear).toEqual([]);
         });
+
+        await waitFor(() => {
+            const calls = useGetCansFundingQuery.mock.calls;
+            const lastCall = calls[calls.length - 1][0];
+            expect(lastCall.fiscalYear).toBeUndefined();
+        });
     });
 });


### PR DESCRIPTION
## What changed

Adds an "All" fiscal year option to the CAN list dropdown, allowing users to view CANs across all fiscal years instead of being limited to a single year. This brings the CAN list into alignment with the AgreementsList filtering pattern.

**`frontend/src/pages/cans/list/CANFiscalYearSelect/CANFiscalYearSelect.jsx`**
- Added `showAllOption={true}` prop to enable the "All" option in the fiscal year dropdown

**`frontend/src/pages/cans/list/CanList.jsx`**
- Added `getFiscalYearFilter()` function that returns `[]` when "All" is selected, or `[Number(selectedFiscalYear)]` for specific years
- Created `fiscalYearFilter` variable for API calls (array format)
- Kept `fiscalYear` variable for display components (numeric, defaults to current FY when "All" is selected)
- Updated both `useGetCansQuery` and `useGetCanFilterOptionsQuery` to use `fiscalYearFilter`

**`frontend/src/api/opsAPI.js`**
- Updated `getCans` query to handle `fiscalYear` as an array, iterating and adding multiple query params (consistent with other filter parameters)
- Updated `getCanFilterOptions` query similarly to handle array format

**`frontend/src/pages/cans/list/CanList.test.jsx`**
- Made fiscal year select mock interactive for testing
- Added test: "sends empty fiscalYear array when 'All' is selected, resulting in no fiscal_year query param"
  - Verifies initial call sends array with current FY
  - Simulates user selecting "All"
  - Confirms both CAN and filter options queries receive empty array

## Issue

https://github.com/HHS/OPRE-OPS/issues/5574

## How to test

**Unit tests:**
```bash
cd frontend
bun run test --run src/pages/cans/list/CanList.test.jsx
```
Expected: All 3 tests pass, including the new "All" fiscal year test.

**Manual testing (requires Docker stack):**
1. Navigate to the CAN list page
2. Click the fiscal year dropdown
3. Verify "All" option appears at the bottom
4. Select "All"
5. Verify the page displays CANs from all fiscal years
6. Check network tab: no `fiscal_year` query parameter should be present in the `/api/v1/cans/` request

**Backend compatibility:**
The backend schema already expects `fiscal_year = fields.List(fields.Integer(), required=False)`, so no backend changes are needed.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

N/A — dropdown behavior change only; no visual changes to the UI.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed (N/A)
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved (existing tests maintained)
- [ ] Form validations updated (N/A - dropdown only)

## Links

N/A