### PR TITLE
feat: scroll to top on error alert in ReviewAgreement component

### DIFF
--- a/frontend/src/pages/agreements/review/ReviewAgreement.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.jsx
@@ -21,6 +21,7 @@ import {
     findPeriodEnd,
     findPeriodStart
 } from "../../../helpers/servicesComponent.helpers";
+import { scrollToTop } from "../../../helpers/scrollToTop.helper";
 import { convertCodeForDisplay } from "../../../helpers/utils";
 import { actionOptions } from "./ReviewAgreement.constants";
 import useReviewAgreement from "./ReviewAgreement.hooks";
@@ -90,6 +91,12 @@ export const ReviewAgreement = () => {
             }
         }
     }, [isLoadingAgreement, errorAgreement, agreement, canUserEditAgreement, navigate]);
+
+    React.useEffect(() => {
+        if (isAlertActive && Object.entries(pageErrors).length > 0) {
+            scrollToTop();
+        }
+    }, [isAlertActive, pageErrors]);
 
     if (isLoadingAgreement) {
         return (


### PR DESCRIPTION
## What changed

- Auto-scroll to the top of the page when the validation error alert is displayed on the Review Agreement page, so users always see the error message even if they've scrolled down
- Reuses the existing scrollToTop helper with smooth scroll behavior

## Issue

#5585 

## How to test

1.  Navigate to the Review Agreement page, scroll down, trigger a validation error (e.g., send to approval with missing fields), and confirm the page scrolls to the top
1. Verify smooth scroll animation works as expected

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated