### PR TITLE
feat: update budget validation and error handling in CANBudgetForm

### DIFF
--- a/frontend/src/components/CANs/CANBudgetForm/CANBudgetForm.jsx
+++ b/frontend/src/components/CANs/CANBudgetForm/CANBudgetForm.jsx
@@ -9,8 +9,9 @@ import CurrencyInput from "../../UI/Form/CurrencyInput";
  * @property {(arg: string) => string} cn
  * @property {Object} res
  * @property {number} fiscalYear
- * @property {(e: React.FormEvent<HTMLFormElement>) => void} handleAddBudget
- * @property {(name: string, value: string) => void} runValidate
+ * @property {() => void} handleAddBudget
+ * @property {(name: string, value: string) => { hasErrors: (name: string) => boolean }} runValidate
+ * @property {(name: string) => void} clearValidationError
  * @property {(value: string) => void} setBudgetAmount
  */
 
@@ -28,6 +29,7 @@ const CANBudgetForm = ({
     fiscalYear,
     handleAddBudget,
     runValidate,
+    clearValidationError,
     setBudgetAmount
 }) => {
     const buttonText = totalFunding ? "Update FY Budget" : "Add FY Budget";
@@ -35,20 +37,27 @@ const CANBudgetForm = ({
     return (
         <form
             onSubmit={(e) => {
-                handleAddBudget(e);
+                e.preventDefault();
+                const result = runValidate("budget-amount", String(budgetAmount ?? ""));
+                if (!result.hasErrors("budget-amount")) {
+                    handleAddBudget();
+                }
             }}
         >
             <div style={{ width: "383px", marginTop: `${showCarryForwardCard ? "0" : "-24px"}` }}>
                 <CurrencyInput
                     name="budget-amount"
                     label={`FY ${fiscalYear} CAN Budget`}
-                    onChange={(name, value) => {
-                        runValidate("budget-amount", value);
+                    onChange={() => {
+                        clearValidationError("budget-amount");
                     }}
                     setEnteredAmount={setBudgetAmount}
                     value={budgetAmount || ""}
                     messages={res.getErrors("budget-amount")}
                     className={cn("budget-amount")}
+                    onBlur={(e) => {
+                        runValidate("budget-amount", e.target.value);
+                    }}
                 />
             </div>
             <button

--- a/frontend/src/components/CANs/CANBudgetForm/CANBudgetForm.test.jsx
+++ b/frontend/src/components/CANs/CANBudgetForm/CANBudgetForm.test.jsx
@@ -12,7 +12,8 @@ describe("CANBudgetForm", () => {
         res: { getErrors: () => [] },
         fiscalYear: 2024,
         handleAddBudget: vi.fn(),
-        runValidate: vi.fn(),
+        runValidate: vi.fn(() => ({ hasErrors: () => false })),
+        clearValidationError: vi.fn(),
         setBudgetAmount: vi.fn()
     };
 
@@ -22,28 +23,83 @@ describe("CANBudgetForm", () => {
         expect(screen.getByRole("button", { name: /update fy budget/i })).toBeInTheDocument();
     });
 
-    test("calls handleAddBudget and setBudgetAmount on form submission", async () => {
+    test("calls runValidate on blur", () => {
+        render(<CANBudgetForm {...defaultProps} />);
+
+        fireEvent.blur(screen.getByLabelText(/FY 2024 CAN Budget/i), {
+            target: { value: "1,000" }
+        });
+
+        expect(defaultProps.runValidate).toHaveBeenCalledWith("budget-amount", "1,000");
+    });
+
+    test("calls handleAddBudget when validation passes on submit", async () => {
         const user = userEvent.setup();
+        const props = {
+            ...defaultProps,
+            handleAddBudget: vi.fn(),
+            runValidate: vi.fn(() => ({ hasErrors: () => false }))
+        };
         render(
             <CANBudgetForm
-                {...defaultProps}
+                {...props}
                 budgetAmount={1000}
             />
         );
 
         await user.click(screen.getByRole("button", { name: /update fy budget/i }));
 
-        expect(defaultProps.handleAddBudget).toHaveBeenCalled();
+        expect(props.runValidate).toHaveBeenCalledWith("budget-amount", "1000");
+        expect(props.handleAddBudget).toHaveBeenCalled();
     });
 
-    test("calls runValidate when currency input changes", () => {
-        render(<CANBudgetForm {...defaultProps} />);
+    test("blocks handleAddBudget when validation fails on submit", async () => {
+        const user = userEvent.setup();
+        const props = {
+            ...defaultProps,
+            handleAddBudget: vi.fn(),
+            runValidate: vi.fn(() => ({ hasErrors: () => true }))
+        };
+        render(
+            <CANBudgetForm
+                {...props}
+                budgetAmount={500}
+            />
+        );
+
+        await user.click(screen.getByRole("button", { name: /update fy budget/i }));
+
+        expect(props.runValidate).toHaveBeenCalledWith("budget-amount", "500");
+        expect(props.handleAddBudget).not.toHaveBeenCalled();
+    });
+
+    test("does not call runValidate on input change", () => {
+        const props = {
+            ...defaultProps,
+            runValidate: vi.fn(() => ({ hasErrors: () => false })),
+            clearValidationError: vi.fn()
+        };
+        render(<CANBudgetForm {...props} />);
 
         fireEvent.change(screen.getByLabelText(/FY 2024 CAN Budget/i), {
             target: { value: "1000" }
         });
 
-        expect(defaultProps.runValidate).toHaveBeenCalledWith("budget-amount", "1,000");
+        expect(props.runValidate).not.toHaveBeenCalled();
+    });
+
+    test("clears validation error on input change", () => {
+        const props = {
+            ...defaultProps,
+            clearValidationError: vi.fn()
+        };
+        render(<CANBudgetForm {...props} />);
+
+        fireEvent.change(screen.getByLabelText(/FY 2024 CAN Budget/i), {
+            target: { value: "1000" }
+        });
+
+        expect(props.clearValidationError).toHaveBeenCalledWith("budget-amount");
     });
 
     test("displays validation errors when present", () => {

--- a/frontend/src/components/CANs/CANFundingReceivedForm/CanFundingReceivedForm.jsx
+++ b/frontend/src/components/CANs/CANFundingReceivedForm/CanFundingReceivedForm.jsx
@@ -7,9 +7,10 @@ import icons from "../../../uswds/img/sprite.svg";
  * @property {(arg: string) => string} cn
  * @property {Object} res
  * @property {string} receivedFundingAmount
- * @property {(e: React.FormEvent<HTMLFormElement>) => void} handleSubmit
+ * @property {() => void} handleSubmit
  * @property {boolean} isEditing
- * @property {(name: string, value: string) => void} runValidate
+ * @property {(name: string, value: string) => { hasErrors: (name: string) => boolean }} runValidate
+ * @property {(name: string) => void} clearValidationError
  * @property {(value: string) => void} setReceivedFundingAmount
  * @property {string} notes
  * @property {(value: string) => void} setNotes
@@ -26,6 +27,7 @@ const CANFundingReceivedForm = ({
     cn,
     res,
     runValidate,
+    clearValidationError,
     handleSubmit,
     isEditing,
     receivedFundingAmount,
@@ -40,15 +42,22 @@ const CANFundingReceivedForm = ({
     return (
         <form
             onSubmit={(e) => {
-                handleSubmit(e);
+                e.preventDefault();
+                const result = runValidate("funding-received-amount", String(receivedFundingAmount ?? ""));
+                if (!result.hasErrors("funding-received-amount")) {
+                    handleSubmit();
+                }
             }}
         >
             <div style={{ width: "383px" }}>
                 <CurrencyInput
                     name="funding-received-amount"
                     label="Funding Received"
-                    onChange={(name, value) => {
-                        runValidate("funding-received-amount", value);
+                    onChange={() => {
+                        clearValidationError("funding-received-amount");
+                    }}
+                    onBlur={(e) => {
+                        runValidate("funding-received-amount", e.target.value);
                     }}
                     setEnteredAmount={setReceivedFundingAmount}
                     value={receivedFundingAmount || ""}

--- a/frontend/src/components/CANs/CANFundingReceivedForm/CanFundingReceivedForm.test.jsx
+++ b/frontend/src/components/CANs/CANFundingReceivedForm/CanFundingReceivedForm.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import CANFundingReceivedForm from "./CanFundingReceivedForm";
@@ -13,7 +13,8 @@ describe("CANFundingReceivedForm", () => {
         },
         receivedFundingAmount: "",
         handleSubmit: vi.fn(),
-        runValidate: vi.fn(),
+        runValidate: vi.fn(() => ({ hasErrors: () => false })),
+        clearValidationError: vi.fn(),
         setReceivedFundingAmount: vi.fn(),
         notes: "",
         setNotes: vi.fn()
@@ -54,17 +55,77 @@ describe("CANFundingReceivedForm", () => {
         expect(defaultProps.setReceivedFundingAmount).toHaveBeenCalledWith(1000);
     });
 
-    it("calls handleSubmit when form is submitted", async () => {
-        render(
-            <CANFundingReceivedForm
-                {...defaultProps}
-                receivedFundingAmount="1000"
-            />
-        );
+    it("calls runValidate on blur", () => {
+        render(<CANFundingReceivedForm {...defaultProps} />);
+
+        fireEvent.blur(screen.getByLabelText(/Funding Received/i), {
+            target: { value: "1,000" }
+        });
+
+        expect(defaultProps.runValidate).toHaveBeenCalledWith("funding-received-amount", "1,000");
+    });
+
+    it("does not call runValidate on input change", () => {
+        const props = {
+            ...defaultProps,
+            runValidate: vi.fn(() => ({ hasErrors: () => false })),
+            clearValidationError: vi.fn()
+        };
+        render(<CANFundingReceivedForm {...props} />);
+
+        fireEvent.change(screen.getByLabelText(/Funding Received/i), {
+            target: { value: "1000" }
+        });
+
+        expect(props.runValidate).not.toHaveBeenCalled();
+    });
+
+    it("clears validation error on input change", () => {
+        const props = {
+            ...defaultProps,
+            clearValidationError: vi.fn()
+        };
+        render(<CANFundingReceivedForm {...props} />);
+
+        fireEvent.change(screen.getByLabelText(/Funding Received/i), {
+            target: { value: "1000" }
+        });
+
+        expect(props.clearValidationError).toHaveBeenCalledWith("funding-received-amount");
+    });
+
+    it("calls handleSubmit when validation passes on submit", async () => {
+        const props = {
+            ...defaultProps,
+            handleSubmit: vi.fn(),
+            runValidate: vi.fn(() => ({ hasErrors: () => false })),
+            receivedFundingAmount: "1000"
+        };
+        render(<CANFundingReceivedForm {...props} />);
 
         await user.click(screen.getByRole("button", { name: /Add Funding Received/i }));
 
-        expect(defaultProps.handleSubmit).toHaveBeenCalled();
+        expect(props.runValidate).toHaveBeenCalledWith("funding-received-amount", "1000");
+        expect(props.handleSubmit).toHaveBeenCalled();
+    });
+
+    it("blocks handleSubmit when validation fails on submit", async () => {
+        const props = {
+            ...defaultProps,
+            handleSubmit: vi.fn(),
+            runValidate: vi.fn(() => ({ hasErrors: () => true })),
+            receivedFundingAmount: "1000",
+            res: {
+                ...defaultProps.res,
+                hasErrors: vi.fn().mockReturnValue(false)
+            }
+        };
+        render(<CANFundingReceivedForm {...props} />);
+
+        await user.click(screen.getByRole("button", { name: /Add Funding Received/i }));
+
+        expect(props.runValidate).toHaveBeenCalledWith("funding-received-amount", "1000");
+        expect(props.handleSubmit).not.toHaveBeenCalled();
     });
 
     it("disables submit button when form is invalid", () => {
@@ -79,5 +140,18 @@ describe("CANFundingReceivedForm", () => {
         );
 
         expect(screen.getByRole("button", { name: /Add Funding Received/i })).toBeDisabled();
+    });
+
+    it("displays validation errors when present", () => {
+        const propsWithError = {
+            ...defaultProps,
+            res: {
+                hasErrors: vi.fn().mockReturnValue(true),
+                getErrors: vi.fn().mockReturnValue(["Amount cannot exceed FY Budget"])
+            }
+        };
+
+        render(<CANFundingReceivedForm {...propsWithError} />);
+        expect(screen.getByText("Amount cannot exceed FY Budget")).toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/cans/detail/CanFunding.hooks.js
+++ b/frontend/src/pages/cans/detail/CanFunding.hooks.js
@@ -134,6 +134,14 @@ export default function useCanFunding(
     };
 
     const [fundingReceivedForm, setFundingReceivedForm] = React.useState(initialFundingReceivedForm);
+    const [, setValidationVersion] = React.useState(0);
+
+    React.useEffect(() => {
+        const unsubscribe = suite.subscribe(() => {
+            setValidationVersion((v) => v + 1);
+        });
+        return unsubscribe;
+    }, []);
 
     const [addCanFundingBudget] = useAddCanFundingBudgetsMutation();
     const [updateCanFundingBudget] = useUpdateCanFundingBudgetMutation();
@@ -306,10 +314,7 @@ export default function useCanFunding(
         }
     };
 
-    /** @param {React.FormEvent<HTMLFormElement>} e */
-    const handleAddBudget = (e) => {
-        e.preventDefault();
-
+    const handleAddBudget = () => {
         const nextForm = {
             ...budgetForm,
             submittedAmount: budgetEnteredAmount,
@@ -555,10 +560,10 @@ export default function useCanFunding(
      * Executes validation for a specific form field
      * @param {string} name - The name of the form field to validate
      * @param {number|string} value - The value to validate for the given field
-     * @returns {void}
+     * @returns {import("vest").SuiteResult<string, string>} Vest suite result, exposing `hasErrors(name)` and `getErrors(name)`
      */
     const runValidate = (name, value) => {
-        suite.run(
+        return suite.run(
             {
                 remainingAmount: +budgetForm.submittedAmount - totalReceived + +fundingReceivedForm.originalAmount,
                 receivedFunding,
@@ -566,6 +571,15 @@ export default function useCanFunding(
             },
             name
         );
+    };
+
+    /**
+     * Clears any existing validation error for a single field without re-running validation.
+     * @param {string} name - The name of the form field whose error should be cleared
+     * @returns {void}
+     */
+    const clearValidationError = (name) => {
+        suite.resetField(name);
     };
 
     /**
@@ -606,6 +620,7 @@ export default function useCanFunding(
         handleSubmit,
         modalProps,
         runValidate,
+        clearValidationError,
         res,
         cn,
         setShowModal,

--- a/frontend/src/pages/cans/detail/CanFunding.hooks.js
+++ b/frontend/src/pages/cans/detail/CanFunding.hooks.js
@@ -344,10 +344,7 @@ export default function useCanFunding(
         });
     };
 
-    /** @param {React.FormEvent<HTMLFormElement>} e */
-    const handleAddFundingReceived = (e) => {
-        e.preventDefault();
-
+    const handleAddFundingReceived = () => {
         // Update total received first using the functional update pattern
 
         // update the table data

--- a/frontend/src/pages/cans/detail/CanFunding.hooks.test.js
+++ b/frontend/src/pages/cans/detail/CanFunding.hooks.test.js
@@ -164,7 +164,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddFundingReceived({ preventDefault: vi.fn() });
+            result.current.handleAddFundingReceived();
         });
 
         expect(result.current.totalReceived).toBe(475);
@@ -190,7 +190,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddFundingReceived({ preventDefault: vi.fn() });
+            result.current.handleAddFundingReceived();
         });
 
         expect(result.current.totalReceived).toBe(550);
@@ -244,7 +244,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddFundingReceived({ preventDefault: vi.fn() });
+            result.current.handleAddFundingReceived();
         });
 
         await waitFor(() => {
@@ -261,7 +261,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddFundingReceived({ preventDefault: vi.fn() });
+            result.current.handleAddFundingReceived();
         });
 
         await waitFor(() => {
@@ -388,7 +388,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddFundingReceived({ preventDefault: vi.fn() });
+            result.current.handleAddFundingReceived();
         });
 
         await act(async () => {
@@ -407,7 +407,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddFundingReceived({ preventDefault: vi.fn() });
+            result.current.handleAddFundingReceived();
         });
 
         const stagedTempId = result.current.enteredFundingReceived.find((f) => f.id === "TBD")?.tempId ?? "";
@@ -422,7 +422,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddFundingReceived({ preventDefault: vi.fn() });
+            result.current.handleAddFundingReceived();
         });
 
         await act(async () => {
@@ -450,7 +450,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddFundingReceived({ preventDefault: vi.fn() });
+            result.current.handleAddFundingReceived();
         });
 
         const stagedTempId = result.current.enteredFundingReceived.find((f) => f.id === "TBD")?.tempId ?? "";
@@ -511,6 +511,65 @@ describe("useCanFunding", () => {
             });
 
             expect(result.current.res.getErrors("budget-amount")).toEqual([]);
+        });
+
+        it("runValidate flags funding received above remaining FY budget and updates res", () => {
+            const { result } = renderUseCanFunding({ isEditMode: true });
+
+            act(() => {
+                result.current.handleEnteredBudgetAmount("1000");
+            });
+            act(() => {
+                result.current.handleAddBudget();
+            });
+
+            let validationResult;
+            act(() => {
+                validationResult = result.current.runValidate("funding-received-amount", "10000");
+            });
+
+            expect(validationResult.hasErrors("funding-received-amount")).toBe(true);
+            expect(result.current.res.getErrors("funding-received-amount")).toContain("Amount cannot exceed FY Budget");
+        });
+
+        it("runValidate passes when funding received is within remaining FY budget", () => {
+            const { result } = renderUseCanFunding({ isEditMode: true });
+
+            act(() => {
+                result.current.handleEnteredBudgetAmount("1000");
+            });
+            act(() => {
+                result.current.handleAddBudget();
+            });
+
+            let validationResult;
+            act(() => {
+                validationResult = result.current.runValidate("funding-received-amount", "100");
+            });
+
+            expect(validationResult.hasErrors("funding-received-amount")).toBe(false);
+            expect(result.current.res.getErrors("funding-received-amount")).toEqual([]);
+        });
+
+        it("clearValidationError removes funding-received-amount errors", () => {
+            const { result } = renderUseCanFunding({ isEditMode: true });
+
+            act(() => {
+                result.current.handleEnteredBudgetAmount("1000");
+            });
+            act(() => {
+                result.current.handleAddBudget();
+            });
+            act(() => {
+                result.current.runValidate("funding-received-amount", "10000");
+            });
+            expect(result.current.res.getErrors("funding-received-amount").length).toBeGreaterThan(0);
+
+            act(() => {
+                result.current.clearValidationError("funding-received-amount");
+            });
+
+            expect(result.current.res.getErrors("funding-received-amount")).toEqual([]);
         });
     });
 });

--- a/frontend/src/pages/cans/detail/CanFunding.hooks.test.js
+++ b/frontend/src/pages/cans/detail/CanFunding.hooks.test.js
@@ -142,7 +142,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddBudget({ preventDefault: vi.fn() });
+            result.current.handleAddBudget();
         });
 
         expect(result.current.budgetForm).toEqual({ submittedAmount: 1200, isSubmitted: true });
@@ -235,7 +235,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddBudget({ preventDefault: vi.fn() });
+            result.current.handleAddBudget();
         });
 
         act(() => {
@@ -336,7 +336,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddBudget({ preventDefault: vi.fn() });
+            result.current.handleAddBudget();
         });
 
         await act(async () => {
@@ -379,7 +379,7 @@ describe("useCanFunding", () => {
         });
 
         act(() => {
-            result.current.handleAddBudget({ preventDefault: vi.fn() });
+            result.current.handleAddBudget();
         });
 
         act(() => {
@@ -469,5 +469,48 @@ describe("useCanFunding", () => {
 
         expect(addCanFundingReceivedMock).not.toHaveBeenCalled();
         expect(deleteCanFundingReceivedMock).not.toHaveBeenCalled();
+    });
+
+    describe("validation", () => {
+        it("runValidate flags budget below received funding and updates res", () => {
+            const { result } = renderUseCanFunding();
+
+            let validationResult;
+            act(() => {
+                validationResult = result.current.runValidate("budget-amount", "100");
+            });
+
+            expect(validationResult.hasErrors("budget-amount")).toBe(true);
+            expect(result.current.res.getErrors("budget-amount")).toContain(
+                "Amount must be greater than or equal to received funding"
+            );
+        });
+
+        it("runValidate passes when budget is at or above received funding", () => {
+            const { result } = renderUseCanFunding();
+
+            let validationResult;
+            act(() => {
+                validationResult = result.current.runValidate("budget-amount", "1000");
+            });
+
+            expect(validationResult.hasErrors("budget-amount")).toBe(false);
+            expect(result.current.res.getErrors("budget-amount")).toEqual([]);
+        });
+
+        it("clearValidationError removes errors for the field and updates res", () => {
+            const { result } = renderUseCanFunding();
+
+            act(() => {
+                result.current.runValidate("budget-amount", "100");
+            });
+            expect(result.current.res.getErrors("budget-amount").length).toBeGreaterThan(0);
+
+            act(() => {
+                result.current.clearValidationError("budget-amount");
+            });
+
+            expect(result.current.res.getErrors("budget-amount")).toEqual([]);
+        });
     });
 });

--- a/frontend/src/pages/cans/detail/CanFunding.jsx
+++ b/frontend/src/pages/cans/detail/CanFunding.jsx
@@ -83,6 +83,7 @@ const CanFunding = ({
         handleSubmit,
         modalProps,
         runValidate,
+        clearValidationError,
         cn,
         res,
         setShowModal,
@@ -281,6 +282,7 @@ const CanFunding = ({
                                     fiscalYear={fiscalYear}
                                     handleAddBudget={handleAddBudget}
                                     runValidate={runValidate}
+                                    clearValidationError={clearValidationError}
                                     setBudgetAmount={handleEnteredBudgetAmount}
                                 />
                             </div>

--- a/frontend/src/pages/cans/detail/CanFunding.jsx
+++ b/frontend/src/pages/cans/detail/CanFunding.jsx
@@ -314,6 +314,7 @@ const CanFunding = ({
                                     cn={cn}
                                     res={res}
                                     runValidate={runValidate}
+                                    clearValidationError={clearValidationError}
                                     cancelFundingReceived={cancelFundingReceived}
                                 />
                             </div>


### PR DESCRIPTION
## What changed

Reworks CAN FY budget and funding received validation in the CAN detail edit flow:

### CANBudgetForm
- Validation now runs on **blur** of the budget input (not on every keystroke), so users don't see error messages while still typing.
- Validation also runs on **submit** and gates `handleAddBudget` — the budget will not be staged if the entered amount is below the received funding total.
- Errors for the field are cleared on each keystroke via a new `clearValidationError` helper (uses `suite.resetField`), giving immediate feedback that the user is fixing the issue.

### CANFundingReceivedForm
- Same blur-based validation pattern applied to the Funding Received input — validation fires on **blur** and on **submit**, not on every keystroke.
- Submit is gated: `handleAddFundingReceived` will not execute if the entered amount exceeds the remaining FY budget.
- Errors are cleared on keystroke via `clearValidationError`.

### Shared hook changes (`useCanFunding`)
- `useCanFunding` now subscribes to the vest suite so React re-renders when validation state updates outside a React state change.
- `runValidate` now returns the vest `SuiteResult` so callers can inspect `hasErrors(name)` synchronously to decide whether to proceed.
- New `clearValidationError(name)` helper exposed for clearing individual field errors without re-running validation.
- `handleAddBudget` and `handleAddFundingReceived` no longer accept the form event — `e.preventDefault()` is now handled at the form component level alongside the validation gate.

## Issue

#5570

## How to test

### FY Budget field
1. Sign in as a budget team member.
2. Navigate to a CAN detail page for the current fiscal year and enter the **Funding** edit mode.
3. Confirm the FY budget field shows the existing budget amount and that no validation error is visible on initial render.
4. In the FY budget input, enter an amount **less than** the total Funding Received YTD.
   - While typing: no error message should appear.
   - On blur (tab out / click away): the inline error _"Amount must be greater than or equal to received funding"_ should appear.
   - Click **Update FY Budget**: the form should NOT submit; the alert should not fire.
5. Edit the value to be **equal to or greater than** received funding.
   - As soon as you start typing, the prior error message should disappear.
   - Click **Update FY Budget**: the budget should stage and the success toast appear.

### Funding Received field
6. In the Funding Received input, enter an amount **greater than** the remaining FY budget.
   - While typing: no error message should appear.
   - On blur: the inline error _"Amount cannot exceed FY Budget"_ should appear.
   - Click **Add Funding Received**: the form should NOT submit.
7. Edit the value to be **within** the remaining FY budget.
   - As soon as you start typing, the prior error message should disappear.
   - Click **Add Funding Received**: the funding entry should stage successfully.
8. Repeat with empty / cleared inputs to confirm empty-case validation still fires on submit.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated