### PR TITLE
feat: add BUDGET_TEAM to For Review tab access

### DIFF
--- a/frontend/src/pages/agreements/list/AgreementTabs.test.jsx
+++ b/frontend/src/pages/agreements/list/AgreementTabs.test.jsx
@@ -109,6 +109,22 @@ describe("AgreementTabs", () => {
         expect(screen.getByText("For Review")).toBeInTheDocument();
     });
 
+    test("does render for budget team", () => {
+        useSelector.mockReturnValue([{ id: 4, name: "BUDGET_TEAM" }]);
+
+        render(
+            <Provider store={store}>
+                <BrowserRouter>
+                    <AgreementTabs />
+                </BrowserRouter>
+            </Provider>
+        );
+
+        expect(screen.getByText("All Agreements")).toBeInTheDocument();
+        expect(screen.getByText("My Agreements")).toBeInTheDocument();
+        expect(screen.getByText("For Review")).toBeInTheDocument();
+    });
+
     test("applies correct class based on location", () => {
         useLocation.mockReturnValueOnce({
             search: "?filter=my-agreements"

--- a/frontend/src/pages/agreements/list/AgreementsTabs.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsTabs.jsx
@@ -16,9 +16,12 @@ const AgreementTabs = () => {
     const { search } = useLocation();
     const changeRequestsTotal = useChangeRequestTotal();
     const userRoles = useSelector((state) => state.auth?.activeUser?.roles) ?? [];
-    // Only display the "For Review" tab if the user has the REVIEWER_APPROVER or SUPER_USER role
+    // Only display the "For Review" tab if the user has the REVIEWER_APPROVER, SUPER_USER, or BUDGET_TEAM role
     const displayReviewTab = userRoles.some(
-        (role) => role?.name === USER_ROLES.REVIEWER_APPROVER || role?.name === USER_ROLES.SUPER_USER
+        (role) =>
+            role?.name === USER_ROLES.REVIEWER_APPROVER ||
+            role?.name === USER_ROLES.SUPER_USER ||
+            role?.name === USER_ROLES.BUDGET_TEAM
     );
 
     const paths = [


### PR DESCRIPTION
## What changed

Added BUDGET_TEAM role to the list of roles that can access the "For Review" tab on the agreements page. Previously only REVIEWER_APPROVER and SUPER_USER had access.

**frontend/src/pages/agreements/list/AgreementsTabs.jsx**
- Updated `displayReviewTab` logic to include `USER_ROLES.BUDGET_TEAM` check
- Updated comment to reflect all three authorized roles

**frontend/src/pages/agreements/list/AgreementTabs.test.jsx**
- Added test case `"does render for budget team"` verifying BUDGET_TEAM users see the For Review tab
- Test follows existing pattern for SUPER_USER and REVIEWER_APPROVER tests

## Issue

https://github.com/HHS/OPRE-OPS/issues/5615

## How to test

1. **Unit tests:**
   ```bash
   cd frontend
   npm test -- AgreementTabs.test.jsx --run
   ```

2. **Manual verification:**
   - Log in as a user with BUDGET_TEAM role
   - Navigate to `/agreements`
   - Verify the "For Review" tab appears alongside "All Agreements" and "My Agreements"
   - Log in as a user without BUDGET_TEAM/REVIEWER_APPROVER/SUPER_USER roles
   - Verify the "For Review" tab does not appear

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

<img width="1029" height="452" alt="Screenshot 2026-05-13 at 9 49 15 AM" src="https://github.com/user-attachments/assets/d3d1b1ca-dc03-4517-b3b9-7ac47f68dca6" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

## Links

https://github.com/HHS/OPRE-OPS/issues/5615