### PR TITLE
fix: fix header text logic in AgreementDetails component

### DIFF
--- a/frontend/src/pages/agreements/details/AgreementDetails.jsx
+++ b/frontend/src/pages/agreements/details/AgreementDetails.jsx
@@ -34,14 +34,11 @@ const AgreementDetails = ({
     // eslint-disable-next-line no-unused-vars
     let { budget_line_items: _, ...agreement_details } = agreement;
     const isEditable = isSuperUser || (agreement?._meta.isEditable && !isAgreementNotDeveloped);
-    const isCreatingAgreement = location.pathname === "/agreements/create";
-    const isEditingAgreement = location.pathname.startsWith("/agreements/edit");
-    const isWizardMode = isCreatingAgreement || isEditingAgreement;
 
     return (
         <article>
             <AgreementDetailHeader
-                heading={isWizardMode ? "Agreement Details" : "Edit Agreement Details"}
+                heading={isEditMode ? "Edit Agreement Details" : "Agreement Details"}
                 details=""
                 isEditMode={isEditMode}
                 setIsEditMode={setIsEditMode}

--- a/frontend/src/pages/agreements/details/AgreementDetails.test.js
+++ b/frontend/src/pages/agreements/details/AgreementDetails.test.js
@@ -250,7 +250,7 @@ describe("AgreementDetails", () => {
             </Provider>
         );
 
-        expect(screen.getByText("Edit Agreement Details")).toBeInTheDocument();
+        expect(screen.getByText("Agreement Details")).toBeInTheDocument();
         expect(screen.getByText("Agreement Type")).toBeInTheDocument();
         expect(screen.getAllByText("Assisted Acquisition (AA)").length).toBeGreaterThan(0);
         expect(screen.getByText("COR")).toBeInTheDocument();
@@ -398,7 +398,7 @@ describe("AgreementDetails", () => {
 
         // Should show edit button for super users even on non-contract agreements
         expect(screen.getByRole("button", { name: /Edit/i })).toBeInTheDocument();
-        expect(screen.getByText("Edit Agreement Details")).toBeInTheDocument();
+        expect(screen.getByText("Agreement Details")).toBeInTheDocument();
     });
 
     test("allows super user to edit when agreement._meta.isEditable is false", () => {
@@ -447,7 +447,7 @@ describe("AgreementDetails", () => {
 
         // Should show edit button for super users even when agreement is not normally editable
         expect(screen.getByRole("button", { name: /Edit/i })).toBeInTheDocument();
-        expect(screen.getByText("Edit Agreement Details")).toBeInTheDocument();
+        expect(screen.getByText("Agreement Details")).toBeInTheDocument();
     });
 
     test("regular user cannot edit when isAgreementNotDeveloped is true", () => {
@@ -492,7 +492,7 @@ describe("AgreementDetails", () => {
 
         // Should NOT show edit button for regular users on non-contract agreements
         expect(screen.queryByRole("button", { name: /Edit/i })).not.toBeInTheDocument();
-        expect(screen.getByText("Edit Agreement Details")).toBeInTheDocument();
+        expect(screen.getByText("Agreement Details")).toBeInTheDocument();
     });
 
     test("renders awarded agreement with contract number", () => {
@@ -718,6 +718,67 @@ describe("AgreementDetails", () => {
 
             // "Editing..." indicator should appear in edit mode
             expect(screen.getByText("Editing...")).toBeInTheDocument();
+        });
+    });
+
+    describe("header text", () => {
+        test("renders 'Agreement Details' when not in edit mode", () => {
+            TestApplicationContext.helpers().callBackend.mockImplementation(async () => {
+                return agreementHistoryData;
+            });
+            mockIntersectionObserver();
+
+            render(
+                <Provider store={store}>
+                    <Router
+                        location={history.location}
+                        navigator={history}
+                    >
+                        <AgreementDetails
+                            agreement={agreement}
+                            projectOfficer={projectOfficer}
+                            alternateProjectOfficer={projectOfficer}
+                            isEditMode={false}
+                            setIsEditMode={mockFn}
+                            setHasAgreementChanged={mockFn}
+                            isAgreementNotDeveloped={false}
+                            isAgreementAwarded={false}
+                        />
+                    </Router>
+                </Provider>
+            );
+
+            expect(screen.getByText("Agreement Details")).toBeInTheDocument();
+            expect(screen.queryByText("Edit Agreement Details")).not.toBeInTheDocument();
+        });
+
+        test("renders 'Edit Agreement Details' when in edit mode", () => {
+            TestApplicationContext.helpers().callBackend.mockImplementation(async () => {
+                return agreementHistoryData;
+            });
+            mockIntersectionObserver();
+
+            render(
+                <Provider store={store}>
+                    <Router
+                        location={history.location}
+                        navigator={history}
+                    >
+                        <AgreementDetails
+                            agreement={agreement}
+                            projectOfficer={projectOfficer}
+                            alternateProjectOfficer={projectOfficer}
+                            isEditMode={true}
+                            setIsEditMode={mockFn}
+                            setHasAgreementChanged={mockFn}
+                            isAgreementNotDeveloped={false}
+                            isAgreementAwarded={false}
+                        />
+                    </Router>
+                </Provider>
+            );
+
+            expect(screen.getByText("Edit Agreement Details")).toBeInTheDocument();
         });
     });
 });


### PR DESCRIPTION
## What changed

This PR replaces the dead `location.pathname` check with the existing `isEditMode` prop (already driven by the parent `Agreement.jsx` via `useState(false)` and toggled by the Edit button), so the heading now reads "Agreement Details" in view mode and switches to "Edit Agreement Details" once the user clicks Edit.

It also updates the existing unit tests that were locked in to the buggy text and adds a new `describe("header text", ...)` block with two regression tests covering both `isEditMode` states.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5672

## How to test

1. Click into any agreement.
2. On the **Agreement Details** tab, confirm the header reads **"Agreement Details"** (not "Edit Agreement Details") before you've clicked Edit.
3. Click the **Edit** button. Confirm the header switches to **"Edit Agreement Details"** alongside the "Editing..." indicator.
4. Cancel out of edit mode. Confirm the header returns to **"Agreement Details"**.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots
<img width="992" height="153" alt="Screenshot 2026-05-15 at 2 56 02 PM" src="https://github.com/user-attachments/assets/a8445032-295d-49e6-9573-cc3caa72b708" />
<img width="992" height="153" alt="Screenshot 2026-05-15 at 2 56 11 PM" src="https://github.com/user-attachments/assets/a20c039a-9a70-408a-add9-47fe2d514914" />



## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated