### PR TITLE
style: adjust notification circle margin 

### DIFF
--- a/frontend/src/pages/agreements/list/AgreementsTabs.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsTabs.jsx
@@ -63,7 +63,8 @@ const AgreementTabs = () => {
                     </Link>
                     {hasChangeRequestsOnReviewTab && (
                         <span
-                            className={`margin-left-neg-1 position-absolute bottom-2 ${tabStyles.notificationCircle}`}
+                            className={`position-absolute bottom-2 ${tabStyles.notificationCircle}`}
+                            style={{ marginLeft: "2px" }}
                         >
                             {changeRequestsTotal}
                         </span>


### PR DESCRIPTION
## What changed

- Removed `margin-left-neg-1` utility class from the notification circle in the Agreements "For Review" tab and replaced it with an inline `marginLeft: "2px"` style to properly position the change request count badge relative to the tab link.

## Issue

#5680

## How to test

1. Navigate to the **Agreements** page.
2. Ensure there are change requests pending review (the "For Review" tab should show a notification circle with a count).
3. Confirm the notification circle is properly spaced — not overlapping the tab text and not too far away.
4. Compare against other tabs to ensure consistent visual alignment.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated