### PR TITLE
fix: consistent table row heights and pagination last page

### DIFF
--- a/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.jsx
+++ b/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.jsx
@@ -13,7 +13,6 @@ import { AWARD_TYPE_LABELS } from "../../../pages/agreements/agreements.constant
 import TableRowExpandable from "../../UI/TableRowExpandable";
 import { expandedRowBGColor } from "../../UI/TableRowExpandable/TableRowExpandable.helpers";
 import { useTableRow } from "../../UI/TableRowExpandable/TableRowExpandable.hooks";
-import tableStyles from "../../UI/Table/table.module.css";
 import TableTag from "../../UI/TableTag";
 import TextClip from "../../UI/Text/TextClip";
 import { useGetPortfolioByIdQuery } from "../../../api/opsAPI";
@@ -42,44 +41,49 @@ const AllBLIRow = ({ budgetLine }) => {
     const agreementLinkLabel =
         budgetLine?.agreement?.name?.trim() ||
         (budgetLine?.agreement?.id ? `Agreement ${budgetLine.agreement.id}` : "Agreement details");
-    const hasAgreementLink = Boolean(budgetLine?.agreement?.id);
 
     const TableRowData = (
         <>
             <td data-cy="bli-id">{budgetLine.id}</td>
             <td data-cy="agreement-name">
-                {budgetLine?.agreement?.id ? (
-                    <Link
-                        to={`/agreements/${budgetLine.agreement.id}`}
-                        className="text-ink text-no-underline"
-                        aria-label={agreementLinkLabel}
-                    >
+                <div style={{ height: "1.5rem", overflow: "visible", position: "relative" }}>
+                    {budgetLine?.agreement?.id ? (
+                        <Link
+                            to={`/agreements/${budgetLine.agreement.id}`}
+                            className="text-ink text-no-underline"
+                            aria-label={agreementLinkLabel}
+                        >
+                            <TextClip
+                                text={agreementName}
+                                maxLines={1}
+                            />
+                        </Link>
+                    ) : (
                         <TextClip
                             text={agreementName}
                             maxLines={1}
                         />
-                    </Link>
-                ) : (
-                    <TextClip
-                        text={agreementName}
-                        maxLines={1}
-                    />
-                )}
+                    )}
+                </div>
             </td>
             <td data-cy="agreement-type">
-                <TextClip
-                    text={convertCodeForDisplay("agreementType", budgetLine?.agreement?.agreement_type) || NO_DATA}
-                    maxLines={1}
-                />
+                <div style={{ height: "1.5rem", overflow: "visible", position: "relative" }}>
+                    <TextClip
+                        text={convertCodeForDisplay("agreementType", budgetLine?.agreement?.agreement_type) || NO_DATA}
+                        maxLines={1}
+                    />
+                </div>
             </td>
             <td data-cy="service-component">{serviceComponentName}</td>
             <td data-cy="date-needed">{formatDateNeeded(budgetLine?.date_needed ?? "")}</td>
             <td data-cy="can">{budgetLine?.can?.display_name}</td>
             <td data-cy="portfolio-name">
-                <TextClip
-                    text={isPortfolioLoading ? "Loading..." : (budgetLinePortfolio?.abbreviation ?? NO_DATA)}
-                    maxLines={1}
-                />
+                <div style={{ height: "1.5rem", overflow: "visible", position: "relative" }}>
+                    <TextClip
+                        text={isPortfolioLoading ? "Loading..." : (budgetLinePortfolio?.abbreviation ?? NO_DATA)}
+                        maxLines={1}
+                    />
+                </div>
             </td>
             <td data-cy="amount">
                 <CurrencyFormat
@@ -187,7 +191,6 @@ const AllBLIRow = ({ budgetLine }) => {
             isExpanded={isExpanded}
             setIsExpanded={setIsExpanded}
             setIsRowActive={setIsRowActive}
-            className={hasAgreementLink ? tableStyles.noPaddingBottom : undefined}
             data-testid={`budget-line-row-${budgetLine?.id}`}
         />
     );

--- a/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.jsx
+++ b/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.jsx
@@ -13,6 +13,7 @@ import { AWARD_TYPE_LABELS } from "../../../pages/agreements/agreements.constant
 import TableRowExpandable from "../../UI/TableRowExpandable";
 import { expandedRowBGColor } from "../../UI/TableRowExpandable/TableRowExpandable.helpers";
 import { useTableRow } from "../../UI/TableRowExpandable/TableRowExpandable.hooks";
+import tableStyles from "../../UI/Table/table.module.css";
 import TableTag from "../../UI/TableTag";
 import TextClip from "../../UI/Text/TextClip";
 import { useGetPortfolioByIdQuery } from "../../../api/opsAPI";
@@ -46,7 +47,7 @@ const AllBLIRow = ({ budgetLine }) => {
         <>
             <td data-cy="bli-id">{budgetLine.id}</td>
             <td data-cy="agreement-name">
-                <div style={{ height: "1.5rem", overflow: "visible", position: "relative" }}>
+                <div className={tableStyles.textClipContainer}>
                     {budgetLine?.agreement?.id ? (
                         <Link
                             to={`/agreements/${budgetLine.agreement.id}`}
@@ -67,7 +68,7 @@ const AllBLIRow = ({ budgetLine }) => {
                 </div>
             </td>
             <td data-cy="agreement-type">
-                <div style={{ height: "1.5rem", overflow: "visible", position: "relative" }}>
+                <div className={tableStyles.textClipContainer}>
                     <TextClip
                         text={convertCodeForDisplay("agreementType", budgetLine?.agreement?.agreement_type) || NO_DATA}
                         maxLines={1}
@@ -78,7 +79,7 @@ const AllBLIRow = ({ budgetLine }) => {
             <td data-cy="date-needed">{formatDateNeeded(budgetLine?.date_needed ?? "")}</td>
             <td data-cy="can">{budgetLine?.can?.display_name}</td>
             <td data-cy="portfolio-name">
-                <div style={{ height: "1.5rem", overflow: "visible", position: "relative" }}>
+                <div className={tableStyles.textClipContainer}>
                     <TextClip
                         text={isPortfolioLoading ? "Loading..." : (budgetLinePortfolio?.abbreviation ?? NO_DATA)}
                         maxLines={1}

--- a/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.jsx
+++ b/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.jsx
@@ -8,6 +8,7 @@ import useGetUserFullNameFromId from "../../../hooks/user.hooks";
 import TableRowExpandable from "../../UI/TableRowExpandable";
 import { expandedRowBGColor } from "../../UI/TableRowExpandable/TableRowExpandable.helpers";
 import { useTableRow } from "../../UI/TableRowExpandable/TableRowExpandable.hooks";
+import tableStyles from "../../UI/Table/table.module.css";
 import TableTag from "../../UI/TableTag";
 import TextClip from "../../UI/Text/TextClip";
 import { getProcurementShopLabel } from "../../../helpers/budgetLines.helpers";
@@ -66,7 +67,7 @@ const CANBudgetLineTableRow = ({
         <>
             <td>{blId}</td>
             <td>
-                <div style={{ height: "1.5rem", overflow: "visible", position: "relative" }}>
+                <div className={tableStyles.textClipContainer}>
                     {budgetLine.agreement ? (
                         <Link
                             className="text-ink text-no-underline"

--- a/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.jsx
+++ b/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.jsx
@@ -8,7 +8,6 @@ import useGetUserFullNameFromId from "../../../hooks/user.hooks";
 import TableRowExpandable from "../../UI/TableRowExpandable";
 import { expandedRowBGColor } from "../../UI/TableRowExpandable/TableRowExpandable.helpers";
 import { useTableRow } from "../../UI/TableRowExpandable/TableRowExpandable.hooks";
-import tableStyles from "../../UI/Table/table.module.css";
 import TableTag from "../../UI/TableTag";
 import TextClip from "../../UI/Text/TextClip";
 import { getProcurementShopLabel } from "../../../helpers/budgetLines.helpers";
@@ -62,26 +61,27 @@ const CANBudgetLineTableRow = ({
     const resolvedAgreementName =
         agreementName?.trim() ||
         (budgetLine?.agreement?.id ? `Agreement ${budgetLine.agreement.id}` : "Agreement details");
-    const hasAgreementLink = Boolean(budgetLine.agreement);
 
     const TableRowData = (
         <>
             <td>{blId}</td>
             <td>
-                {budgetLine.agreement ? (
-                    <Link
-                        className="text-ink text-no-underline"
-                        to={`/agreements/${budgetLine.agreement.id}`}
-                        aria-label={resolvedAgreementName}
-                    >
-                        <TextClip
-                            text={agreementName?.trim() || `${budgetLine.agreement.id}`}
-                            maxLines={1}
-                        />
-                    </Link>
-                ) : (
-                    <span className="text-ink">{agreementName}</span>
-                )}
+                <div style={{ height: "1.5rem", overflow: "visible", position: "relative" }}>
+                    {budgetLine.agreement ? (
+                        <Link
+                            className="text-ink text-no-underline"
+                            to={`/agreements/${budgetLine.agreement.id}`}
+                            aria-label={resolvedAgreementName}
+                        >
+                            <TextClip
+                                text={agreementName?.trim() || `${budgetLine.agreement.id}`}
+                                maxLines={1}
+                            />
+                        </Link>
+                    ) : (
+                        <span className="text-ink">{agreementName}</span>
+                    )}
+                </div>
             </td>
             <td>{obligateDate}</td>
             <td>{fiscalYear}</td>
@@ -174,7 +174,6 @@ const CANBudgetLineTableRow = ({
             isExpanded={isExpanded}
             setIsExpanded={setIsExpanded}
             setIsRowActive={setIsRowActive}
-            className={hasAgreementLink ? tableStyles.noPaddingBottom : undefined}
         />
     );
 };

--- a/frontend/src/components/UI/PaginationNav/PaginationNav.jsx
+++ b/frontend/src/components/UI/PaginationNav/PaginationNav.jsx
@@ -51,7 +51,7 @@ export const PaginationNav = ({ currentPage, setCurrentPage, items = [], itemsPe
                 tmpPageNumberArray.push(null);
             }
 
-            tmpPageNumberArray.push(totalPages);
+            tmpPageNumberArray.push(computedTotalPages);
         }
         setPageNumberArray(tmpPageNumberArray);
     }, [currentPage, totalPages, computedTotalPages]);

--- a/frontend/src/components/UI/PaginationNav/PaginationNav.test.jsx
+++ b/frontend/src/components/UI/PaginationNav/PaginationNav.test.jsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import PaginationNav from "./PaginationNav";
+
+describe("PaginationNav", () => {
+    it("shows last page number when totalPages prop is not passed", () => {
+        const items = Array.from({ length: 80 });
+        render(
+            <PaginationNav
+                currentPage={1}
+                setCurrentPage={vi.fn()}
+                items={items}
+                itemsPerPage={10}
+            />
+        );
+        expect(screen.getByText("8")).toBeInTheDocument();
+    });
+
+    it("shows last page number when totalPages prop is explicitly passed", () => {
+        render(
+            <PaginationNav
+                currentPage={1}
+                setCurrentPage={vi.fn()}
+                totalPages={12}
+            />
+        );
+        expect(screen.getByText("12")).toBeInTheDocument();
+    });
+
+    it("does not render pagination slots for fewer than 7 pages", () => {
+        const items = Array.from({ length: 30 });
+        render(
+            <PaginationNav
+                currentPage={1}
+                setCurrentPage={vi.fn()}
+                items={items}
+                itemsPerPage={10}
+            />
+        );
+        expect(screen.getByText("1")).toBeInTheDocument();
+        expect(screen.getByText("2")).toBeInTheDocument();
+        expect(screen.getByText("3")).toBeInTheDocument();
+        expect(screen.queryByText("4")).not.toBeInTheDocument();
+    });
+
+    it("navigates to next page when Next button is clicked", async () => {
+        const user = userEvent.setup();
+        const setCurrentPage = vi.fn();
+        render(
+            <PaginationNav
+                currentPage={1}
+                setCurrentPage={setCurrentPage}
+                totalPages={5}
+            />
+        );
+        await user.click(screen.getByLabelText("Next page"));
+        expect(setCurrentPage).toHaveBeenCalledWith(2);
+    });
+
+    it("navigates to previous page when Previous button is clicked", async () => {
+        const user = userEvent.setup();
+        const setCurrentPage = vi.fn();
+        render(
+            <PaginationNav
+                currentPage={3}
+                setCurrentPage={setCurrentPage}
+                totalPages={5}
+            />
+        );
+        await user.click(screen.getByLabelText("Previous page"));
+        expect(setCurrentPage).toHaveBeenCalledWith(2);
+    });
+
+    it("navigates to a specific page when page number is clicked", async () => {
+        const user = userEvent.setup();
+        const setCurrentPage = vi.fn();
+        render(
+            <PaginationNav
+                currentPage={1}
+                setCurrentPage={setCurrentPage}
+                totalPages={10}
+            />
+        );
+        await user.click(screen.getByLabelText("Page 4"));
+        expect(setCurrentPage).toHaveBeenCalledWith(4);
+    });
+});

--- a/frontend/src/components/UI/Table/table.module.css
+++ b/frontend/src/components/UI/Table/table.module.css
@@ -12,6 +12,12 @@
     vertical-align: top;
 }
 
+.textClipContainer {
+    height: 1.5rem;
+    overflow: visible;
+    position: relative;
+}
+
 .procurementDetailsTable td:nth-child(2),
 .procurementDetailsTable th:nth-child(2) {
     padding-left: 2rem !important;

--- a/frontend/src/components/UI/Table/table.module.css
+++ b/frontend/src/components/UI/Table/table.module.css
@@ -12,10 +12,6 @@
     vertical-align: top;
 }
 
-.noPaddingBottom td {
-    padding-bottom: 0 !important;
-}
-
 .procurementDetailsTable td:nth-child(2),
 .procurementDetailsTable th:nth-child(2) {
     padding-left: 2rem !important;


### PR DESCRIPTION
## What changed

- Fixed inconsistent table row heights in `CANBudgetLineTableRow` and `AllBLIRow` caused by USWDS tooltip DOM mutations changing cell height when TextClip text overflows
- Fixed PaginationNav not showing the last page number when `totalPages` prop is not explicitly passed
- Removed unused `.noPaddingBottom` CSS class and related dead code

## Issue

#5692

## How to test

1. Navigate to a CAN detail page with multiple budget lines (some with long agreement names, some short)
2. Confirm all rows have equal height regardless of text truncation/tooltip
3. Navigate to the Budget Lines list page — confirm consistent row heights
4. On any paginated table with 7+ pages, confirm the last page number displays correctly

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated