### PR TITLE
fix(deps): update Python base image to 3.14.5-alpine3.23

### DIFF
--- a/backend/Dockerfile.data-tools
+++ b/backend/Dockerfile.data-tools
@@ -1,4 +1,4 @@
-FROM python:3.14.2-alpine3.22 AS deps
+FROM python:3.14.5-alpine3.23 AS deps
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/home/app

--- a/backend/Dockerfile.data-tools-import
+++ b/backend/Dockerfile.data-tools-import
@@ -1,4 +1,4 @@
-FROM python:3.14.2-alpine3.22 AS deps
+FROM python:3.14.5-alpine3.23 AS deps
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/home/app

--- a/backend/Dockerfile.debug
+++ b/backend/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM python:3.14.2-alpine3.22
+FROM python:3.14.5-alpine3.23
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/home/app

--- a/backend/Dockerfile.ops-api
+++ b/backend/Dockerfile.ops-api
@@ -1,4 +1,4 @@
-FROM python:3.14.2-alpine3.22 AS deps
+FROM python:3.14.5-alpine3.23 AS deps
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/home/app


### PR DESCRIPTION
## What changed

Updates all 4 backend Dockerfiles from `python:3.14.2-alpine3.22` to `python:3.14.5-alpine3.23` to address Snyk-reported vulnerabilities in the Alpine OS packages shipped with the old base image.

**Resolved CVEs:**
- **Critical:** CVE-2026-31789 (openssl/libcrypto)
- **High:** CVE-2026-28387, CVE-2026-28389, CVE-2026-28388, CVE-2026-28390 (openssl/musl)
- **Medium:** Heap-based Buffer Overflow, Improper Validation of Specified Quantity in Input
- **Low:** Always-Incorrect Control Flow, Improper Resource Shutdown, CVE-2026-2673, CVE-2026-31790

**Files updated:**
- `backend/Dockerfile.ops-api`
- `backend/Dockerfile.data-tools`
- `backend/Dockerfile.data-tools-import`
- `backend/Dockerfile.debug`

## Issue

No ticket — addressing Snyk weekly report findings (May 6–13, 2026).

## How to test

1. Build the backend images locally:
   ```bash
   docker compose build backend data-import
   ```
2. Verify they start correctly:
   ```bash
   docker compose up backend data-import
   ```
3. Confirm the base image version:
   ```bash
   docker run --rm $(docker compose images backend -q) cat /etc/alpine-release
   # Should output: 3.23.x
   ```

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

N/A — backend infrastructure changes only.

## Definition of Done Checklist
- [x] OESA: Dependency rules followed
- [x] Automated integration tests updated and passed
- [x] Automated security tests updated and passed

## Links

N/A