### PR TITLE
feat: add project history panel and API

### DIFF
--- a/backend/alembic/versions/2026_05_26_1000-d4f5a6b7c8e9_add_project_history_table.py
+++ b/backend/alembic/versions/2026_05_26_1000-d4f5a6b7c8e9_add_project_history_table.py
@@ -1,0 +1,71 @@
+"""add project_history table
+
+Revision ID: d4f5a6b7c8e9
+Revises: e9f8a7b6c5d4
+Create Date: 2026-05-26 10:00:00.000000+00:00
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4f5a6b7c8e9'
+down_revision: Union[str, None] = 'e9f8a7b6c5d4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PROJECT_HISTORY_TYPE_VALUES = (
+    'PROJECT_CREATED',
+    'PROJECT_TITLE_EDITED',
+    'PROJECT_SHORT_TITLE_EDITED',
+    'PROJECT_DESCRIPTION_EDITED',
+    'PROJECT_URL_EDITED',
+    'PROJECT_TYPE_EDITED',
+    'PROJECT_TEAM_LEADER_ADDED',
+    'PROJECT_TEAM_LEADER_REMOVED',
+)
+
+
+def upgrade() -> None:
+    sa.Enum(*PROJECT_HISTORY_TYPE_VALUES, name='projecthistorytype').create(op.get_bind())
+
+    op.create_table(
+        'project_history',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('project_id', sa.Integer(), nullable=True),
+        sa.Column('project_id_record', sa.Integer(), nullable=False),
+        sa.Column('ops_event_id', sa.Integer(), nullable=True),
+        sa.Column('history_title', sa.String(), nullable=False),
+        sa.Column('history_message', sa.Text(), nullable=False),
+        sa.Column('timestamp', sa.String(), nullable=False),
+        sa.Column(
+            'history_type',
+            postgresql.ENUM(*PROJECT_HISTORY_TYPE_VALUES, name='projecthistorytype', create_type=False),
+            nullable=True,
+        ),
+        sa.Column('created_by', sa.Integer(), nullable=True),
+        sa.Column('updated_by', sa.Integer(), nullable=True),
+        sa.Column('created_on', sa.DateTime(), nullable=True),
+        sa.Column('updated_on', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['project_id'], ['project.id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['ops_event_id'], ['ops_event.id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['created_by'], ['ops_user.id']),
+        sa.ForeignKeyConstraint(['updated_by'], ['ops_user.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        'ix_project_history_project_id_record',
+        'project_history',
+        ['project_id_record'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_project_history_project_id_record', table_name='project_history')
+    op.drop_table('project_history')
+    sa.Enum(*PROJECT_HISTORY_TYPE_VALUES, name='projecthistorytype').drop(op.get_bind())

--- a/backend/alembic/versions/2026_05_26_1000-d4f5a6b7c8e9_add_project_history_table.py
+++ b/backend/alembic/versions/2026_05_26_1000-d4f5a6b7c8e9_add_project_history_table.py
@@ -34,6 +34,34 @@ def upgrade() -> None:
     sa.Enum(*PROJECT_HISTORY_TYPE_VALUES, name='projecthistorytype').create(op.get_bind())
 
     op.create_table(
+        'project_history_version',
+        sa.Column('id', sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column('project_id', sa.Integer(), autoincrement=False, nullable=True),
+        sa.Column('project_id_record', sa.Integer(), autoincrement=False, nullable=True),
+        sa.Column('ops_event_id', sa.Integer(), autoincrement=False, nullable=True),
+        sa.Column('history_title', sa.String(), autoincrement=False, nullable=True),
+        sa.Column('history_message', sa.Text(), autoincrement=False, nullable=True),
+        sa.Column('timestamp', sa.String(), autoincrement=False, nullable=True),
+        sa.Column(
+            'history_type',
+            postgresql.ENUM(*PROJECT_HISTORY_TYPE_VALUES, name='projecthistorytype', create_type=False),
+            autoincrement=False,
+            nullable=True,
+        ),
+        sa.Column('created_by', sa.Integer(), autoincrement=False, nullable=True),
+        sa.Column('updated_by', sa.Integer(), autoincrement=False, nullable=True),
+        sa.Column('created_on', sa.DateTime(), autoincrement=False, nullable=True),
+        sa.Column('updated_on', sa.DateTime(), autoincrement=False, nullable=True),
+        sa.Column('transaction_id', sa.BigInteger(), autoincrement=False, nullable=False),
+        sa.Column('end_transaction_id', sa.BigInteger(), nullable=True),
+        sa.Column('operation_type', sa.SmallInteger(), nullable=False),
+        sa.PrimaryKeyConstraint('id', 'transaction_id'),
+    )
+    op.create_index(op.f('ix_project_history_version_end_transaction_id'), 'project_history_version', ['end_transaction_id'], unique=False)
+    op.create_index(op.f('ix_project_history_version_operation_type'), 'project_history_version', ['operation_type'], unique=False)
+    op.create_index(op.f('ix_project_history_version_transaction_id'), 'project_history_version', ['transaction_id'], unique=False)
+
+    op.create_table(
         'project_history',
         sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
         sa.Column('project_id', sa.Integer(), nullable=True),
@@ -68,4 +96,8 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index('ix_project_history_project_id_record', table_name='project_history')
     op.drop_table('project_history')
+    op.drop_index(op.f('ix_project_history_version_transaction_id'), table_name='project_history_version')
+    op.drop_index(op.f('ix_project_history_version_operation_type'), table_name='project_history_version')
+    op.drop_index(op.f('ix_project_history_version_end_transaction_id'), table_name='project_history_version')
+    op.drop_table('project_history_version')
     sa.Enum(*PROJECT_HISTORY_TYPE_VALUES, name='projecthistorytype').drop(op.get_bind())

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -16,6 +16,7 @@ from .procurement_shops import *
 from .procurement_tracker import *
 from .procurement_action import *
 from .projects import *
+from .project_history import *
 from .services_components import *
 from .users import *
 from .vendors import *

--- a/backend/models/project_history.py
+++ b/backend/models/project_history.py
@@ -261,17 +261,21 @@ def create_project_update_history_event(
 
 def add_history_events(events: List[ProjectHistory], session: Session) -> None:
     """Add ProjectHistory events to the session, skipping any that look like duplicates of existing rows."""
+    if not events:
+        return
+
+    project_id_record = events[0].project_id_record
+    existing_items = (
+        session.query(ProjectHistory)
+        .where(ProjectHistory.project_id_record == project_id_record)
+        .all()
+    )
+
+    for item in session.new:
+        if isinstance(item, ProjectHistory) and item.project_id_record == project_id_record:
+            existing_items.append(item)
+
     for event in events:
-        existing_items = (
-            session.query(ProjectHistory)
-            .where(ProjectHistory.project_id_record == event.project_id_record)
-            .all()
-        )
-
-        for item in session.new:
-            if isinstance(item, ProjectHistory) and item.project_id_record == event.project_id_record:
-                existing_items.append(item)
-
         duplicate_found = False
         for item in existing_items:
             if (
@@ -284,6 +288,7 @@ def add_history_events(events: List[ProjectHistory], session: Session) -> None:
 
         if not duplicate_found:
             session.add(event)
+            existing_items.append(event)
 
 
 def is_timespan_within_one_minute(datetime_to_check: str, reference_datetime: str) -> bool:

--- a/backend/models/project_history.py
+++ b/backend/models/project_history.py
@@ -1,0 +1,298 @@
+from datetime import datetime
+from enum import Enum, auto
+from typing import List, Optional
+
+from loguru import logger
+from sqlalchemy import ForeignKey, Integer, Text
+from sqlalchemy.dialects.postgresql import ENUM
+from sqlalchemy.orm import Mapped, Session, mapped_column
+
+from models import (
+    OpsEvent,
+    OpsEventStatus,
+    OpsEventType,
+    Project,
+    ProjectType,
+    User,
+)
+from models.base import BaseModel
+
+
+class ProjectHistoryType(Enum):
+    PROJECT_CREATED = auto()
+    PROJECT_TITLE_EDITED = auto()
+    PROJECT_SHORT_TITLE_EDITED = auto()
+    PROJECT_DESCRIPTION_EDITED = auto()
+    PROJECT_URL_EDITED = auto()
+    PROJECT_TYPE_EDITED = auto()
+    PROJECT_TEAM_LEADER_ADDED = auto()
+    PROJECT_TEAM_LEADER_REMOVED = auto()
+
+
+class ProjectHistory(BaseModel):
+    __tablename__ = "project_history"
+
+    id: Mapped[int] = BaseModel.get_pk_column()
+    project_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("project.id", ondelete="SET NULL"), nullable=True
+    )
+    project_id_record: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    ops_event_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("ops_event.id", ondelete="SET NULL"), nullable=True
+    )
+    history_title: Mapped[str]
+    history_message: Mapped[str] = mapped_column(Text)
+    timestamp: Mapped[str]
+    history_type: Mapped[ProjectHistoryType] = mapped_column(ENUM(ProjectHistoryType), nullable=True)
+
+
+_PROJECT_TYPE_DISPLAY = {
+    ProjectType.RESEARCH.name: "Research",
+    ProjectType.ADMINISTRATIVE_AND_SUPPORT.name: "Admin & Support",
+}
+
+
+def _project_type_display(value) -> str:
+    """Render a project type code (string or ProjectType) as a human-readable label."""
+    if value is None:
+        return "None"
+    if isinstance(value, ProjectType):
+        return _PROJECT_TYPE_DISPLAY.get(value.name, value.name)
+    return _PROJECT_TYPE_DISPLAY.get(str(value), str(value))
+
+
+def project_history_trigger_func(
+    event: OpsEvent,
+    session: Session,
+    system_user: User,
+    dry_run: bool = False,
+) -> None:
+    """Trigger function that builds ProjectHistory rows from CREATE_PROJECT and UPDATE_PROJECT events."""
+    if event.event_status == OpsEventStatus.FAILED or event.event_status == OpsEventStatus.UNKNOWN:
+        return
+
+    logger.debug(f"Handling event {event.event_type} with details: {event.event_details}")
+    assert session is not None
+
+    event_user = session.get(User, event.created_by)
+    if event_user is None:
+        event_user = User(id=-1, full_name="Unknown User")
+        logger.error(f"Event user for event {event.id} is None. Using placeholder user.")
+    updated_by_system_user = system_user.id == event_user.id
+    timestamp = event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    history_events: List[ProjectHistory] = []
+
+    match event.event_type:
+        case OpsEventType.CREATE_PROJECT:
+            new_project = event.event_details.get("new_project") if event.event_details else None
+            if new_project and new_project.get("id") is not None:
+                project_id = new_project["id"]
+                history_events.append(
+                    ProjectHistory(
+                        project_id=project_id,
+                        project_id_record=project_id,
+                        ops_event_id=event.id,
+                        history_title="Project Created",
+                        history_message=(
+                            "Changes made to the OPRE budget spreadsheet created a new project."
+                            if updated_by_system_user
+                            else f"Project created by {event_user.full_name}."
+                        ),
+                        timestamp=timestamp,
+                        history_type=ProjectHistoryType.PROJECT_CREATED,
+                    )
+                )
+        case OpsEventType.UPDATE_PROJECT:
+            project_updates = event.event_details.get("project_updates") if event.event_details else None
+            if project_updates:
+                owner_id = project_updates.get("owner_id")
+                changes = project_updates.get("changes", {}) or {}
+                for property_name, change in changes.items():
+                    history_item = create_project_update_history_event(
+                        property_name,
+                        change.get("old_value"),
+                        change.get("new_value"),
+                        event_user,
+                        timestamp,
+                        owner_id,
+                        event.id,
+                        session,
+                        system_user,
+                    )
+                    if history_item is not None:
+                        history_events.append(history_item)
+
+                team_leader_changes = project_updates.get("team_leader_changes") or {}
+                for added_user_id in team_leader_changes.get("user_ids_added", []) or []:
+                    added_user = session.get(User, added_user_id)
+                    added_name = added_user.full_name if added_user else f"user {added_user_id}"
+                    history_events.append(
+                        ProjectHistory(
+                            project_id=owner_id,
+                            project_id_record=owner_id,
+                            ops_event_id=event.id,
+                            history_title="Change to Team Leaders",
+                            history_message=f"{event_user.full_name} added team leader {added_name}.",
+                            timestamp=timestamp,
+                            history_type=ProjectHistoryType.PROJECT_TEAM_LEADER_ADDED,
+                        )
+                    )
+                for removed_user_id in team_leader_changes.get("user_ids_removed", []) or []:
+                    removed_user = session.get(User, removed_user_id)
+                    removed_name = removed_user.full_name if removed_user else f"user {removed_user_id}"
+                    history_events.append(
+                        ProjectHistory(
+                            project_id=owner_id,
+                            project_id_record=owner_id,
+                            ops_event_id=event.id,
+                            history_title="Change to Team Leaders",
+                            history_message=f"{event_user.full_name} removed team leader {removed_name}.",
+                            timestamp=timestamp,
+                            history_type=ProjectHistoryType.PROJECT_TEAM_LEADER_REMOVED,
+                        )
+                    )
+
+    history_events = [e for e in history_events if e.project_id_record is not None]
+    add_history_events(history_events, session)
+    if not dry_run:
+        session.commit()
+
+
+def create_project_update_history_event(
+    property_name: str,
+    old_value,
+    new_value,
+    updated_by_user: User,
+    updated_on: str,
+    project_id: int,
+    ops_event_id: int,
+    session: Session,
+    sys_user: User,
+) -> Optional[ProjectHistory]:
+    """Generate a ProjectHistory event for a single updated property. Returns None if the property is not handled."""
+    updated_by_system_user = sys_user.id == updated_by_user.id
+
+    project = session.get(Project, project_id) if project_id is not None else None
+    project_id_for_fk = project.id if project else None
+
+    match property_name:
+        case "title":
+            return ProjectHistory(
+                project_id=project_id_for_fk,
+                project_id_record=project_id,
+                ops_event_id=ops_event_id,
+                history_title="Change to Project Title",
+                history_message=(
+                    f"Changes made to the OPRE budget spreadsheet changed the Project Title from {old_value} to {new_value}."
+                    if updated_by_system_user
+                    else f"{updated_by_user.full_name} changed the Project Title from {old_value} to {new_value}."
+                ),
+                timestamp=updated_on,
+                history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+            )
+        case "short_title":
+            old_short = old_value if old_value else "TBD"
+            new_short = new_value if new_value else "TBD"
+            return ProjectHistory(
+                project_id=project_id_for_fk,
+                project_id_record=project_id,
+                ops_event_id=ops_event_id,
+                history_title="Change to Project Nickname",
+                history_message=(
+                    f"Changes made to the OPRE budget spreadsheet changed the Project Nickname from {old_short} to {new_short}."
+                    if updated_by_system_user
+                    else f"{updated_by_user.full_name} changed the Project Nickname from {old_short} to {new_short}."
+                ),
+                timestamp=updated_on,
+                history_type=ProjectHistoryType.PROJECT_SHORT_TITLE_EDITED,
+            )
+        case "description":
+            return ProjectHistory(
+                project_id=project_id_for_fk,
+                project_id_record=project_id,
+                ops_event_id=ops_event_id,
+                history_title="Change to Description",
+                history_message=(
+                    "Changes made to the OPRE budget spreadsheet changed the Project Description."
+                    if updated_by_system_user
+                    else f"{updated_by_user.full_name} changed the Project Description."
+                ),
+                timestamp=updated_on,
+                history_type=ProjectHistoryType.PROJECT_DESCRIPTION_EDITED,
+            )
+        case "url":
+            old_url = old_value if old_value else "None"
+            new_url = new_value if new_value else "None"
+            return ProjectHistory(
+                project_id=project_id_for_fk,
+                project_id_record=project_id,
+                ops_event_id=ops_event_id,
+                history_title="Change to URL",
+                history_message=(
+                    f"Changes made to the OPRE budget spreadsheet changed the URL from {old_url} to {new_url}."
+                    if updated_by_system_user
+                    else f"{updated_by_user.full_name} changed the URL from {old_url} to {new_url}."
+                ),
+                timestamp=updated_on,
+                history_type=ProjectHistoryType.PROJECT_URL_EDITED,
+            )
+        case "project_type":
+            old_label = _project_type_display(old_value)
+            new_label = _project_type_display(new_value)
+            return ProjectHistory(
+                project_id=project_id_for_fk,
+                project_id_record=project_id,
+                ops_event_id=ops_event_id,
+                history_title="Change to Project Type",
+                history_message=(
+                    f"Changes made to the OPRE budget spreadsheet changed the Project Type from {old_label} to {new_label}."
+                    if updated_by_system_user
+                    else f"{updated_by_user.full_name} changed the Project Type from {old_label} to {new_label}."
+                ),
+                timestamp=updated_on,
+                history_type=ProjectHistoryType.PROJECT_TYPE_EDITED,
+            )
+        case _:
+            logger.info(
+                f"{property_name} edited by {updated_by_user.full_name} from {old_value} to {new_value}"
+            )
+            return None
+
+
+def add_history_events(events: List[ProjectHistory], session: Session) -> None:
+    """Add ProjectHistory events to the session, skipping any that look like duplicates of existing rows."""
+    for event in events:
+        existing_items = (
+            session.query(ProjectHistory)
+            .where(ProjectHistory.project_id_record == event.project_id_record)
+            .all()
+        )
+
+        for item in session.new:
+            if isinstance(item, ProjectHistory) and item.project_id_record == event.project_id_record:
+                existing_items.append(item)
+
+        duplicate_found = False
+        for item in existing_items:
+            if (
+                is_timespan_within_one_minute(event.timestamp, item.timestamp)
+                and item.history_type == event.history_type
+                and item.history_message == event.history_message
+            ):
+                duplicate_found = True
+                break
+
+        if not duplicate_found:
+            session.add(event)
+
+
+def is_timespan_within_one_minute(datetime_to_check: str, reference_datetime: str) -> bool:
+    """Check if two ISO format timestamp strings are within one minute of each other."""
+    try:
+        datetime_to_check_dt = datetime.fromisoformat(datetime_to_check.replace("Z", "+00:00"))
+        reference_datetime_dt = datetime.fromisoformat(reference_datetime.replace("Z", "+00:00"))
+        difference = abs((datetime_to_check_dt - reference_datetime_dt).total_seconds())
+        return difference <= 60
+    except ValueError as e:
+        logger.error(f"Error parsing timespan strings: {e}")
+        return False

--- a/backend/models/utils/__init__.py
+++ b/backend/models/utils/__init__.py
@@ -240,3 +240,55 @@ def generate_agreement_events_update(old_serialized_obj, new_serialized_obj, own
             "research_methodologies_ids_added": added_research_methodologies,
         }
     return updates
+
+
+def _extract_team_leader_ids(team_leaders) -> set:
+    """Pull team-leader IDs out of either a list of dicts or a list of ints. Filters out missing IDs."""
+    ids = set()
+    for entry in team_leaders or []:
+        if isinstance(entry, dict):
+            tl_id = entry.get("id")
+        else:
+            tl_id = entry
+        if tl_id is not None:
+            ids.add(tl_id)
+    return ids
+
+
+def generate_project_events_update(old_serialized_obj, new_serialized_obj, owner_id, updated_by_id):
+    """Generates updates for project events, including scalar property diffs and team-leader add/remove."""
+    updates = generate_events_update(old_serialized_obj, new_serialized_obj, owner_id, updated_by_id)
+
+    # Drop changes for fields that are derived/computed and not user-editable on the project itself.
+    # These show up in DeepDiff because the metadata changes between fetches but should not generate history.
+    derived_fields = {
+        "project_metadata",
+        "special_topics",
+        "research_methodologies",
+        "team_members",
+        "division_directors",
+        "project_officers",
+        "alternate_project_officers",
+        "project_start",
+        "project_end",
+        "created_on",
+        "updated_on",
+        "_meta",
+    }
+    if updates.get("changes"):
+        updates["changes"] = {k: v for k, v in updates["changes"].items() if k not in derived_fields}
+
+    old_team_leader_ids = _extract_team_leader_ids(old_serialized_obj.get("team_leaders"))
+    new_team_leader_ids = _extract_team_leader_ids(new_serialized_obj.get("team_leaders"))
+    removed = sorted(old_team_leader_ids - new_team_leader_ids)
+    added = sorted(new_team_leader_ids - old_team_leader_ids)
+
+    if removed or added:
+        updates["team_leader_changes"] = {
+            "user_ids_removed": removed,
+            "user_ids_added": added,
+        }
+    # team_leaders itself can show up in changes via DeepDiff; remove it since the diff is captured above.
+    if updates.get("changes"):
+        updates["changes"].pop("team_leaders", None)
+    return updates

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -3783,6 +3783,51 @@ paths:
         "404":
           description: Not Found - Project does not exist
 
+  /projects/{id}/history/:
+    get:
+      tags:
+        - Project History
+      operationId: getAllProjectHistory
+      summary: Get a paginated list of Project history items, sorted by timestamp newest first by default
+      parameters:
+        - $ref: "#/components/parameters/simulatedError"
+        - in: path
+          name: id
+          description: Project Id
+          required: true
+          schema:
+            type: integer
+          example: 1000
+        - name: offset
+          in: query
+          schema:
+            type: integer
+          example: 0
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+          example: 10
+        - name: sort_asc
+          in: query
+          description: Optional parameter that sets whether to sort the results in ascending (oldest to newest) order
+          schema:
+            type: boolean
+          example: true
+      description: Get ProjectHistory entries for a project.
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProjectHistoryList"
+        "401":
+          description: Insufficient Privileges to use this endpoint.
+        "403":
+          description: Forbidden
+
   /projects-filters/:
     get:
       tags:
@@ -5747,6 +5792,84 @@ components:
         - id
         - can_id
         - ops_event_id
+    ProjectHistoryList:
+      description: Paginated list of Project history items
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProjectHistoryItem"
+        count:
+          type: integer
+          description: Total number of history items matching the query
+          example: 25
+        limit:
+          type: integer
+          description: Maximum number of items returned
+          example: 10
+        offset:
+          type: integer
+          description: Number of items skipped
+          example: 0
+      required:
+        - data
+        - count
+        - limit
+        - offset
+    ProjectHistoryItem:
+      description: A single Project history record
+      type: object
+      properties:
+        id:
+          type: integer
+          description: The unique identifier for the history record.
+          example: 2
+        project_id:
+          type: integer
+          nullable: true
+          description: FK to the Project (null if the project has been deleted).
+          example: 1000
+        project_id_record:
+          type: integer
+          description: Stable Project id reference that survives deletion.
+          example: 1000
+        ops_event_id:
+          type: integer
+          nullable: true
+          description: FK to the OPS event that triggered the history record.
+          example: 4
+        history_title:
+          type: string
+          description: Short title of the history event.
+          example: "Change to Project Title"
+        history_message:
+          type: string
+          description: Human-readable description of the history event in Markdown format.
+          example: "Amelia Popham changed the Project Title from Foo to Bar."
+        timestamp:
+          type: string
+          description: The timestamp of when the history event was created.
+          format: date-time
+          example: "2026-05-26T12:00:00.000000Z"
+        history_type:
+          type: string
+          enum:
+            - PROJECT_CREATED
+            - PROJECT_TITLE_EDITED
+            - PROJECT_SHORT_TITLE_EDITED
+            - PROJECT_DESCRIPTION_EDITED
+            - PROJECT_URL_EDITED
+            - PROJECT_TYPE_EDITED
+            - PROJECT_TEAM_LEADER_ADDED
+            - PROJECT_TEAM_LEADER_REMOVED
+          example: "PROJECT_TITLE_EDITED"
+      required:
+        - id
+        - project_id_record
+        - history_title
+        - history_message
+        - timestamp
     FundingReceived:
       description: Funding Received Object
       type: object

--- a/backend/ops_api/ops/__init__.py
+++ b/backend/ops_api/ops/__init__.py
@@ -29,6 +29,7 @@ from ops_api.ops.home_page.views import home
 from ops_api.ops.services.agreement_messages import agreement_history_trigger
 from ops_api.ops.services.can_messages import can_history_trigger
 from ops_api.ops.services.message_bus import MessageBus
+from ops_api.ops.services.project_messages import project_history_trigger
 from ops_api.ops.urls import register_api
 from ops_api.ops.utils.api_helpers import is_deployed_system
 from ops_api.ops.utils.core import is_fake_user, is_unit_test
@@ -242,6 +243,10 @@ def initialize_event_subscriptions():
     MessageBus.subscribe_globally(OpsEventType.UPDATE_SERVICES_COMPONENT, agreement_history_trigger)
     MessageBus.subscribe_globally(OpsEventType.DELETE_SERVICES_COMPONENT, agreement_history_trigger)
     MessageBus.subscribe_globally(OpsEventType.UPDATE_PROCUREMENT_TRACKER_STEP, agreement_history_trigger)
+
+    # Subscribe to events that should generate project history events
+    MessageBus.subscribe_globally(OpsEventType.CREATE_PROJECT, project_history_trigger)
+    MessageBus.subscribe_globally(OpsEventType.UPDATE_PROJECT, project_history_trigger)
 
 
 def before_request_function(app: Flask, request: request):

--- a/backend/ops_api/ops/resources/project_history.py
+++ b/backend/ops_api/ops/resources/project_history.py
@@ -1,0 +1,36 @@
+from flask import Response, request
+
+from ops_api.ops.auth.auth_types import Permission, PermissionType
+from ops_api.ops.auth.decorators import is_authorized
+from ops_api.ops.base_views import BaseListAPI
+from ops_api.ops.schemas.project_history import (
+    GetProjectHistoryListQueryParametersSchema,
+    ProjectHistoryItemSchema,
+)
+from ops_api.ops.services.project_history import ProjectHistoryService
+from ops_api.ops.utils.response import make_response_with_headers
+
+
+class ProjectHistoryListAPI(BaseListAPI):
+    def __init__(self, model):
+        super().__init__(model)
+        self.service = ProjectHistoryService()
+        self._get_schema = GetProjectHistoryListQueryParametersSchema()
+
+    @is_authorized(PermissionType.GET, Permission.HISTORY)
+    def get(self, id: int) -> Response:
+        data = self._get_schema.dump(self._get_schema.load(request.args))
+        result, metadata = self.service.get(
+            id,
+            data.get("limit"),
+            data.get("offset"),
+            data.get("sort_asc"),
+        )
+        project_history_schema = ProjectHistoryItemSchema()
+        response_data = {
+            "data": [project_history_schema.dump(project_history) for project_history in result],
+            "count": metadata["count"],
+            "limit": metadata["limit"],
+            "offset": metadata["offset"],
+        }
+        return make_response_with_headers(response_data)

--- a/backend/ops_api/ops/resources/projects.py
+++ b/backend/ops_api/ops/resources/projects.py
@@ -5,6 +5,7 @@ from typing_extensions import List
 from models import AdministrativeAndSupportProject, Project, ProjectType, ResearchProject
 from models.base import BaseModel
 from models.events import OpsEventType
+from models.utils import generate_project_events_update
 from models.utils.fiscal_year import get_current_fiscal_year
 from ops_api.ops.auth.auth_types import Permission, PermissionType
 from ops_api.ops.auth.decorators import is_authorized
@@ -26,6 +27,18 @@ from ops_api.ops.services.projects import ProjectsService
 from ops_api.ops.utils.events import OpsEventHandler
 from ops_api.ops.utils.projects_helpers import check_project_user_association
 from ops_api.ops.utils.response import make_response_with_headers
+
+
+def _dump_project_for_history(project: Project) -> dict:
+    """Serialize a project for use in OpsEvent payloads. Uses the type-specific response schema, minus _meta."""
+    match project.project_type:
+        case ProjectType.RESEARCH:
+            schema = ResearchProjectResponse(exclude=["_meta"])
+        case ProjectType.ADMINISTRATIVE_AND_SUPPORT:
+            schema = ProjectResponse(exclude=["_meta"])
+        case _:
+            schema = ProjectResponse(exclude=["_meta"])
+    return schema.dump(project)
 
 
 class ProjectItemAPI(BaseItemAPI):
@@ -61,8 +74,20 @@ class ProjectItemAPI(BaseItemAPI):
             request_schema = ProjectUpdateRequestSchema(partial=True)
             data = request_schema.load(request.json)
             service = ProjectsService(current_app.db_session)
+
+            old_project = service.get(id)
+            old_serialized_project = _dump_project_for_history(old_project)
+
             updated_project, status_code = service.update(id, data)
-            meta.metadata.update({"updated_project": updated_project.to_dict()})
+            new_serialized_project = _dump_project_for_history(updated_project)
+
+            updates = generate_project_events_update(
+                old_serialized_project,
+                new_serialized_project,
+                updated_project.id,
+                updated_project.updated_by,
+            )
+            meta.metadata.update({"project_updates": updates})
             return make_response_with_headers({"id": updated_project.id}, status_code)
 
 
@@ -108,7 +133,7 @@ class ProjectListAPI(BaseListAPI):
                 return make_response_with_headers({}, 400)
             service = ProjectsService(current_app.db_session)
             project = service.create(data)
-            meta.metadata.update({"new_project": project.to_dict()})
+            meta.metadata.update({"new_project": {"id": project.id}})
             return make_response_with_headers({"id": project.id}, 201)
 
 

--- a/backend/ops_api/ops/schemas/project_history.py
+++ b/backend/ops_api/ops/schemas/project_history.py
@@ -1,0 +1,19 @@
+from marshmallow import Schema, fields
+
+from models import ProjectHistoryType
+from ops_api.ops.schemas.pagination import PaginationSchema
+
+
+class ProjectHistoryItemSchema(Schema):
+    id = fields.Integer(required=True)
+    project_id = fields.Integer(allow_none=True)
+    project_id_record = fields.Integer(required=True)
+    ops_event_id = fields.Integer(allow_none=True)
+    history_title = fields.String(required=True)
+    history_message = fields.String(required=True)
+    timestamp = fields.String(required=True)
+    history_type = fields.Enum(ProjectHistoryType)
+
+
+class GetProjectHistoryListQueryParametersSchema(PaginationSchema):
+    sort_asc = fields.Boolean(load_default=False, dump_default=False)

--- a/backend/ops_api/ops/services/project_history.py
+++ b/backend/ops_api/ops/services/project_history.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+from flask import current_app
+from sqlalchemy import func, select
+
+from models import ProjectHistory
+
+
+class ProjectHistoryService:
+    def get(self, project_id, limit, offset, sort_ascending: bool = False) -> tuple[list[ProjectHistory], dict]:
+        """Get a paginated list of Project History items for a single project."""
+        stmt = select(ProjectHistory).where(ProjectHistory.project_id_record == project_id)
+
+        count_stmt = select(func.count()).select_from(stmt.subquery())
+        total_count = current_app.db_session.scalar(count_stmt) or 0
+
+        if sort_ascending:
+            stmt = stmt.order_by(ProjectHistory.timestamp)
+        else:
+            stmt = stmt.order_by(ProjectHistory.timestamp.desc())
+        stmt = stmt.offset(offset).limit(limit)
+        results = current_app.db_session.execute(stmt).all()
+        items = [project_history for result in results for project_history in result]
+        return items, {"count": total_count, "limit": limit, "offset": offset}
+
+    def create(self, create_request: dict[str, Any]) -> ProjectHistory:
+        """Required by OpsService protocol but not implemented yet."""
+        raise NotImplementedError("Method not implemented")
+
+    def update(self, id: int, updated_fields: dict[str, Any]) -> tuple[ProjectHistory, int]:
+        """Required by OpsService protocol but not implemented yet."""
+        raise NotImplementedError("Method not implemented")
+
+    def delete(self, id: int) -> None:
+        """Required by OpsService protocol but not implemented yet."""
+        raise NotImplementedError("Method not implemented")

--- a/backend/ops_api/ops/services/project_messages.py
+++ b/backend/ops_api/ops/services/project_messages.py
@@ -1,0 +1,18 @@
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from models import OpsEvent, project_history_trigger_func
+from ops_api.ops.utils.users import get_sys_user
+
+
+def project_history_trigger(
+    event: OpsEvent,
+    session: Session,
+):
+    try:
+        sys_user = get_sys_user(session)
+        # Pass dry_run=True to prevent subscriber from committing
+        # The outer transaction will handle the commit
+        project_history_trigger_func(event, session, sys_user, dry_run=True)
+    except Exception as e:
+        logger.error(f"Error in project_history_trigger: {e}")

--- a/backend/ops_api/ops/urls.py
+++ b/backend/ops_api/ops/urls.py
@@ -58,6 +58,7 @@ from ops_api.ops.views import (
     PRODUCT_SERVICE_CODE_ITEM_API_VIEW_FUNC,
     PRODUCT_SERVICE_CODE_LIST_API_VIEW_FUNC,
     PROJECT_FUNDING_API_VIEW_FUNC,
+    PROJECT_HISTORY_LIST_API_VIEW_FUNC,
     PROJECT_ITEM_API_VIEW_FUNC,
     PROJECT_LIST_API_VIEW_FUNC,
     PROJECT_LIST_FILTER_OPTION_API_VIEW_FUNC,
@@ -253,6 +254,10 @@ def register_api(api_bp: Blueprint) -> None:
     api_bp.add_url_rule(
         "/projects/<int:id>/spending/",
         view_func=PROJECT_SPENDING_ITEM_API_VIEW_FUNC,
+    )
+    api_bp.add_url_rule(
+        "/projects/<int:id>/history/",
+        view_func=PROJECT_HISTORY_LIST_API_VIEW_FUNC,
     )
 
     api_bp.add_url_rule(

--- a/backend/ops_api/ops/views.py
+++ b/backend/ops_api/ops/views.py
@@ -21,6 +21,7 @@ from models import (
     ProcurementTrackerStep,
     ProductServiceCode,
     Project,
+    ProjectHistory,
     ResearchMethodology,
     ResearchType,
     ServicesComponent,
@@ -110,6 +111,7 @@ from ops_api.ops.resources.product_service_code import (
     ProductServiceCodeItemAPI,
     ProductServiceCodeListAPI,
 )
+from ops_api.ops.resources.project_history import ProjectHistoryListAPI
 from ops_api.ops.resources.projects import ProjectFundingAPI, ProjectItemAPI, ProjectListAPI, ProjectListFilterOptionAPI
 from ops_api.ops.resources.projects_spending import ProjectSpendingItemAPI
 from ops_api.ops.resources.reporting_summary import ReportingSummaryListAPI
@@ -246,6 +248,7 @@ PROJECT_LIST_API_VIEW_FUNC = ProjectListAPI.as_view("projects-group", Project)
 PROJECT_LIST_FILTER_OPTION_API_VIEW_FUNC = ProjectListFilterOptionAPI.as_view("projects-filters", Project)
 PROJECT_SPENDING_ITEM_API_VIEW_FUNC = ProjectSpendingItemAPI.as_view("projects-spending-item", Project)
 PROJECT_FUNDING_API_VIEW_FUNC = ProjectFundingAPI.as_view("projects-funding", Project)
+PROJECT_HISTORY_LIST_API_VIEW_FUNC = ProjectHistoryListAPI.as_view("project-history", ProjectHistory)
 
 RESEARCH_METHODOLOGY_ITEM_API_VIEW_FUNC = ResearchMethodologyItemAPI.as_view(
     "research-methodology-item", ResearchMethodology

--- a/backend/ops_api/tests/ops/project_history/test_project_history.py
+++ b/backend/ops_api/tests/ops/project_history/test_project_history.py
@@ -1,0 +1,688 @@
+from datetime import datetime, timedelta
+
+from sqlalchemy import select
+
+from models import (
+    OpsEvent,
+    OpsEventStatus,
+    OpsEventType,
+    Project,
+    ProjectHistory,
+    ProjectHistoryType,
+    User,
+)
+from models.project_history import add_history_events
+from ops_api.ops.services.project_history import ProjectHistoryService
+from ops_api.ops.services.project_messages import project_history_trigger
+from ops_api.ops.utils.users import get_sys_user
+
+TEST_PROJECT_ID = 1000
+TEST_USER_ID = 503  # Amelia Popham
+TIMESTAMP_FMT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(loaded_db, event_type, event_details, created_by=TEST_USER_ID):
+    """Create, flush, and re-fetch an OpsEvent so created_by/created_on are populated."""
+    ops_event = OpsEvent(
+        event_type=event_type,
+        event_status=OpsEventStatus.SUCCESS,
+        created_by=created_by,
+        event_details=event_details,
+    )
+    loaded_db.add(ops_event)
+    loaded_db.flush()
+    loaded_db.commit()
+    return loaded_db.query(OpsEvent).filter(OpsEvent.id == ops_event.id).one()
+
+
+def _history_for_event(loaded_db, ops_event_id):
+    return (
+        loaded_db.query(ProjectHistory)
+        .where(ProjectHistory.ops_event_id == ops_event_id)
+        .order_by(ProjectHistory.id)
+        .all()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trigger tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_project_history_trigger(loaded_db, app_ctx):
+    project = loaded_db.get(Project, TEST_PROJECT_ID)
+    assert project is not None
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.CREATE_PROJECT,
+        {"new_project": {"id": project.id, "title": project.title}},
+    )
+
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert len(items) == 1
+    assert items[0].history_type == ProjectHistoryType.PROJECT_CREATED
+    assert items[0].history_title == "Project Created"
+    assert items[0].project_id_record == project.id
+    user = loaded_db.get(User, TEST_USER_ID)
+    assert items[0].history_message == f"Project created by {user.full_name}."
+
+
+def test_create_project_history_trigger_system_user(loaded_db, app_ctx):
+    project = loaded_db.get(Project, TEST_PROJECT_ID)
+    sys_user = get_sys_user(loaded_db)
+    assert sys_user is not None, "System admin user must exist in seed data"
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.CREATE_PROJECT,
+        {"new_project": {"id": project.id}},
+        created_by=sys_user.id,
+    )
+
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert len(items) == 1
+    assert items[0].history_message == "Changes made to the OPRE budget spreadsheet created a new project."
+
+
+def test_update_project_title_trigger(loaded_db, app_ctx):
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.UPDATE_PROJECT,
+        {
+            "project_updates": {
+                "owner_id": TEST_PROJECT_ID,
+                "updated_by": TEST_USER_ID,
+                "changes": {
+                    "title": {"old_value": "Old Title", "new_value": "New Title"},
+                },
+            }
+        },
+    )
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert len(items) == 1
+    assert items[0].history_type == ProjectHistoryType.PROJECT_TITLE_EDITED
+    assert items[0].history_title == "Change to Project Title"
+    user = loaded_db.get(User, TEST_USER_ID)
+    assert items[0].history_message == f"{user.full_name} changed the Project Title from Old Title to New Title."
+
+
+def test_update_project_short_title_trigger_renders_tbd(loaded_db, app_ctx):
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.UPDATE_PROJECT,
+        {
+            "project_updates": {
+                "owner_id": TEST_PROJECT_ID,
+                "updated_by": TEST_USER_ID,
+                "changes": {
+                    "short_title": {"old_value": None, "new_value": "Nick"},
+                },
+            }
+        },
+    )
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert len(items) == 1
+    assert items[0].history_type == ProjectHistoryType.PROJECT_SHORT_TITLE_EDITED
+    user = loaded_db.get(User, TEST_USER_ID)
+    assert items[0].history_message == f"{user.full_name} changed the Project Nickname from TBD to Nick."
+
+
+def test_update_project_description_trigger(loaded_db, app_ctx):
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.UPDATE_PROJECT,
+        {
+            "project_updates": {
+                "owner_id": TEST_PROJECT_ID,
+                "updated_by": TEST_USER_ID,
+                "changes": {
+                    "description": {"old_value": "Old desc", "new_value": "New desc"},
+                },
+            }
+        },
+    )
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert len(items) == 1
+    assert items[0].history_type == ProjectHistoryType.PROJECT_DESCRIPTION_EDITED
+    user = loaded_db.get(User, TEST_USER_ID)
+    assert items[0].history_message == f"{user.full_name} changed the Project Description."
+
+
+def test_update_project_url_trigger(loaded_db, app_ctx):
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.UPDATE_PROJECT,
+        {
+            "project_updates": {
+                "owner_id": TEST_PROJECT_ID,
+                "updated_by": TEST_USER_ID,
+                "changes": {
+                    "url": {"old_value": None, "new_value": "https://example.com"},
+                },
+            }
+        },
+    )
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert len(items) == 1
+    assert items[0].history_type == ProjectHistoryType.PROJECT_URL_EDITED
+    user = loaded_db.get(User, TEST_USER_ID)
+    assert items[0].history_message == f"{user.full_name} changed the URL from None to https://example.com."
+
+
+def test_update_project_type_trigger(loaded_db, app_ctx):
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.UPDATE_PROJECT,
+        {
+            "project_updates": {
+                "owner_id": TEST_PROJECT_ID,
+                "updated_by": TEST_USER_ID,
+                "changes": {
+                    "project_type": {
+                        "old_value": "RESEARCH",
+                        "new_value": "ADMINISTRATIVE_AND_SUPPORT",
+                    },
+                },
+            }
+        },
+    )
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert len(items) == 1
+    assert items[0].history_type == ProjectHistoryType.PROJECT_TYPE_EDITED
+    user = loaded_db.get(User, TEST_USER_ID)
+    assert items[0].history_message == f"{user.full_name} changed the Project Type from Research to Admin & Support."
+
+
+def test_update_project_team_leader_added_and_removed_trigger(loaded_db, app_ctx):
+    added_user = loaded_db.get(User, 504)
+    removed_user = loaded_db.get(User, 505)
+    assert added_user is not None and removed_user is not None
+
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.UPDATE_PROJECT,
+        {
+            "project_updates": {
+                "owner_id": TEST_PROJECT_ID,
+                "updated_by": TEST_USER_ID,
+                "changes": {},
+                "team_leader_changes": {
+                    "user_ids_added": [added_user.id],
+                    "user_ids_removed": [removed_user.id],
+                },
+            }
+        },
+    )
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert len(items) == 2
+    types = {item.history_type for item in items}
+    assert ProjectHistoryType.PROJECT_TEAM_LEADER_ADDED in types
+    assert ProjectHistoryType.PROJECT_TEAM_LEADER_REMOVED in types
+    user = loaded_db.get(User, TEST_USER_ID)
+    messages = {item.history_message for item in items}
+    assert f"{user.full_name} added team leader {added_user.full_name}." in messages
+    assert f"{user.full_name} removed team leader {removed_user.full_name}." in messages
+
+
+def test_update_project_multi_field_change_trigger(loaded_db, app_ctx):
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.UPDATE_PROJECT,
+        {
+            "project_updates": {
+                "owner_id": TEST_PROJECT_ID,
+                "updated_by": TEST_USER_ID,
+                "changes": {
+                    "title": {"old_value": "A", "new_value": "B"},
+                    "short_title": {"old_value": "X", "new_value": "Y"},
+                    "description": {"old_value": "d1", "new_value": "d2"},
+                },
+            }
+        },
+    )
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert len(items) == 3
+    types = {item.history_type for item in items}
+    assert types == {
+        ProjectHistoryType.PROJECT_TITLE_EDITED,
+        ProjectHistoryType.PROJECT_SHORT_TITLE_EDITED,
+        ProjectHistoryType.PROJECT_DESCRIPTION_EDITED,
+    }
+
+
+def test_unknown_property_logs_and_skips(loaded_db, app_ctx):
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.UPDATE_PROJECT,
+        {
+            "project_updates": {
+                "owner_id": TEST_PROJECT_ID,
+                "updated_by": TEST_USER_ID,
+                "changes": {
+                    "some_unknown_field": {"old_value": "a", "new_value": "b"},
+                },
+            }
+        },
+    )
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert items == []
+
+
+def test_failed_event_no_history(loaded_db, app_ctx):
+    ops_event = OpsEvent(
+        event_type=OpsEventType.UPDATE_PROJECT,
+        event_status=OpsEventStatus.FAILED,
+        created_by=TEST_USER_ID,
+        event_details={
+            "project_updates": {
+                "owner_id": TEST_PROJECT_ID,
+                "updated_by": TEST_USER_ID,
+                "changes": {"title": {"old_value": "A", "new_value": "B"}},
+            }
+        },
+    )
+    loaded_db.add(ops_event)
+    loaded_db.flush()
+    loaded_db.commit()
+    ops_event = loaded_db.query(OpsEvent).filter(OpsEvent.id == ops_event.id).one()
+
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert items == []
+
+
+def test_no_duplicate_messages_when_trigger_runs_twice(loaded_db, app_ctx):
+    ops_event = _make_event(
+        loaded_db,
+        OpsEventType.UPDATE_PROJECT,
+        {
+            "project_updates": {
+                "owner_id": TEST_PROJECT_ID,
+                "updated_by": TEST_USER_ID,
+                "changes": {"title": {"old_value": "A", "new_value": "B"}},
+            }
+        },
+    )
+    project_history_trigger(ops_event, loaded_db)
+    project_history_trigger(ops_event, loaded_db)
+    loaded_db.flush()
+
+    items = _history_for_event(loaded_db, ops_event.id)
+    assert len(items) == 1
+
+
+# ---------------------------------------------------------------------------
+# add_history_events dedup tests
+# ---------------------------------------------------------------------------
+
+
+def _ts_now():
+    return datetime.utcnow().strftime(TIMESTAMP_FMT)
+
+
+def test_add_history_events_prevents_duplicates_in_same_batch(loaded_db, app_ctx):
+    ts = _ts_now()
+    event1 = ProjectHistory(
+        project_id=TEST_PROJECT_ID,
+        project_id_record=TEST_PROJECT_ID,
+        history_title="Test",
+        history_message="Same message",
+        timestamp=ts,
+        history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+    )
+    event2 = ProjectHistory(
+        project_id=TEST_PROJECT_ID,
+        project_id_record=TEST_PROJECT_ID,
+        history_title="Test",
+        history_message="Same message",
+        timestamp=ts,
+        history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+    )
+
+    initial = loaded_db.query(ProjectHistory).filter(ProjectHistory.project_id_record == TEST_PROJECT_ID).count()
+
+    add_history_events([event1, event2], loaded_db)
+    loaded_db.flush()
+
+    final = loaded_db.query(ProjectHistory).filter(ProjectHistory.project_id_record == TEST_PROJECT_ID).count()
+    assert final == initial + 1
+
+
+def test_add_history_events_allows_different_messages(loaded_db, app_ctx):
+    ts = _ts_now()
+    event1 = ProjectHistory(
+        project_id=TEST_PROJECT_ID,
+        project_id_record=TEST_PROJECT_ID,
+        history_title="Test",
+        history_message="Message 1",
+        timestamp=ts,
+        history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+    )
+    event2 = ProjectHistory(
+        project_id=TEST_PROJECT_ID,
+        project_id_record=TEST_PROJECT_ID,
+        history_title="Test",
+        history_message="Message 2",
+        timestamp=ts,
+        history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+    )
+
+    initial = loaded_db.query(ProjectHistory).filter(ProjectHistory.project_id_record == TEST_PROJECT_ID).count()
+
+    add_history_events([event1, event2], loaded_db)
+    loaded_db.flush()
+
+    final = loaded_db.query(ProjectHistory).filter(ProjectHistory.project_id_record == TEST_PROJECT_ID).count()
+    assert final == initial + 2
+
+
+def test_add_history_events_allows_different_types(loaded_db, app_ctx):
+    ts = _ts_now()
+    event1 = ProjectHistory(
+        project_id=TEST_PROJECT_ID,
+        project_id_record=TEST_PROJECT_ID,
+        history_title="Test",
+        history_message="Same message",
+        timestamp=ts,
+        history_type=ProjectHistoryType.PROJECT_CREATED,
+    )
+    event2 = ProjectHistory(
+        project_id=TEST_PROJECT_ID,
+        project_id_record=TEST_PROJECT_ID,
+        history_title="Test",
+        history_message="Same message",
+        timestamp=ts,
+        history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+    )
+
+    initial = loaded_db.query(ProjectHistory).filter(ProjectHistory.project_id_record == TEST_PROJECT_ID).count()
+
+    add_history_events([event1, event2], loaded_db)
+    loaded_db.flush()
+
+    final = loaded_db.query(ProjectHistory).filter(ProjectHistory.project_id_record == TEST_PROJECT_ID).count()
+    assert final == initial + 2
+
+
+def test_add_history_events_allows_events_outside_time_window(loaded_db, app_ctx):
+    base = datetime.utcnow()
+    ts1 = base.strftime(TIMESTAMP_FMT)
+    ts2 = (base + timedelta(minutes=2)).strftime(TIMESTAMP_FMT)
+
+    event1 = ProjectHistory(
+        project_id=TEST_PROJECT_ID,
+        project_id_record=TEST_PROJECT_ID,
+        history_title="Test",
+        history_message="Same message",
+        timestamp=ts1,
+        history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+    )
+    event2 = ProjectHistory(
+        project_id=TEST_PROJECT_ID,
+        project_id_record=TEST_PROJECT_ID,
+        history_title="Test",
+        history_message="Same message",
+        timestamp=ts2,
+        history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+    )
+
+    initial = loaded_db.query(ProjectHistory).filter(ProjectHistory.project_id_record == TEST_PROJECT_ID).count()
+
+    add_history_events([event1, event2], loaded_db)
+    loaded_db.flush()
+
+    final = loaded_db.query(ProjectHistory).filter(ProjectHistory.project_id_record == TEST_PROJECT_ID).count()
+    assert final == initial + 2
+
+
+# ---------------------------------------------------------------------------
+# Service tests
+# ---------------------------------------------------------------------------
+
+
+def _seed_project_history(loaded_db, project_id, count, base_timestamp=None):
+    """Seed `count` ProjectHistory rows for a project. Returns nothing."""
+    base = base_timestamp or datetime.utcnow()
+    for i in range(count):
+        ts = (base + timedelta(seconds=i * 90)).strftime(TIMESTAMP_FMT)
+        loaded_db.add(
+            ProjectHistory(
+                project_id=project_id,
+                project_id_record=project_id,
+                history_title=f"Title {i}",
+                history_message=f"Message {i}",
+                timestamp=ts,
+                history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+            )
+        )
+    loaded_db.flush()
+
+
+def test_service_get_returns_count_metadata(app_ctx, loaded_db):
+    _seed_project_history(loaded_db, TEST_PROJECT_ID, 3)
+    service = ProjectHistoryService()
+    items, metadata = service.get(TEST_PROJECT_ID, 10, 0)
+    assert metadata["count"] >= 3
+    assert metadata["limit"] == 10
+    assert metadata["offset"] == 0
+    assert len(items) == metadata["count"]
+
+
+def test_service_get_pagination(app_ctx, loaded_db):
+    _seed_project_history(loaded_db, TEST_PROJECT_ID, 5)
+    service = ProjectHistoryService()
+    page1, meta1 = service.get(TEST_PROJECT_ID, 2, 0)
+    page2, meta2 = service.get(TEST_PROJECT_ID, 2, 2)
+    assert len(page1) == 2
+    assert len(page2) == 2
+    assert meta1["count"] == meta2["count"]
+    assert {item.id for item in page1}.isdisjoint({item.id for item in page2})
+
+
+def test_service_get_sort_default_descending(app_ctx, loaded_db):
+    _seed_project_history(loaded_db, TEST_PROJECT_ID, 3)
+    service = ProjectHistoryService()
+    items, _ = service.get(TEST_PROJECT_ID, 10, 0)
+    timestamps = [i.timestamp for i in items]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+def test_service_get_sort_ascending(app_ctx, loaded_db):
+    _seed_project_history(loaded_db, TEST_PROJECT_ID, 3)
+    service = ProjectHistoryService()
+    items, _ = service.get(TEST_PROJECT_ID, 10, 0, sort_ascending=True)
+    timestamps = [i.timestamp for i in items]
+    assert timestamps == sorted(timestamps)
+
+
+def test_service_get_offset_beyond_total(app_ctx, loaded_db):
+    _seed_project_history(loaded_db, TEST_PROJECT_ID, 3)
+    service = ProjectHistoryService()
+    items, metadata = service.get(TEST_PROJECT_ID, 10, 1000)
+    assert items == []
+    assert metadata["count"] >= 3
+    assert metadata["offset"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# API integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_project_history_unauthorized(client, app_ctx):
+    response = client.get(f"/api/v1/projects/{TEST_PROJECT_ID}/history/")
+    assert response.status_code == 401
+
+
+def test_get_project_history_forbidden_for_user_without_history_permission(no_perms_auth_client, app_ctx):
+    response = no_perms_auth_client.get(f"/api/v1/projects/{TEST_PROJECT_ID}/history/")
+    assert response.status_code == 403
+
+
+def test_get_project_history_returns_wrapped_envelope(auth_client, mocker, app_ctx):
+    mock_items = [
+        ProjectHistory(
+            id=i,
+            project_id=TEST_PROJECT_ID,
+            project_id_record=TEST_PROJECT_ID,
+            history_title="Title",
+            history_message="Message",
+            timestamp="2026-01-01T00:00:00.000000Z",
+            history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+        )
+        for i in range(1, 6)
+    ]
+    mock_get = mocker.patch("ops_api.ops.services.project_history.ProjectHistoryService.get")
+    mock_get.return_value = (mock_items, {"count": 5, "limit": 10, "offset": 0})
+
+    response = auth_client.get(f"/api/v1/projects/{TEST_PROJECT_ID}/history/")
+    assert response.status_code == 200
+    body = response.json
+    assert body["count"] == 5
+    assert body["limit"] == 10
+    assert body["offset"] == 0
+    assert len(body["data"]) == 5
+
+
+def test_get_project_history_with_limit_offset(auth_client, mocker, app_ctx):
+    mock_get = mocker.patch("ops_api.ops.services.project_history.ProjectHistoryService.get")
+    mock_get.return_value = ([], {"count": 50, "limit": 5, "offset": 10})
+
+    response = auth_client.get(f"/api/v1/projects/{TEST_PROJECT_ID}/history/?limit=5&offset=10")
+    assert response.status_code == 200
+    mock_get.assert_called_once_with(TEST_PROJECT_ID, 5, 10, False)
+    assert response.json["count"] == 50
+    assert response.json["limit"] == 5
+    assert response.json["offset"] == 10
+
+
+def test_get_project_history_sort_asc_passthrough(auth_client, mocker, app_ctx):
+    mock_get = mocker.patch("ops_api.ops.services.project_history.ProjectHistoryService.get")
+    mock_get.return_value = ([], {"count": 0, "limit": 10, "offset": 0})
+
+    response = auth_client.get(f"/api/v1/projects/{TEST_PROJECT_ID}/history/?sort_asc=true")
+    assert response.status_code == 200
+    mock_get.assert_called_once_with(TEST_PROJECT_ID, 10, 0, True)
+
+
+def test_get_project_history_offset_beyond_total(auth_client, mocker, app_ctx):
+    mock_get = mocker.patch("ops_api.ops.services.project_history.ProjectHistoryService.get")
+    mock_get.return_value = ([], {"count": 5, "limit": 10, "offset": 1000})
+
+    response = auth_client.get(f"/api/v1/projects/{TEST_PROJECT_ID}/history/?offset=1000")
+    assert response.status_code == 200
+    assert response.json["data"] == []
+    assert response.json["count"] == 5
+    assert response.json["offset"] == 1000
+
+
+def test_get_project_history_bad_limit(auth_client, app_ctx):
+    response = auth_client.get(f"/api/v1/projects/{TEST_PROJECT_ID}/history/?limit=0")
+    assert response.status_code == 400
+
+
+def test_get_project_history_bad_offset(auth_client, app_ctx):
+    response = auth_client.get(f"/api/v1/projects/{TEST_PROJECT_ID}/history/?offset=-1")
+    assert response.status_code == 400
+
+
+def test_get_project_history_real_db_round_trip(auth_client, loaded_db, app_ctx):
+    """End-to-end sanity check: seeded rows show up in the API response, sorted newest-first."""
+    base = datetime.utcnow()
+    for i in range(2):
+        ts = (base + timedelta(seconds=i * 120)).strftime(TIMESTAMP_FMT)
+        loaded_db.add(
+            ProjectHistory(
+                project_id=TEST_PROJECT_ID,
+                project_id_record=TEST_PROJECT_ID,
+                history_title=f"Title {i}",
+                history_message=f"Message {i}",
+                timestamp=ts,
+                history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+            )
+        )
+    loaded_db.flush()
+    loaded_db.commit()
+
+    response = auth_client.get(f"/api/v1/projects/{TEST_PROJECT_ID}/history/?limit=50")
+    assert response.status_code == 200
+    body = response.json
+    assert body["count"] >= 2
+    seeded = [item for item in body["data"] if item["history_message"].startswith("Message ")]
+    assert len(seeded) == 2
+    # newest-first
+    assert seeded[0]["history_message"] == "Message 1"
+    assert seeded[1]["history_message"] == "Message 0"
+
+
+# ---------------------------------------------------------------------------
+# Service get on stale project_id_record
+# ---------------------------------------------------------------------------
+
+
+def test_service_filters_by_project_id_record(loaded_db, app_ctx):
+    """Rows persist via project_id_record even if project_id is NULL."""
+    base = datetime.utcnow()
+    ts = base.strftime(TIMESTAMP_FMT)
+    loaded_db.add(
+        ProjectHistory(
+            project_id=None,  # simulates SET NULL after deletion
+            project_id_record=TEST_PROJECT_ID,
+            history_title="Orphan",
+            history_message="Orphan message",
+            timestamp=ts,
+            history_type=ProjectHistoryType.PROJECT_TITLE_EDITED,
+        )
+    )
+    loaded_db.flush()
+
+    service = ProjectHistoryService()
+    items, metadata = service.get(TEST_PROJECT_ID, 100, 0)
+    assert any(item.history_message == "Orphan message" for item in items)
+    assert metadata["count"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Sanity import-check for select() (to keep the imports used)
+# ---------------------------------------------------------------------------
+
+
+def test_select_module_available():
+    # Smoke test to keep the imported symbol referenced.
+    assert select is not None

--- a/frontend/cypress/e2e/projectDetails.cy.js
+++ b/frontend/cypress/e2e/projectDetails.cy.js
@@ -68,6 +68,12 @@ describe("Project Details Page", () => {
         cy.contains("Project Updated").should("be.visible");
         cy.get("[data-cy='project-nickname-tag']").should("contain", updatedShortTitle);
 
+        cy.get("[data-cy='project-history-container']").should("be.visible");
+        cy.get("[data-cy='project-history-list']").within(() => {
+            cy.get("[data-cy='log-item-title']").first().should("contain", "Project Nickname");
+            cy.get("[data-cy='log-item-message']").first().should("contain", updatedShortTitle);
+        });
+
         // Restore the seeded short_title so later tests (and the seeded fixture assertions
         // above) keep passing when the spec reruns against the same database.
         cy.get("[data-cy='project-details-edit-button']").click();

--- a/frontend/src/api/getProjectHistory.js
+++ b/frontend/src/api/getProjectHistory.js
@@ -1,0 +1,23 @@
+import ApplicationContext from "../applicationContext/ApplicationContext";
+
+/**
+ * Fetch a page of Project history items.
+ *
+ * @param {number} id - The project id.
+ * @param {number} page - 1-indexed page number.
+ * @returns {Promise<{items: Array<Object>, count: number, limit: number, offset: number}>}
+ */
+export const getProjectHistoryByIdAndPage = async (id, page) => {
+    const pageSize = 20;
+    const limit = pageSize;
+    const offset = pageSize * (page - 1);
+    const api_version = ApplicationContext.get().helpers().backEndConfig.apiVersion;
+    const endpoint = `/api/${api_version}/projects/${id}/history/?limit=${limit}&offset=${offset}`;
+    const responseData = await ApplicationContext.get().helpers().callBackend(endpoint, "get");
+    return {
+        items: responseData?.data ?? [],
+        count: responseData?.count ?? 0,
+        limit: responseData?.limit ?? limit,
+        offset: responseData?.offset ?? offset
+    };
+};

--- a/frontend/src/api/getProjectHistory.test.js
+++ b/frontend/src/api/getProjectHistory.test.js
@@ -1,0 +1,58 @@
+import { getProjectHistoryByIdAndPage } from "./getProjectHistory";
+import TestApplicationContext from "../applicationContext/TestApplicationContext";
+
+beforeEach(() => {
+    TestApplicationContext.helpers().callBackend.mockReset();
+});
+
+test("returns wrapped envelope unwrapped to {items, count, limit, offset}", async () => {
+    TestApplicationContext.helpers().callBackend.mockImplementation(async () => ({
+        data: [{ id: 1, history_title: "x", history_message: "y", timestamp: "2026-01-01T00:00:00Z" }],
+        count: 1,
+        limit: 20,
+        offset: 0
+    }));
+
+    const result = await getProjectHistoryByIdAndPage(1000, 1);
+    expect(result.items).toHaveLength(1);
+    expect(result.count).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.offset).toBe(0);
+});
+
+test("requests page 1 with limit=20 and offset=0", async () => {
+    TestApplicationContext.helpers().callBackend.mockImplementation(async () => ({
+        data: [],
+        count: 0,
+        limit: 20,
+        offset: 0
+    }));
+    await getProjectHistoryByIdAndPage(1000, 1);
+    expect(TestApplicationContext.helpers().callBackend).toHaveBeenCalledWith(
+        "/api/v1/projects/1000/history/?limit=20&offset=0",
+        "get"
+    );
+});
+
+test("requests page 2 with offset=20", async () => {
+    TestApplicationContext.helpers().callBackend.mockImplementation(async () => ({
+        data: [],
+        count: 0,
+        limit: 20,
+        offset: 20
+    }));
+    await getProjectHistoryByIdAndPage(1000, 2);
+    expect(TestApplicationContext.helpers().callBackend).toHaveBeenCalledWith(
+        "/api/v1/projects/1000/history/?limit=20&offset=20",
+        "get"
+    );
+});
+
+test("falls back to safe defaults when response is empty", async () => {
+    TestApplicationContext.helpers().callBackend.mockImplementation(async () => null);
+    const result = await getProjectHistoryByIdAndPage(1000, 1);
+    expect(result.items).toEqual([]);
+    expect(result.count).toBe(0);
+    expect(result.limit).toBe(20);
+    expect(result.offset).toBe(0);
+});

--- a/frontend/src/components/Projects/ProjectDetailForm/ProjectDetailForm.jsx
+++ b/frontend/src/components/Projects/ProjectDetailForm/ProjectDetailForm.jsx
@@ -116,7 +116,6 @@ const ProjectDetailForm = ({
                 inputStyle={{ maxWidth: "664px" }}
             />
             <TextArea
-                maxLength={1000}
                 name="description"
                 label="Description"
                 hintMsg="Brief description for internal purposes, not for the OPRE website."

--- a/frontend/src/components/Projects/ProjectHistoryPanel/ProjectHistoryPanel.jsx
+++ b/frontend/src/components/Projects/ProjectHistoryPanel/ProjectHistoryPanel.jsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import InfiniteScroll from "../../Agreements/AgreementDetails/InfiniteScroll";
+import { getProjectHistoryByIdAndPage } from "../../../api/getProjectHistory";
+import LogItem from "../../UI/LogItem";
+
+/**
+ * Renders a project's change history with infinite-scroll pagination.
+ *
+ * @component
+ * @param {Object} props
+ * @param {number} props.projectId
+ * @returns {JSX.Element}
+ */
+const ProjectHistoryPanel = ({ projectId }) => {
+    const [page, setPage] = useState(1);
+    const [isLoading, setIsLoading] = useState(false);
+    const [stopped, setStopped] = useState(false);
+    const [projectHistory, setProjectHistory] = useState([]);
+
+    const fetchMoreData = async () => {
+        if (stopped) return;
+        setIsLoading(true);
+        try {
+            const response = await getProjectHistoryByIdAndPage(projectId, page);
+            const items = response?.items ?? [];
+            const count = response?.count ?? 0;
+            const limit = response?.limit ?? 20;
+            const offset = response?.offset ?? 0;
+
+            if (items.length > 0) {
+                setProjectHistory((prev) => {
+                    const existingIds = new Set(prev.map((item) => item.id));
+                    const newItems = items.filter((item) => !existingIds.has(item.id));
+                    return newItems.length > 0 ? [...prev, ...newItems] : prev;
+                });
+            }
+
+            if (offset + limit >= count) {
+                setStopped(true);
+            }
+            setPage(page + 1);
+        } catch (error) {
+            console.log("Error loading project history:", error);
+            setStopped(true);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const sortedProjectHistory = [...projectHistory].sort(
+        (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    );
+
+    return (
+        <>
+            {projectHistory.length > 0 ? (
+                <div
+                    className="overflow-y-scroll force-show-scrollbars"
+                    style={{ height: "15rem" }}
+                    data-cy="project-history-container"
+                    role="region"
+                    aria-live="polite"
+                    aria-label="Project History"
+                    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+                    tabIndex={0}
+                >
+                    <ul
+                        className="usa-list--unstyled"
+                        data-cy="project-history-list"
+                    >
+                        {sortedProjectHistory.map((item) => (
+                            <LogItem
+                                key={item.id}
+                                title={item.history_title}
+                                createdOn={item.timestamp}
+                                message={item.history_message}
+                            />
+                        ))}
+                    </ul>
+                    {!stopped && (
+                        <InfiniteScroll
+                            fetchMoreData={fetchMoreData}
+                            isLoading={isLoading}
+                        />
+                    )}
+                </div>
+            ) : (
+                <>
+                    <p className="font-12px text-base margin-top-1">No History</p>
+                    {!stopped && (
+                        <InfiniteScroll
+                            fetchMoreData={fetchMoreData}
+                            isLoading={isLoading}
+                        />
+                    )}
+                </>
+            )}
+        </>
+    );
+};
+
+export default ProjectHistoryPanel;

--- a/frontend/src/components/Projects/ProjectHistoryPanel/ProjectHistoryPanel.jsx
+++ b/frontend/src/components/Projects/ProjectHistoryPanel/ProjectHistoryPanel.jsx
@@ -40,7 +40,7 @@ const ProjectHistoryPanel = ({ projectId }) => {
             }
             setPage(page + 1);
         } catch (error) {
-            console.log("Error loading project history:", error);
+            console.error("Error loading project history:", error);
             setStopped(true);
         } finally {
             setIsLoading(false);

--- a/frontend/src/components/Projects/ProjectHistoryPanel/ProjectHistoryPanel.test.jsx
+++ b/frontend/src/components/Projects/ProjectHistoryPanel/ProjectHistoryPanel.test.jsx
@@ -1,0 +1,169 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import ProjectHistoryPanel from "./ProjectHistoryPanel";
+import { getProjectHistoryByIdAndPage } from "../../../api/getProjectHistory";
+
+vi.mock("../../../api/getProjectHistory");
+
+// Capture each InfiniteScroll's fetchMoreData so the test can drive pagination directly.
+let capturedFetchMoreData;
+vi.mock("../../Agreements/AgreementDetails/InfiniteScroll", () => ({
+    default: ({ fetchMoreData }) => {
+        capturedFetchMoreData = fetchMoreData;
+        return <div data-testid="infinite-scroll-sentinel" />;
+    }
+}));
+
+describe("ProjectHistoryPanel", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        capturedFetchMoreData = undefined;
+    });
+
+    it("renders 'No History' before the first fetch resolves", () => {
+        getProjectHistoryByIdAndPage.mockResolvedValue({
+            items: [],
+            count: 0,
+            limit: 20,
+            offset: 0
+        });
+        render(<ProjectHistoryPanel projectId={1000} />);
+        expect(screen.getByText("No History")).toBeInTheDocument();
+    });
+
+    it("renders history items after fetchMoreData resolves", async () => {
+        getProjectHistoryByIdAndPage.mockResolvedValue({
+            items: [
+                {
+                    id: 1,
+                    history_title: "Project Created",
+                    history_message: "Project created by Amelia.",
+                    timestamp: "2026-01-01T00:00:00.000000Z"
+                },
+                {
+                    id: 2,
+                    history_title: "Change to Project Title",
+                    history_message: "Amelia changed the Project Title from A to B.",
+                    timestamp: "2026-01-02T00:00:00.000000Z"
+                }
+            ],
+            count: 2,
+            limit: 20,
+            offset: 0
+        });
+
+        render(<ProjectHistoryPanel projectId={1000} />);
+        await capturedFetchMoreData();
+
+        expect(await screen.findByText("Project Created")).toBeInTheDocument();
+        expect(await screen.findByText("Change to Project Title")).toBeInTheDocument();
+    });
+
+    it("calls the helper with page 1 on first fetch and page 2 on second", async () => {
+        getProjectHistoryByIdAndPage
+            .mockResolvedValueOnce({
+                items: [
+                    {
+                        id: 1,
+                        history_title: "Title A",
+                        history_message: "msg A",
+                        timestamp: "2026-01-01T00:00:00.000000Z"
+                    }
+                ],
+                count: 50,
+                limit: 20,
+                offset: 0
+            })
+            .mockResolvedValueOnce({
+                items: [
+                    {
+                        id: 2,
+                        history_title: "Title B",
+                        history_message: "msg B",
+                        timestamp: "2026-01-02T00:00:00.000000Z"
+                    }
+                ],
+                count: 50,
+                limit: 20,
+                offset: 20
+            });
+
+        render(<ProjectHistoryPanel projectId={1000} />);
+        await capturedFetchMoreData();
+        expect(await screen.findByText("Title A")).toBeInTheDocument();
+        await capturedFetchMoreData();
+        expect(await screen.findByText("Title B")).toBeInTheDocument();
+
+        expect(getProjectHistoryByIdAndPage).toHaveBeenNthCalledWith(1, 1000, 1);
+        expect(getProjectHistoryByIdAndPage).toHaveBeenNthCalledWith(2, 1000, 2);
+    });
+
+    it("stops fetching once offset + limit >= count", async () => {
+        getProjectHistoryByIdAndPage.mockResolvedValue({
+            items: [
+                {
+                    id: 1,
+                    history_title: "Only one",
+                    history_message: "msg",
+                    timestamp: "2026-01-01T00:00:00.000000Z"
+                }
+            ],
+            count: 1,
+            limit: 20,
+            offset: 0
+        });
+
+        render(<ProjectHistoryPanel projectId={1000} />);
+        await capturedFetchMoreData();
+        expect(await screen.findByText("Only one")).toBeInTheDocument();
+
+        // After stopping, the InfiniteScroll sentinel should be gone.
+        expect(screen.queryByTestId("infinite-scroll-sentinel")).not.toBeInTheDocument();
+    });
+
+    it("stops scrolling on error", async () => {
+        getProjectHistoryByIdAndPage.mockRejectedValue(new Error("boom"));
+        render(<ProjectHistoryPanel projectId={1000} />);
+        await capturedFetchMoreData();
+        // Empty state still rendered; sentinel removed because stopped is true.
+        expect(await screen.findByText("No History")).toBeInTheDocument();
+        expect(screen.queryByTestId("infinite-scroll-sentinel")).not.toBeInTheDocument();
+    });
+
+    it("deduplicates items returned across pages", async () => {
+        getProjectHistoryByIdAndPage
+            .mockResolvedValueOnce({
+                items: [
+                    {
+                        id: 1,
+                        history_title: "Title A",
+                        history_message: "msg A",
+                        timestamp: "2026-01-01T00:00:00.000000Z"
+                    }
+                ],
+                count: 50,
+                limit: 20,
+                offset: 0
+            })
+            .mockResolvedValueOnce({
+                items: [
+                    {
+                        id: 1,
+                        history_title: "Title A",
+                        history_message: "msg A",
+                        timestamp: "2026-01-01T00:00:00.000000Z"
+                    }
+                ],
+                count: 50,
+                limit: 20,
+                offset: 20
+            });
+
+        render(<ProjectHistoryPanel projectId={1000} />);
+        await capturedFetchMoreData();
+        expect(await screen.findByText("Title A")).toBeInTheDocument();
+        await capturedFetchMoreData();
+        // Same id returned twice: only one row should be visible.
+        expect(screen.getAllByText("Title A")).toHaveLength(1);
+    });
+});

--- a/frontend/src/components/Projects/ProjectHistoryPanel/index.js
+++ b/frontend/src/components/Projects/ProjectHistoryPanel/index.js
@@ -1,0 +1,1 @@
+export { default } from "./ProjectHistoryPanel";

--- a/frontend/src/pages/projects/detail/ProjectDetail.test.jsx
+++ b/frontend/src/pages/projects/detail/ProjectDetail.test.jsx
@@ -29,6 +29,11 @@ vi.mock("../../../App", () => ({
     default: ({ children }) => <div data-testid="app-wrapper">{children}</div>
 }));
 
+vi.mock("../../../components/Projects/ProjectHistoryPanel", () => ({
+    __esModule: true,
+    default: () => <div data-testid="project-history-panel" />
+}));
+
 const mockProject = {
     id: 1000,
     title: "Human Services Interoperability Support",

--- a/frontend/src/pages/projects/detail/ProjectDetailsView.jsx
+++ b/frontend/src/pages/projects/detail/ProjectDetailsView.jsx
@@ -1,6 +1,7 @@
 import { faPen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import ProjectDetailForm from "../../../components/Projects/ProjectDetailForm";
+import ProjectHistoryPanel from "../../../components/Projects/ProjectHistoryPanel";
 import Tag from "../../../components/UI/Tag/Tag";
 import { TagList } from "../../../components/UI/Tag";
 import Tooltip from "../../../components/UI/USWDS/Tooltip";
@@ -127,7 +128,7 @@ const ProjectDetailsView = ({ project, isEditMode = false, toggleEditMode, canEd
                         </dl>
 
                         <h3 className="text-base-dark margin-top-5 margin-bottom-0 text-normal font-12px">History</h3>
-                        <p className="font-12px text-base margin-top-1">History coming soon.</p>
+                        <ProjectHistoryPanel projectId={project.id} />
                     </div>
 
                     {/* RIGHT COLUMN */}

--- a/frontend/src/pages/projects/detail/ProjectDetailsView.test.jsx
+++ b/frontend/src/pages/projects/detail/ProjectDetailsView.test.jsx
@@ -21,6 +21,11 @@ vi.mock("../../../hooks/use-alert.hooks", () => ({
     default: () => ({ setAlert: vi.fn() })
 }));
 
+vi.mock("../../../components/Projects/ProjectHistoryPanel", () => ({
+    __esModule: true,
+    default: () => <div data-testid="project-history-panel" />
+}));
+
 const baseProject = {
     id: 1000,
     title: "Human Services Interoperability Support",
@@ -220,10 +225,10 @@ describe("ProjectDetailsView", () => {
         expect(toggleFn).toHaveBeenCalledTimes(1);
     });
 
-    it("renders History placeholder", () => {
+    it("renders History panel", () => {
         renderComponent(baseProject);
         expect(screen.getByText("History")).toBeInTheDocument();
-        expect(screen.getByText("History coming soon.")).toBeInTheDocument();
+        expect(screen.getByTestId("project-history-panel")).toBeInTheDocument();
     });
 
     it("renders 'Admin & Support' tag for ADMINISTRATIVE_AND_SUPPORT project type", () => {

--- a/frontend/src/types/ProjectTypes.d.ts
+++ b/frontend/src/types/ProjectTypes.d.ts
@@ -54,3 +54,14 @@ export type Project = {
     updated_by?: any;
     _meta?: { isEditable: boolean };
 };
+
+export type ProjectHistoryItem = {
+    id: number;
+    project_id: number | null;
+    project_id_record: number;
+    ops_event_id: number | null;
+    history_title: string;
+    history_message: string;
+    timestamp: string;
+    history_type: string;
+};


### PR DESCRIPTION
## What changed

Adds a project change-history feature end to end:

- **Backend data layer**: new `ProjectHistory` model + alembic migration with the `projecthistorytype` enum and the `project_id_record` index. `project_id` is FK `SET NULL` so history survives project deletion via `project_id_record`.
- **Backend API**: new `GET /projects/{id}/history/` endpoint (paginated, sortable). The PATCH path now diffs the project via `generate_project_events_update` (skipping derived/computed fields and surfacing team-leader add/remove). `CREATE_PROJECT` and `UPDATE_PROJECT` are subscribed on the message bus to drive the trigger that builds history rows. Reads require `Permission.HISTORY` to match the agreement-history pattern.
- **Frontend**: new `ProjectHistoryPanel` rendered on the project detail page in place of the History placeholder. Uses the existing `LogItem` and `InfiniteScroll` components, deduplicates items across pages, and stops paging once `offset + limit >= count`.

## Issue

#5367

## How to test

1. `docker compose up --build` and `cd backend && alembic upgrade head` to apply the new migration.
2. Open a project at `http://localhost:3000/projects/{id}` — the History section under Description renders the new panel ("No History" if empty).
3. Edit the project (title, nickname, description, project type) and reload the detail page — corresponding history entries should appear, newest first.
4. Hit the API directly: `GET /api/v1/projects/{id}/history/?limit=10&offset=0` returns `{ data, count, limit, offset }`. Try `?sort_asc=true`, `?limit=0` (400), and an unauthenticated request (401).
5. Confirm a user without `Permission.HISTORY` gets 403 from the endpoint.
6. All tests pass


## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated