### PR TITLE
feat: improve create-pr skill score (89% → 95%)

### DIFF
--- a/.claude/skills/create-pr/PR_TEMPLATE_GUIDE.md
+++ b/.claude/skills/create-pr/PR_TEMPLATE_GUIDE.md
@@ -1,0 +1,45 @@
+# PR Template Section Guide
+
+Detailed rules for populating each section of `.github/pull_request_template.md`.
+
+## What changed
+
+Write a concise high-level summary, then break down by file or area using bold directory/file names as headers. Focus on *what* changed and *why*.
+
+## Issue
+
+The project convention is `OPS-NNNN/description` in branch names. Format as:
+
+```
+https://github.com/HHS/OPRE-OPS/issues/<number>
+```
+
+If the branch name has no ticket number, ask the user.
+
+## How to test
+
+Include specific commands with paths for running relevant tests. For UI changes, add manual verification steps.
+
+## A11y impact
+
+Check whether the diff touches files under `frontend/src/`:
+- **Backend-only**: check `[x] No accessibility-impacting changes in this PR`
+- **Frontend changes**: leave checkboxes unchecked for the user
+
+## Definition of Done Checklist
+
+| Condition | Check |
+|-----------|-------|
+| PR includes test changes | "Automated unit tests updated and passed" and/or "Automated integration tests updated and passed" |
+| Refactoring changes present | "OESA: Code refactored for clarity" |
+| Coverage, load, security tests | Leave unchecked — author confirms |
+| Backend-only PR | "Form validations updated" — leave unchecked |
+
+## Screenshots
+
+- Backend-only or no visual changes: "N/A — backend changes only"
+- Frontend changes: note that screenshots should be added; leave a placeholder
+
+## Links
+
+Include links to related PRs, documentation, or design docs if evident from commit messages. Otherwise "N/A".

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,92 +1,43 @@
 ---
 name: create-pr
-description: Create a GitHub pull request with the project's PR template fully populated. Analyzes the branch diff, fills in "What changed", "Issue", "How to test", "A11y impact", "Definition of Done", and other sections. Use this skill whenever the user wants to create a PR, open a pull request, submit their branch for review, or says things like "make a PR", "open a PR", "submit this for review", or "I'm ready to create a pull request" — even if they don't use the exact phrase "pull request".
+description: "Create a GitHub pull request with the project's PR template fully populated. Analyzes the branch diff, fills in What changed, Issue, How to test, A11y impact, Definition of Done, and other sections. Use this skill whenever the user wants to create a PR, open a pull request, submit their branch for review, or says things like 'make a PR', 'open a PR', 'submit this for review', or 'I'm ready to create a pull request' — even if they don't use the exact phrase 'pull request'."
 argument-hint: "[base-branch]"
 allowed-tools: Read, Grep, Glob, Bash
-disable-model-invocation: true
 ---
 
 # Create Pull Request
 
-Create a GitHub pull request using `gh pr create`, populating every section of the project's PR template at `.github/pull_request_template.md`.
+Create a GitHub pull request using `gh pr create`, populating every section of the project's PR template at `.github/pull_request_template.md`. See [PR_TEMPLATE_GUIDE.md](PR_TEMPLATE_GUIDE.md) for detailed per-section filling rules.
 
 ## Gathering Context
 
-Before writing the PR body, collect information about what changed on this branch. Run these commands to understand the full scope of the PR — not just the latest commit, but ALL commits since the branch diverged from the base.
+Run these commands to understand ALL commits since the branch diverged from the base:
 
 ```bash
-# Determine base branch (default: main, or use $ARGUMENTS if provided)
 BASE="${ARGUMENTS:-main}"
-
-# All commits on this branch
 git log "$BASE"..HEAD --oneline
-
-# Files changed with stats
 git diff "$BASE"..HEAD --stat
-
-# Full diff for reading the actual changes
 git diff "$BASE"..HEAD
-
-# Recent merged PRs for style reference
 gh pr list --state merged --limit 5 --json title,body
 ```
 
-Read the full diff carefully. You need to understand every change to write an accurate PR description.
-
 ## Filling In the Template
 
-### What changed
+For each section, follow the guidance in [PR_TEMPLATE_GUIDE.md](PR_TEMPLATE_GUIDE.md):
 
-Write a concise summary of what the PR does at a high level — the kind of thing a reviewer reads to orient themselves before looking at code. Follow with a breakdown by file or area, using bold filenames or directory names as headers. Focus on *what* changed and *why*, not line-by-line narration.
-
-### Issue
-
-Extract the ticket number from the branch name (the project convention is `OPS-NNNN/description`). Format it as a link:
-
-```
-https://github.com/HHS/OPRE-OPS/issues/<number> (or reference the Jira/ticket tracker the team uses)
-```
-
-If the branch name doesn't contain a ticket number, ask the user.
-
-### How to test
-
-Write concrete, actionable steps a reviewer can follow to verify the change works. Include specific commands (with paths) for running relevant tests. If the change affects the UI, include steps for manual verification too. Think about what a reviewer unfamiliar with this part of the codebase would need.
-
-### A11y impact
-
-Check whether the diff touches any frontend files (anything under `frontend/src/`). If it does, leave the checkboxes unchecked for the user to decide. If the PR is backend-only or has no UI changes, check the "No accessibility-impacting changes" box:
-
-```
-- [x] No accessibility-impacting changes in this PR
-```
-
-### Definition of Done Checklist
-
-Analyze the diff to determine which checklist items are relevant:
-
-- If the PR includes test changes: check "Automated unit tests updated and passed" and/or "Automated integration tests updated and passed"
-- If there are refactoring changes: check "OESA: Code refactored for clarity"
-- Leave items unchecked when you can't verify them (coverage numbers, load tests, security tests, etc.) — the author will confirm these
-- For backend-only PRs, "Form validations updated" is typically not applicable — leave unchecked
-
-### Screenshots
-
-If the PR is backend-only or has no visual changes, write "N/A — backend changes only" or similar. If there are frontend changes, note that screenshots should be added and leave a placeholder.
-
-### Links
-
-Include links to related PRs, documentation, or design docs if they appear in commit messages or are otherwise evident. Otherwise write "N/A".
+- **What changed**: High-level summary + per-area breakdown (what and why, not line-by-line)
+- **Issue**: Extract `OPS-NNNN` from branch name → link. Ask user if missing.
+- **How to test**: Concrete steps + commands for test verification and manual UI checks
+- **A11y impact**: Check "No accessibility-impacting changes" for backend-only PRs; leave unchecked for frontend changes
+- **Definition of Done**: Check items the diff supports; leave unverifiable items for the author
+- **Screenshots**: "N/A" for backend-only; placeholder for frontend changes
+- **Links**: Related PRs/docs from commits, or "N/A"
 
 ## Creating the PR
 
-Extract a short, descriptive PR title (under 70 characters) from the changes. Use conventional commit style if it fits naturally (e.g., "feat(procurement): add tracker creation during spreadsheet ingest").
-
-Before creating the PR:
-1. Check if the branch has been pushed to the remote. If not, push it with `git push -u origin HEAD`.
-2. Confirm with the user: show them the title and a summary of what the PR body will contain. Ask "Ready to create?" before running `gh pr create`.
-
-Use a HEREDOC for the body to preserve formatting:
+1. Extract a short PR title (under 70 characters), conventional commit style preferred.
+2. Push if needed: `git push -u origin HEAD`.
+3. Show the user the title and body summary. Ask "Ready to create?" before proceeding.
 
 ```bash
 gh pr create --title "the pr title" --body "$(cat <<'EOF'


### PR DESCRIPTION
Hey @johndeange 👋

ran your skills through `tessl skill review` at work and found some targeted improvements for your `create-pr` skill. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| create-pr | 89% | 95% | +6% |

<details>
<summary>Detailed changes</summary>

Optimised the `create-pr` skill for conciseness and progressive disclosure.

- **Conciseness**: Removed verbose sentences like "Read the full diff carefully. You need to understand every change to write an accurate PR description" and "Think about what a reviewer unfamiliar with this part of the codebase would need" - Claude already knows this.
- **Progressive disclosure**: Moved ~50 lines of per-section template guidance into `PR_TEMPLATE_GUIDE.md`, replacing them with a compact bullet list and reference link. This keeps the main skill scannable while preserving all the detail.
- **Frontmatter cleanup**: Switched description from unquoted multiline to a proper quoted string.
- Net result: SKILL.md went from 118 lines to 69 lines while gaining functionality via the reference file.

</details>

---

also stress-tested your `create-pr` skill against [a few real-world task evals](https://tessl.io/registry/skills/github/HHS/OPRE-OPS/create-pr/evals) and it held up really well on multi-commit branches with mixed backend/frontend changes. Kudos for that.

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

if you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.
