### PR TITLE
fix: received funding card renders 0 state without bar

### DIFF
--- a/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.jsx
+++ b/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.jsx
@@ -51,9 +51,9 @@ const ReceivedFundingCard = ({ title, totalReceived, totalFunding }) => {
                     dollarsClasses="font-sans-xl text-bold margin-bottom-0"
                     centsStyles={{ fontSize: "10px" }}
                 />
-                {totalFunding > 0 && <Tag tagStyle={"budgetAvailable"}>Received</Tag>}
+                {totalReceived > 0 && <Tag tagStyle={"budgetAvailable"}>Received</Tag>}
             </div>
-            {totalFunding > 0 && (
+            {totalReceived > 0 && (
                 <div
                     id="currency-summary-card"
                     className="margin-top-2"

--- a/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.test.jsx
+++ b/frontend/src/components/UI/Cards/BudgetCard/ReceivedFundingCard.test.jsx
@@ -47,12 +47,12 @@ describe("ReceivedFundingCard", () => {
         expect(screen.getByText("Received")).toBeInTheDocument();
     });
 
-    it("does not render the 'Received' tag when totalFunding is 0", () => {
+    it("does not render the 'Received' tag when totalReceived is 0", () => {
         render(
             <ReceivedFundingCard
                 title="Test"
-                totalReceived={1000}
-                totalFunding={0}
+                totalReceived={0}
+                totalFunding={4500000}
             />
         );
         expect(screen.queryByText("Received")).not.toBeInTheDocument();
@@ -71,15 +71,15 @@ describe("ReceivedFundingCard", () => {
         expect(screen.getByTestId("line-graph-left-bar")).toHaveStyle("flex: 0 1 20%");
     });
 
-    it("does not render the ReverseLineGraph when totalFunding is 0", () => {
+    it("does not render the ReverseLineGraph when totalReceived is 0", () => {
         render(
             <ReceivedFundingCard
                 title="Test"
-                totalReceived={1000}
-                totalFunding={0}
+                totalReceived={0}
+                totalFunding={4500000}
             />
         );
-        expect(screen.queryByRole("img", { hidden: true })).not.toBeInTheDocument();
+        expect(screen.queryByTestId("line-graph-left-bar")).not.toBeInTheDocument();
     });
 
     it("handles zero totalReceived and totalFunding gracefully", () => {

--- a/frontend/src/pages/cans/detail/Can.jsx
+++ b/frontend/src/pages/cans/detail/Can.jsx
@@ -72,6 +72,7 @@ const Can = () => {
                     <CANFiscalYearSelect
                         fiscalYear={fiscalYear}
                         setSelectedFiscalYear={setSelectedFiscalYear}
+                        showAllOption={false}
                     />
                 )}
             </section>

--- a/frontend/src/pages/cans/list/CANFiscalYearSelect/CANFiscalYearSelect.jsx
+++ b/frontend/src/pages/cans/list/CANFiscalYearSelect/CANFiscalYearSelect.jsx
@@ -6,14 +6,15 @@ import FiscalYear from "../../../../components/UI/FiscalYear";
  * @param {Object} props
  * @param {number} props.fiscalYear
  * @param { (e: string) => void } props.setSelectedFiscalYear
+ * @param {boolean} [props.showAllOption=true]
  * @returns  {JSX.Element} - The component JSX.
  */
-const CANFiscalYearSelect = ({ fiscalYear, setSelectedFiscalYear }) => {
+const CANFiscalYearSelect = ({ fiscalYear, setSelectedFiscalYear, showAllOption = true }) => {
     return (
         <FiscalYear
             fiscalYear={fiscalYear}
             handleChangeFiscalYear={setSelectedFiscalYear}
-            showAllOption={true}
+            showAllOption={showAllOption}
         />
     );
 };


### PR DESCRIPTION
## What changed

Corrected $0 rendering of ReceivedFundingCard component and added tests.

Removed incorrect "All" option from Fiscal Year filters within Can Details, Spending and Funding pages. 

## Issue

#3686 

## How to test

- frontend tests pass
- go to cans/523/funding and set the Fiscal Year filter to 2025
- Verify that the received funding card renders $0 without the bar

## A11y impact

- [ ] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots

<img width="2224" height="1714" alt="image" src="https://github.com/user-attachments/assets/44b7fd02-c490-4b9b-b30c-e02a4eb89125" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated

