### PR TITLE
fix: strip UI-only fields from services_components before API submission

### DIFF
--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
@@ -831,7 +831,8 @@ const useCreateBLIsAndSCs = (
                     // creating new agreement
                     const newServicesComponents = servicesComponents
                         .filter((sc) => !("created_on" in sc))
-                        .map(({ display_title, ...sc }) => ({
+                        // eslint-disable-next-line no-unused-vars
+                        .map(({ display_title, has_changed, popStartDate, popEndDate, mode, ...sc }) => ({
                             ...sc,
                             ref: display_title
                         }));
@@ -880,10 +881,14 @@ const useCreateBLIsAndSCs = (
                     const changedServicesComponents = existingServicesComponents.filter((sc) => sc.has_changed);
 
                     const serviceComponentsCreationPromises = newServicesComponents.map((sc) => {
-                        return addServicesComponent(sc).unwrap();
+                        // eslint-disable-next-line no-unused-vars
+                        const { display_title, has_changed, popStartDate, popEndDate, mode, ...cleanSc } = sc;
+                        return addServicesComponent(cleanSc).unwrap();
                     });
                     const serviceComponentsUpdatePromises = changedServicesComponents.map((sc) => {
-                        return updateServicesComponent({ id: sc.id, data: sc }).unwrap();
+                        // eslint-disable-next-line no-unused-vars
+                        const { display_title, has_changed, popStartDate, popEndDate, mode, ...cleanSc } = sc;
+                        return updateServicesComponent({ id: sc.id, data: cleanSc }).unwrap();
                     });
 
                     const createdServiceComponents = await Promise.all(serviceComponentsCreationPromises);

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
@@ -91,8 +91,9 @@ vi.mock("../../../hooks/user.hooks", () => ({
     useGetLoggedInUserFullName: () => "Reviewer User"
 }));
 
+const useEditAgreementMock = vi.fn(() => editAgreementMockData);
 vi.mock("../../Agreements/AgreementEditor/AgreementEditorContext.hooks", () => ({
-    useEditAgreement: () => editAgreementMockData
+    useEditAgreement: () => useEditAgreementMock()
 }));
 
 vi.mock("../BudgetLinesForm/datePickerSuite", () => {
@@ -266,5 +267,140 @@ describe("useCreateBLIsAndSCs", () => {
 
         expect(suiteModule.default.run).toHaveBeenCalledWith({ budgetLines: [] });
         expect(result.current.budgetLinePageErrorsExist).toBe(true);
+    });
+
+    it("does not send UI-only fields in services_components when creating a new agreement", async () => {
+        useEditAgreementMock.mockReturnValue({
+            agreement: { team_members: [] },
+            services_components: [
+                {
+                    number: 1,
+                    optional: false,
+                    description: "Base period",
+                    period_start: "2026-01-01",
+                    period_end: "2026-12-31",
+                    display_title: "Base Period 1",
+                    has_changed: true,
+                    popStartDate: "01/01/2026",
+                    popEndDate: "12/31/2026",
+                    mode: "edit"
+                }
+            ],
+            deleted_services_components_ids: []
+        });
+
+        addAgreementMock.mockReturnValue({ unwrap: () => Promise.resolve({ id: 99 }) });
+
+        const { result } = renderHook(() =>
+            useCreateBLIsAndSCs(
+                true,
+                false,
+                [],
+                vi.fn(),
+                goBackMock,
+                vi.fn(),
+                { agreement_type: "CONTRACT", display_name: "AGR-NEW" },
+                { fee_percentage: 5, abbr: "PSC" },
+                setIsEditModeMock,
+                "none",
+                true,
+                false,
+                "Save & Exit",
+                1
+            )
+        );
+
+        await act(async () => {
+            await result.current.handleSave(false);
+        });
+
+        expect(addAgreementMock).toHaveBeenCalled();
+        const payload = addAgreementMock.mock.calls[0][0];
+        const sc = payload.services_components[0];
+
+        expect(sc).not.toHaveProperty("has_changed");
+        expect(sc).not.toHaveProperty("popStartDate");
+        expect(sc).not.toHaveProperty("popEndDate");
+        expect(sc).not.toHaveProperty("mode");
+        expect(sc).toHaveProperty("number", 1);
+        expect(sc).toHaveProperty("ref", "Base Period 1");
+    });
+
+    it("does not send UI-only fields in services_components when editing an existing agreement", async () => {
+        useEditAgreementMock.mockReturnValue({
+            agreement: { id: 42, team_members: [] },
+            services_components: [
+                {
+                    number: 1,
+                    optional: false,
+                    description: "New SC",
+                    period_start: "2026-01-01",
+                    period_end: "2026-12-31",
+                    display_title: "Base Period 1",
+                    popStartDate: "01/01/2026",
+                    popEndDate: "12/31/2026",
+                    mode: "add"
+                },
+                {
+                    id: 77,
+                    number: 2,
+                    optional: true,
+                    description: "Existing SC",
+                    period_start: "2026-06-01",
+                    period_end: "2027-05-31",
+                    display_title: "Option Period 2",
+                    created_on: "2026-01-15",
+                    has_changed: true,
+                    popStartDate: "06/01/2026",
+                    popEndDate: "05/31/2027",
+                    mode: "edit"
+                }
+            ],
+            deleted_services_components_ids: []
+        });
+
+        addServicesComponentMock.mockReturnValue({ unwrap: () => Promise.resolve({ id: 88, number: 1 }) });
+        updateServicesComponentMock.mockReturnValue({ unwrap: () => Promise.resolve({ id: 77, number: 2 }) });
+
+        const { result } = renderHook(() =>
+            useCreateBLIsAndSCs(
+                true,
+                false,
+                [],
+                vi.fn(),
+                goBackMock,
+                vi.fn(),
+                { id: 42, agreement_type: "CONTRACT", display_name: "AGR-42" },
+                { fee_percentage: 5, abbr: "PSC" },
+                setIsEditModeMock,
+                "none",
+                true,
+                false,
+                "Save & Exit",
+                1
+            )
+        );
+
+        await act(async () => {
+            await result.current.handleSave(false);
+        });
+
+        expect(addServicesComponentMock).toHaveBeenCalled();
+        const createdSc = addServicesComponentMock.mock.calls[0][0];
+        expect(createdSc).not.toHaveProperty("has_changed");
+        expect(createdSc).not.toHaveProperty("popStartDate");
+        expect(createdSc).not.toHaveProperty("popEndDate");
+        expect(createdSc).not.toHaveProperty("mode");
+        expect(createdSc).not.toHaveProperty("display_title");
+        expect(createdSc).toHaveProperty("number", 1);
+
+        expect(updateServicesComponentMock).toHaveBeenCalled();
+        const updateCall = updateServicesComponentMock.mock.calls[0][0];
+        expect(updateCall.data).not.toHaveProperty("has_changed");
+        expect(updateCall.data).not.toHaveProperty("popStartDate");
+        expect(updateCall.data).not.toHaveProperty("popEndDate");
+        expect(updateCall.data).not.toHaveProperty("mode");
+        expect(updateCall.data).not.toHaveProperty("display_title");
+        expect(updateCall.data).toHaveProperty("number", 2);
     });
 });


### PR DESCRIPTION
## What changed

**frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js**

Strips UI-only fields (`has_changed`, `popStartDate`, `popEndDate`, `mode`) from services component objects before they are sent to the backend API. These fields are used for local form state management but are not accepted by the backend's `NestedServicesComponentRequestSchema`, causing marshmallow `ValidationError` (HTTP 400) when present.

Three code paths are fixed:
1. New agreement creation — destructure out extra fields in the `.map()` that builds `newServicesComponents`
2. Adding services components to an existing agreement — strip fields before calling `addServicesComponent`
3. Updating services components on an existing agreement — strip fields before calling `updateServicesComponent`

### Why the bug was intermittent

The extra fields only appear when a user **edits** a services component during the wizard (even one they just added). The "add" path dispatches a clean payload, but the "edit" path merges local form state (`popStartDate`, `popEndDate`, `mode`) and flags (`has_changed`) into the Redux state. If a user adds a component and submits without editing it, the request succeeds.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5681

## How to test

1. Run frontend lint to confirm no errors:
   ```bash
   cd frontend && bun run lint
   ```

2. Run related unit tests (requires Node 24 per `.nvmrc`):
   ```bash
   cd frontend && bun run test --watch=false src/components/BudgetLineItems/CreateBLIsAndSCs/
   ```

3. Manual verification:
   - Start the full stack: `docker compose up --build`
   - Sign in and navigate to create a new agreement
   - Add a services component, then **edit** it (click to modify), then submit
   - Verify the agreement is created successfully without HTTP 400

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

N/A — no visual changes.

## Definition of Done Checklist

- [x] OESA: Code refactored for clarity
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed

## Links

N/A