### PR TITLE
fix: fix disabled edit button style and a bug in CAN FY dropdown

### DIFF
--- a/frontend/src/components/Agreements/AgreementBudgetLinesHeader.jsx
+++ b/frontend/src/components/Agreements/AgreementBudgetLinesHeader.jsx
@@ -35,7 +35,7 @@ export const AgreementBudgetLinesHeader = ({
                     {heading}
                 </h2>
 
-                <div>
+                <div className="display-flex flex-align-baseline">
                     <button
                         type="button"
                         id="toggleDraftBLIs"
@@ -65,26 +65,30 @@ export const AgreementBudgetLinesHeader = ({
                                 className="text-primary height-2 width-2 margin-right-1 cursor-pointer usa-tooltip"
                                 title="edit"
                                 data-position="top"
+                                style={{ top: "-2px" }}
                             />
                             <span className="text-primary">Edit</span>
                         </button>
                     )}
                     {/* DISABLED EDIT BUTTON */}
                     {!isEditMode && isEditable && isPreAwardInReview && (
-                        <Tooltip label="This agreement is In Review for Pre-Award Approval. Edits or changes cannot be made at this time.">
+                        <Tooltip
+                            label="This agreement is In Review for Pre-Award Approval. Edits or changes cannot be made at this time."
+                            className="display-flex flex-align-baseline"
+                        >
                             <span
                                 id="edit-disabled"
-                                className="usa-button--unstyled usa-button--disabled"
+                                className="usa-button--unstyled usa-button--disabled display-flex flex-align-baseline"
                                 aria-disabled="true"
                                 data-cy="edit-disabled"
-                                tabIndex={0}
-                                role="button"
                             >
                                 <FontAwesomeIcon
                                     icon={faPen}
                                     size="2x"
                                     className="height-2 width-2 margin-right-1"
+                                    style={{ position: "relative", top: "2px" }}
                                     aria-hidden="true"
+                                    data-position="top"
                                 />
                                 <span>Edit</span>
                             </span>

--- a/frontend/src/pages/cans/detail/Can.hooks.js
+++ b/frontend/src/pages/cans/detail/Can.hooks.js
@@ -22,7 +22,7 @@ export default function useCan() {
     const isBudgetTeam = userRoles?.some((role) => role?.name === USER_ROLES.BUDGET_TEAM);
 
     const [selectedFiscalYear, setSelectedFiscalYear] = React.useState(getCurrentFiscalYear());
-    const fiscalYear = Number(selectedFiscalYear);
+    const fiscalYear = selectedFiscalYear === "All" ? null : Number(selectedFiscalYear);
     const canId = parseInt(urlPathParams.id ?? "-1");
     const initialModalProps = {
         heading: "",
@@ -60,21 +60,23 @@ export default function useCan() {
         data: CANFunding,
         isLoading: CANFundingLoading,
         isFetching: isCANFundingFetching
-    } = useGetCanFundingQuery({ id: canId, fiscalYear: fiscalYear }, { refetchOnMountOrArgChange: true });
+    } = useGetCanFundingQuery({ id: canId, fiscalYear }, { refetchOnMountOrArgChange: true });
 
-    const { data: previousFYfundingSummary } = useGetCanFundingQuery({
-        id: canId,
-        fiscalYear: fiscalYear - 1
-    });
+    const { data: previousFYfundingSummary } = useGetCanFundingQuery(
+        { id: canId, fiscalYear: fiscalYear ? fiscalYear - 1 : null },
+        { skip: !fiscalYear }
+    );
 
     const budgetLineItemsByFiscalYear = React.useMemo(() => {
-        if (!fiscalYear || !can) return [];
+        if (!can) return [];
+        if (!fiscalYear) return can?.budget_line_items ?? [];
 
         return can?.budget_line_items?.filter((bli) => bli.fiscal_year === fiscalYear) ?? [];
     }, [can, fiscalYear]);
 
     const fundingReceivedByFiscalYear = React.useMemo(() => {
-        if (!fiscalYear || !can) return [];
+        if (!can) return [];
+        if (!fiscalYear) return can?.funding_received ?? [];
 
         return can?.funding_received?.filter((fr) => fr.fiscal_year === fiscalYear) ?? [];
     }, [can, fiscalYear]);

--- a/frontend/src/pages/cans/detail/Can.hooks.test.js
+++ b/frontend/src/pages/cans/detail/Can.hooks.test.js
@@ -265,6 +265,40 @@ describe("useCan", () => {
         expect(result.current.isTableLoading).toBe(true);
     });
 
+    it("handles 'All' fiscal year selection without infinite loop", async () => {
+        useGetCanFundingQueryMock.mockImplementation(({ fiscalYear }) => {
+            if (fiscalYear === 2025) {
+                return { data: { funding: { available_funding: 75 } }, isLoading: false };
+            }
+            return {
+                data: {
+                    funding: {
+                        total_funding: 1500,
+                        planned_funding: 300,
+                        obligated_funding: 100,
+                        in_execution_funding: 200,
+                        in_draft_funding: 400,
+                        received_funding: 300
+                    }
+                },
+                isLoading: false
+            };
+        });
+
+        const { result } = renderHook(() => useCan());
+
+        act(() => {
+            result.current.setSelectedFiscalYear("All");
+        });
+
+        await waitFor(() => {
+            expect(result.current.fiscalYear).toBeNull();
+        });
+
+        expect(result.current.budgetLineItemsByFiscalYear.map((item) => item.id)).toEqual([11, 12, 13]);
+        expect(result.current.fundingReceivedByFiscalYear.map((item) => item.id)).toEqual([1, 2]);
+    });
+
     it("resets isEditMode when location.pathname changes", () => {
         const { result, rerender } = renderHook(() => useCan());
 


### PR DESCRIPTION
## What changed

- Fixed disabled "Edit" button styling on AgreementBudgetLinesHeader to properly show disabled appearance and accessibility attributes
- Fixed infinite loop bug on CAN details page when switching the Fiscal Year dropdown to "All" — `Number("All")` produced `NaN`, and since `NaN !== NaN`, RTK Query continuously detected "changed" arguments and refetched endlessly
- When "All" is selected, budget line items and funding received now display unfiltered (all fiscal years) instead of empty arrays

## Issue

#5673 

## How to test

1. Navigate to a CAN details page (e.g. `/cans/502`)
2. Open the Fiscal Year dropdown and select "All"
3. Verify the page does NOT spam network requests to `/api/v1/cans/<id>/funding/`
4. Verify budget line items and funding received tables show data from all fiscal years
5. Switch back to a specific fiscal year (e.g. 2026) and confirm filtering still works
6. On an Agreement page, verify the disabled "Edit" button in the Budget Lines header appears visually disabled

## A11y impact

- [x] Accessibility changes included and validated against WCAG 2.1 AA intent
  - Added `aria-disabled` attribute to the disabled Edit button in AgreementBudgetLinesHeader

## Screenshots
<img width="992" height="89" alt="Screenshot 2026-05-20 at 11 11 01 AM" src="https://github.com/user-attachments/assets/8dffae70-1f5b-4a62-8f0b-d34da586f2bb" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated