### PR TITLE
fix: move pagination after permission filter in find_in_review_requests_by_user

### DIFF
--- a/backend/ops_api/ops/utils/change_requests_helpers.py
+++ b/backend/ops_api/ops/utils/change_requests_helpers.py
@@ -5,15 +5,18 @@ from sqlalchemy import or_, select
 from sqlalchemy.orm import with_polymorphic
 
 from models import (
+    CAN,
+    Agreement,
     AgreementChangeRequest,
+    BudgetLineItem,
     BudgetLineItemChangeRequest,
     BudgetLineItemStatus,
     ChangeRequest,
     ChangeRequestStatus,
     ChangeRequestType,
     Division,
+    Portfolio,
 )
-from ops_api.ops.utils.agreements_helpers import get_division_directors_for_agreement
 from ops_api.ops.utils.budget_line_items_helpers import (
     convert_BLI_status_name_to_pretty_string,
 )
@@ -69,30 +72,44 @@ def get_division_ids_user_can_review_for(user_id: int) -> set[int]:
     return {row[0] for row in current_app.db_session.execute(stmt).all()}
 
 
+def get_reviewable_agreement_ids_for_user(user_id: int) -> set[int]:
+    """Return agreement IDs where the user is a division director or deputy via BLI→CAN→Portfolio→Division."""
+    stmt = (
+        select(Agreement.id)
+        .join(Agreement.budget_line_items)
+        .join(BudgetLineItem.can)
+        .join(CAN.portfolio)
+        .join(Portfolio.division)
+        .where(
+            or_(
+                Division.division_director_id == user_id,
+                Division.deputy_division_director_id == user_id,
+            )
+        )
+    )
+    return {row[0] for row in current_app.db_session.execute(stmt).all()}
+
+
 def find_in_review_requests_by_user(user_id: int, limit: int = 10, offset: int = 0):
-    # Prepare polymorphic loading to access subtype fields
     cr_poly = with_polymorphic(ChangeRequest, [AgreementChangeRequest, BudgetLineItemChangeRequest])
 
-    # Get explicit divisions
     reviewable_division_ids = get_division_ids_user_can_review_for(user_id)
+    reviewable_agreement_ids = get_reviewable_agreement_ids_for_user(user_id)
 
-    # Query all in-review change requests
-    stmt = select(cr_poly).where(cr_poly.status == ChangeRequestStatus.IN_REVIEW).limit(limit).offset(offset)
+    stmt = select(cr_poly).where(cr_poly.status == ChangeRequestStatus.IN_REVIEW).order_by(ChangeRequest.id)
 
     results = current_app.db_session.execute(stmt).scalars().all()
     filtered_results = []
 
-    # Filter results based on user's review permissions
     for cr in results:
         if isinstance(cr, BudgetLineItemChangeRequest):
             if cr.managing_division_id in reviewable_division_ids:
                 filtered_results.append(cr)
         elif isinstance(cr, AgreementChangeRequest):
-            division_directors, deputies = get_division_directors_for_agreement(cr.agreement)
-            if user_id in division_directors or user_id in deputies:
+            if cr.agreement_id in reviewable_agreement_ids:
                 filtered_results.append(cr)
 
-    return filtered_results
+    return filtered_results[offset : offset + limit]
 
 
 def build_review_outcome_title_and_message(

--- a/backend/ops_api/tests/ops/utils/test_change_requests_helpers.py
+++ b/backend/ops_api/tests/ops/utils/test_change_requests_helpers.py
@@ -4,6 +4,7 @@ import pytest
 
 from models import (
     AgreementChangeRequest,
+    BudgetLineItem,
     BudgetLineItemChangeRequest,
     BudgetLineItemStatus,
     ChangeRequest,
@@ -64,6 +65,44 @@ def test_build_approve_url_raises_on_unrecognized():
         cr_helpers.build_approve_url(cr, agreement_id=1, fe_url="http://localhost")
 
 
+def test_find_in_review_requests_by_user_with_pagination(loaded_db, app_ctx):
+    dave_director = loaded_db.get(User, 522)  # Dave Director — division 4
+    director_derrek = loaded_db.get(User, 525)  # Director Derrek
+
+    # Assign Derrek as director of division 6
+    division_6: Division = loaded_db.get(Division, 6)
+    division_6.division_director_id = director_derrek.id
+    loaded_db.flush()
+
+    bli = loaded_db.get(BudgetLineItem, 15000)
+
+    def make_bli_cr(division_id: int) -> BudgetLineItemChangeRequest:
+        cr = BudgetLineItemChangeRequest()
+        cr.status = ChangeRequestStatus.IN_REVIEW
+        cr.budget_line_item_id = bli.id
+        cr.agreement_id = bli.agreement_id
+        cr.created_by = dave_director.id
+        cr.managing_division_id = division_id
+        cr.requested_change_data = {"amount": 100}
+        loaded_db.add(cr)
+        return cr
+
+    cr1 = make_bli_cr(4)
+    cr2 = make_bli_cr(4)
+    cr3 = make_bli_cr(4)
+    cr4 = make_bli_cr(6)
+    loaded_db.flush()
+
+    # Derrek can only review division 6; with a page size of 3 his lone CR still appears
+    results = cr_helpers.find_in_review_requests_by_user(user_id=director_derrek.id, limit=3, offset=0)
+    result_ids = [r.id for r in results]
+    assert cr1.id not in result_ids
+    assert cr2.id not in result_ids
+    assert cr3.id not in result_ids
+    assert cr4.id in result_ids
+    assert len(results) == 1
+
+
 def test_get_division_ids_user_can_review_for(loaded_db, app_ctx):
     director = User(
         first_name="Jane",
@@ -108,28 +147,21 @@ def test_get_division_ids_user_can_review_for(loaded_db, app_ctx):
 
 @patch("ops_api.ops.utils.change_requests_helpers.current_app", new_callable=Mock)
 @patch("ops_api.ops.utils.change_requests_helpers.get_division_ids_user_can_review_for")
-@patch("ops_api.ops.utils.change_requests_helpers.get_division_directors_for_agreement")
-def test_find_in_review_requests_by_user(mock_get_division_directors, mock_get_division_ids, mock_app, app_ctx):
-    # Mocks 3 change requests
+@patch("ops_api.ops.utils.change_requests_helpers.get_reviewable_agreement_ids_for_user")
+def test_find_in_review_requests_by_user(mock_get_agreement_ids, mock_get_division_ids, mock_app, app_ctx):
     cr1 = Mock(spec=BudgetLineItemChangeRequest, managing_division_id=1)
-    cr2 = Mock(spec=AgreementChangeRequest, agreement="AGREEMENT")
+    cr2 = Mock(spec=AgreementChangeRequest, agreement_id=42)
     cr3 = Mock(spec=BudgetLineItemChangeRequest, managing_division_id=999)  # Should be filtered out
 
-    # Mock the return values for the database session to return the 3 change requests
-    mock_app.db_session.execute.return_value.scalars.return_value.all.return_value = [
-        cr1,
-        cr2,
-        cr3,
-    ]
+    mock_app.db_session.execute.return_value.scalars.return_value.all.return_value = [cr1, cr2, cr3]
 
-    # Mocks the helper functions
     mock_get_division_ids.return_value = {1}
-    mock_get_division_directors.return_value = ([123], [])
+    mock_get_agreement_ids.return_value = {42}
 
     result = cr_helpers.find_in_review_requests_by_user(user_id=123)
     assert cr1 in result
     assert cr2 in result
-    assert cr3 not in result  # cr3 should be filtered out due to managing_division_id not being in {1}
+    assert cr3 not in result  # filtered out — managing_division_id 999 not in {1}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

`find_in_review_requests_by_user` was applying `LIMIT`/`OFFSET` at the SQL level before filtering by division director permissions. This meant a director with a reviewable change request beyond the first page of raw results would never see it — the record was silently cut before the permission check ran.

**`ops/utils/change_requests_helpers.py`**
- Removed `.limit(limit).offset(offset)` from the SQL query; pagination is now a Python slice applied _after_ permission filtering
- Added `get_reviewable_agreement_ids_for_user` — a single SQL join (Agreement → BLI → CAN → Portfolio → Division) that returns all agreement IDs the user can review; replaces the previous per-`AgreementChangeRequest` call to `get_division_directors_for_agreement`, eliminating an N+1 query
- Removed the now-unused `get_division_directors_for_agreement` import

**`tests/ops/utils/test_change_requests_helpers.py`**
- Added `test_find_in_review_requests_by_user_with_pagination`: integration test that seeds 3 CRs for division 4 (Dave Director) and 1 for division 6 (Director Derrek), then asserts that calling with `limit=3, offset=0` as Derrek returns only his CR — reproducing the original bug
- Updated `test_find_in_review_requests_by_user` to patch `get_reviewable_agreement_ids_for_user` instead of the removed `get_division_directors_for_agreement`

## Issue

https://github.com/HHS/OPRE-OPS/issues/5723

## How to test

Run the updated test file:
```bash
cd backend/ops_api
pipenv run pytest tests/ops/utils/test_change_requests_helpers.py -v
```

To reproduce the original bug manually: log in as a division director whose only in-review change request is the 11th or later when all in-review CRs are sorted by ID. Before this fix, the review queue would appear empty for that director.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

N/A — backend changes only

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

## Links

N/A