### PR TITLE
fix: prevent Loading in tooltip message on in-review BLI status tags

### DIFF
--- a/frontend/src/components/UI/TableTag/TableTag.jsx
+++ b/frontend/src/components/UI/TableTag/TableTag.jsx
@@ -1,4 +1,5 @@
 import { convertCodeForDisplay } from "../../../helpers/utils";
+import { CHANGE_REQUESTS_TOOLTIP_LOADING } from "../../../hooks/useChangeRequests.hooks";
 import Tag from "../Tag";
 import Tooltip from "../USWDS/Tooltip";
 
@@ -19,7 +20,7 @@ const TableTag = ({ status, inReview = false, lockedMessage, isObe = false }) =>
     const statusText = convertCodeForDisplay("budgetLineStatus", status);
     let classNames = "";
 
-    if (inReview && lockedMessage) {
+    if (inReview && lockedMessage && lockedMessage !== CHANGE_REQUESTS_TOOLTIP_LOADING) {
         return (
             <Tooltip
                 label={lockedMessage}


### PR DESCRIPTION
## What changed

Fixes the "In Review" status tooltip on budget line rows so it no longer shows the `"Loading..."` sentinel string. `TableTag` now skips the tooltip branch when the locked message equals `CHANGE_REQUESTS_TOOLTIP_LOADING` and falls through to the plain `In Review` tag until `useGetAllCans` / `useGetProcurementShopsQuery` resolve. Matches the existing pattern in `ChangeIcons.jsx`.

## Issue

#5651

## How to test

Hover over an in-review BLI status tag, the tooltip should show what is In Review instead of Loading...

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots
<img width="1003" height="150" alt="Screenshot 2026-05-11 at 11 00 07 PM" src="https://github.com/user-attachments/assets/e76b0b4e-a53b-4974-9895-c947bb1bc568" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [-] Automated load tests updated and passed
- [-] Automated a11y tests updated and passed
- [-] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated