### PR TITLE
update dependency eslint and unblock frontend deps upgrades

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -63,7 +63,7 @@
         "cypress-axe": "1.7.0",
         "cypress-localstorage-commands": "2.3.0",
         "esbuild": "0.28.0",
-        "eslint": "10.2.1",
+        "eslint": "10.3.0",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-cypress": "6.4.0",
         "eslint-plugin-import": "2.32.0",
@@ -1198,7 +1198,7 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@10.2.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.5.5", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q=="],
+    "eslint": ["eslint@10.3.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.5.5", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw=="],
 
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,7 +62,7 @@
         "cypress": "15.14.2",
         "cypress-axe": "1.7.0",
         "cypress-localstorage-commands": "2.3.0",
-        "eslint": "10.2.1",
+        "eslint": "10.3.0",
         "eslint-config-prettier": "10.1.8",
         "eslint-plugin-cypress": "6.4.0",
         "eslint-plugin-import": "2.32.0",


### PR DESCRIPTION
## What changed

Upgrades eslint from 10.2.1 to 10.3.0 (minor version bump) and regenerates `frontend/bun.lock` to match.

This replaces Renovate PR #5625, which failed CI because Renovate could not update the bun lockfile (artifact failure). The `--frozen-lockfile` check in CI rejected the stale lockfile, cascading into failures across all frontend CI jobs.

**frontend/package.json** — bumped eslint version from 10.2.1 to 10.3.0

**frontend/bun.lock** — regenerated to reflect the new eslint version and integrity hash

## Issue

Replaces #5625 (Renovate PR with artifact failure)

## How to test

1. Verify CI passes — all frontend jobs (Linting, Frontend Unit Tests, Storybook Build, A11y Regression Gate, E2E tests) should succeed now that the lockfile is in sync
2. Locally:
   ```bash
   cd frontend
   bun install --frozen-lockfile  # Should succeed without errors
   bun run lint                   # Should work with eslint 10.3.0
   ```

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

N/A — dependency upgrade only, no visual changes.

## Definition of Done Checklist

- [x] OESA: Code refactored for clarity
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Validated in a staging environment

## Links

- Renovate PR (superseded): #5625
- [eslint 10.3.0 release](https://github.com/eslint/eslint/compare/v10.2.1...v10.3.0)