### PR TITLE
feat(projects): show Multi in FY dropdown and clear filter on dropdown change

### DIFF
--- a/frontend/cypress/e2e/projectsList.cy.js
+++ b/frontend/cypress/e2e/projectsList.cy.js
@@ -333,6 +333,67 @@ describe("Projects List Page", () => {
         cy.contains("span", "Filters Applied:").should("not.exist");
     });
 
+    it("shows 'Multi' in the fiscal year dropdown when 2+ fiscal years are selected via filter modal", () => {
+        cy.get("button").contains("Filter").click();
+
+        // Select FY 2043 — menu closes after each selection (closeMenuOnSelect=true)
+        cy.get(".fiscal-year-combobox__control").click();
+        cy.get(".fiscal-year-combobox__menu").should("be.visible");
+        cy.get(".fiscal-year-combobox__menu").contains("FY 2043").click();
+        cy.get(".fiscal-year-combobox__menu").should("not.exist");
+        // Re-open to select FY 2044
+        cy.get(".fiscal-year-combobox__control").click();
+        cy.get(".fiscal-year-combobox__menu").should("be.visible");
+        cy.get(".fiscal-year-combobox__menu").contains("FY 2044").click();
+
+        cy.get("button").contains("Apply").click();
+
+        // Verify both filter tags are displayed
+        getAppliedFilters().within(() => {
+            cy.contains("FY 2043", { timeout: 10000 }).should("exist");
+            cy.contains("FY 2044").should("exist");
+        });
+
+        // The fiscal year dropdown should show "Multi" (disabled sentinel option)
+        cy.get("#fiscal-year-select option:selected").should("have.text", "Multi");
+
+        // Reset
+        cy.get("button").contains("Filter").click();
+        cy.get("button").contains("Reset").click();
+        cy.get("button").contains("Apply").click();
+        cy.contains("span", "Filters Applied:").should("not.exist");
+    });
+
+    it("clears fiscal year filter tags when the fiscal year dropdown changes", () => {
+        // Apply two fiscal years via the filter modal
+        cy.get("button").contains("Filter").click();
+        // Select FY 2043 — menu closes after each selection (closeMenuOnSelect=true)
+        cy.get(".fiscal-year-combobox__control").click();
+        cy.get(".fiscal-year-combobox__menu").should("be.visible");
+        cy.get(".fiscal-year-combobox__menu").contains("FY 2043").click();
+        cy.get(".fiscal-year-combobox__menu").should("not.exist");
+        // Re-open to select FY 2044
+        cy.get(".fiscal-year-combobox__control").click();
+        cy.get(".fiscal-year-combobox__menu").should("be.visible");
+        cy.get(".fiscal-year-combobox__menu").contains("FY 2044").click();
+        cy.get("button").contains("Apply").click();
+
+        // Confirm the "Multi" state and both tags are visible
+        cy.get("#fiscal-year-select option:selected", { timeout: 10000 }).should("have.text", "Multi");
+        getAppliedFilters().within(() => {
+            cy.contains("FY 2043").should("exist");
+            cy.contains("FY 2044").should("exist");
+        });
+
+        // Change the dropdown to a single year
+        cy.get("#fiscal-year-select").select("2044");
+
+        // Fiscal year filter tags should be cleared — entire "Filters Applied" section disappears
+        cy.get("tbody tr", { timeout: 15000 }).should("have.length.greaterThan", 0);
+        cy.get("#fiscal-year-select").should("have.value", "2044");
+        cy.contains("span", "Filters Applied:").should("not.exist");
+    });
+
     it("clears unapplied filter values when filter is closed and reopened but keeps applied values", () => {
         // Apply initial filters
         cy.get("button").contains("Filter").click();

--- a/frontend/src/pages/projects/list/ProjectsList.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.jsx
@@ -78,7 +78,10 @@ const ProjectsList = () => {
 
     const handleChangeFiscalYear = (newValue) => {
         setSelectedFiscalYear(newValue);
+        setFilters((prev) => ({ ...prev, fiscalYear: [] }));
     };
+
+    const fiscalYearDropdownValue = filters.fiscalYear.length >= 2 ? "Multi" : selectedFiscalYear;
 
     const fiscalYearDisplay = selectedFiscalYear === "All" ? "All FYs" : `FY ${selectedFiscalYear}`;
 
@@ -105,7 +108,7 @@ const ProjectsList = () => {
                     TabsSection={
                         <div className="margin-left-auto">
                             <FiscalYear
-                                fiscalYear={selectedFiscalYear}
+                                fiscalYear={fiscalYearDropdownValue}
                                 handleChangeFiscalYear={handleChangeFiscalYear}
                                 showAllOption={true}
                             />
@@ -180,7 +183,7 @@ const ProjectsList = () => {
                 TabsSection={
                     <div className="margin-left-auto">
                         <FiscalYear
-                            fiscalYear={selectedFiscalYear}
+                            fiscalYear={fiscalYearDropdownValue}
                             handleChangeFiscalYear={handleChangeFiscalYear}
                             showAllOption={true}
                         />


### PR DESCRIPTION
## What changed

When 2 or more fiscal years are selected via the filter modal on the Projects list page, the fiscal year dropdown now shows "Multi" instead of the raw year value. Changing the dropdown back to a single year (or "All") also clears any multi-year filter selections from the modal.

**frontend/src/pages/projects/list/ProjectsList.jsx**
- Added `fiscalYearDropdownValue` — resolves to `"Multi"` when `filters.fiscalYear.length >= 2`, otherwise falls through to `selectedFiscalYear`
- `handleChangeFiscalYear` now clears `filters.fiscalYear` when the dropdown changes, so modal-selected fiscal year filters are reset when the user picks a single year or "All"
- Both `<FiscalYear>` usages (normal and loading states) now use `fiscalYearDropdownValue`

**frontend/cypress/e2e/projectsList.cy.js**
- New test: verifies the FY dropdown displays "Multi" when 2+ fiscal years are selected via the filter modal
- New test: verifies that changing the dropdown to a single year clears all fiscal year filter tags

## Issue

https://github.com/HHS/OPRE-OPS/issues/5241

## How to test

1. **E2E tests:**
   ```bash
   cd frontend
   npx cypress run --config-file ./cypress.config.js --headless --spec "cypress/e2e/projectsList.cy.js"
   ```

2. **Manual verification:**
   - Navigate to `/projects`
   - Click **Filter**, select two fiscal years (e.g. FY 2043 and FY 2044), click **Apply**
   - Verify the fiscal year dropdown reads "Multi"
   - Select any single year from the dropdown
   - Verify the "Filters Applied" tags for the two fiscal years disappear and the dropdown shows the selected year

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

<img width="1011" height="707" alt="Screenshot 2026-05-13 at 3 15 02 PM" src="https://github.com/user-attachments/assets/144352ef-881e-47c2-8b30-a0f201618998" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

## Links

N/A