### PR TITLE
fix: COR validation error not clearing/showing on change

### DIFF
--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.test.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.test.js
@@ -534,3 +534,53 @@ describe("useAgreementEditForm - handleDraft creates new agreements", () => {
         expect(navigateMock).not.toHaveBeenCalledWith("/agreements");
     });
 });
+
+describe("useAgreementEditForm - runValidate project_officer validation", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useLocationMock.mockReturnValue({ pathname: "/agreements/1/edit" });
+        useSelectorMock.mockReturnValue(false);
+        hasStateChangedMock.mockReturnValue(false);
+        useEditAgreementDispatchMock.mockReturnValue(vi.fn());
+        useSetStateMock.mockReturnValue(vi.fn());
+        useUpdateAgreementMock.mockReturnValue(vi.fn());
+    });
+
+    it("clears project_officer validation error when a valid officer id is provided via override", () => {
+        useEditAgreementMock.mockReturnValue(
+            makeEditState({
+                agreement_type: "CONTRACT",
+                project_officer_id: null
+            })
+        );
+
+        const { result, rerender } = renderUseAgreementEditForm({ isReviewMode: true });
+
+        act(() => {
+            result.current.runValidate("project_officer", 5, { project_officer_id: 5 });
+        });
+        rerender();
+
+        const errors = result.current.res.getErrors("project_officer");
+        expect(errors).toEqual([]);
+    });
+
+    it("shows project_officer validation error when value is null (cleared)", () => {
+        useEditAgreementMock.mockReturnValue(
+            makeEditState({
+                agreement_type: "CONTRACT",
+                project_officer_id: 5
+            })
+        );
+
+        const { result, rerender } = renderUseAgreementEditForm({ isReviewMode: true });
+
+        act(() => {
+            result.current.runValidate("project_officer", null, { project_officer_id: null });
+        });
+        rerender();
+
+        const errors = result.current.res.getErrors("project_officer");
+        expect(errors).toContain("This is required information");
+    });
+});

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -478,7 +478,7 @@ const AgreementEditForm = ({
                     messages={res.getErrors("project_officer")}
                     onChange={(name, value) => {
                         if (isReviewMode) {
-                            runValidate(name, value);
+                            runValidate(name, value, { project_officer_id: value });
                         }
                     }}
                     overrideStyles={{ width: "15em" }}

--- a/frontend/src/components/Agreements/ProjectOfficerComboBox.jsx
+++ b/frontend/src/components/Agreements/ProjectOfficerComboBox.jsx
@@ -46,7 +46,7 @@ export const ProjectOfficerComboBox = ({
 
     const handleChange = (user) => {
         setSelectedProjectOfficer(user);
-        onChange("project_officer", user.id);
+        onChange("project_officer", user?.id ?? null);
     };
 
     return (

--- a/frontend/src/components/Agreements/ProjectOfficerComboBox.test.jsx
+++ b/frontend/src/components/Agreements/ProjectOfficerComboBox.test.jsx
@@ -1,0 +1,111 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi, expect, describe, it, beforeEach } from "vitest";
+import { ProjectOfficerComboBox } from "./ProjectOfficerComboBox";
+import { useGetUsersQuery } from "../../api/opsAPI";
+
+vi.mock("react-router-dom", () => ({
+    useNavigate: () => vi.fn()
+}));
+
+vi.mock("../../api/opsAPI", () => ({
+    useGetUsersQuery: vi.fn()
+}));
+
+vi.mock("../UI/Form/ComboBox", () => ({
+    default: ({ selectedData, setSelectedData }) => (
+        <div data-testid="combobox">
+            <button
+                data-testid="select-user"
+                onClick={() => setSelectedData({ id: 5, display_name: "Jane Doe" })}
+            >
+                Select
+            </button>
+            <button
+                data-testid="clear-user"
+                onClick={() => setSelectedData(null)}
+            >
+                Clear
+            </button>
+            {selectedData && <span data-testid="selected">{selectedData.display_name}</span>}
+        </div>
+    )
+}));
+
+describe("ProjectOfficerComboBox", () => {
+    const mockSetSelectedProjectOfficer = vi.fn();
+    const mockOnChange = vi.fn();
+    const mockUsers = [
+        { id: 5, display_name: "Jane Doe", full_name: "Jane Doe", email: "jane@example.com" },
+        { id: 6, display_name: "John Smith", full_name: "John Smith", email: "john@example.com" }
+    ];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useGetUsersQuery.mockReturnValue({
+            data: mockUsers,
+            error: null,
+            isLoading: false
+        });
+    });
+
+    it("calls onChange with user id when a user is selected", () => {
+        render(
+            <ProjectOfficerComboBox
+                selectedProjectOfficer={null}
+                setSelectedProjectOfficer={mockSetSelectedProjectOfficer}
+                onChange={mockOnChange}
+            />
+        );
+
+        fireEvent.click(screen.getByTestId("select-user"));
+
+        expect(mockSetSelectedProjectOfficer).toHaveBeenCalledWith({ id: 5, display_name: "Jane Doe" });
+        expect(mockOnChange).toHaveBeenCalledWith("project_officer", 5);
+    });
+
+    it("calls onChange with null when the selection is cleared", () => {
+        render(
+            <ProjectOfficerComboBox
+                selectedProjectOfficer={{ id: 5, display_name: "Jane Doe" }}
+                setSelectedProjectOfficer={mockSetSelectedProjectOfficer}
+                onChange={mockOnChange}
+            />
+        );
+
+        fireEvent.click(screen.getByTestId("clear-user"));
+
+        expect(mockSetSelectedProjectOfficer).toHaveBeenCalledWith(null);
+        expect(mockOnChange).toHaveBeenCalledWith("project_officer", null);
+    });
+
+    it("renders loading state", () => {
+        useGetUsersQuery.mockReturnValue({
+            data: undefined,
+            error: null,
+            isLoading: true
+        });
+
+        render(
+            <ProjectOfficerComboBox
+                selectedProjectOfficer={null}
+                setSelectedProjectOfficer={mockSetSelectedProjectOfficer}
+            />
+        );
+
+        expect(screen.getByText("Loading...")).toBeInTheDocument();
+    });
+
+    it("displays validation error messages", () => {
+        render(
+            <ProjectOfficerComboBox
+                selectedProjectOfficer={null}
+                setSelectedProjectOfficer={mockSetSelectedProjectOfficer}
+                messages={["This is required information"]}
+                label="Project Officer"
+            />
+        );
+
+        expect(screen.getByText("This is required information")).toBeInTheDocument();
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+});

--- a/frontend/src/pages/projects/detail/ProjectFunding.jsx
+++ b/frontend/src/pages/projects/detail/ProjectFunding.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import App from "../../../App";
 import { useGetProjectByIdQuery, useGetProjectFundingByIdQuery } from "../../../api/opsAPI";
-import DebugCode from "../../../components/DebugCode";
 import ProjectFundingByCANCard from "../../../components/Projects/ProjectFundingByCANCard/ProjectFundingByCANCard";
 import ProjectFundingByFYCard from "../../../components/Projects/ProjectFundingByFYCard/ProjectFundingByFYCard";
 import ProjectFundingByPortfolioCard from "../../../components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard";
@@ -129,7 +128,6 @@ const ProjectFunding = () => {
                     />
                 )}
             </section>
-            <DebugCode data={fundingData} />
         </App>
     );
 };

--- a/frontend/src/pages/projects/detail/ProjectFunding.test.jsx
+++ b/frontend/src/pages/projects/detail/ProjectFunding.test.jsx
@@ -166,7 +166,6 @@ describe("ProjectFunding", () => {
         expect(screen.getByTestId("project-funding-by-can-card")).toBeInTheDocument();
         expect(screen.getByTestId("project-funding-by-fy-card")).toBeInTheDocument();
         expect(screen.getByTestId("project-funding-cans-table")).toBeInTheDocument();
-        expect(screen.getByTestId("debug-code")).toBeInTheDocument();
     });
 
     it("passes CAN data to the table", () => {

--- a/frontend/src/pages/projects/detail/ProjectSpending.jsx
+++ b/frontend/src/pages/projects/detail/ProjectSpending.jsx
@@ -6,7 +6,6 @@ import {
     useGetProjectByIdQuery,
     useGetProjectSpendingByIdQuery
 } from "../../../api/opsAPI";
-import DebugCode from "../../../components/DebugCode";
 import FiscalYear from "../../../components/UI/FiscalYear";
 import DonutGraphWithLegendCard from "../../../components/UI/Cards/DonutGraphWithLegendCard";
 import { AGREEMENT_TYPE_ORDER } from "../../../components/Agreements/AgreementSpendingCards/AgreementSpendingCards.constants";
@@ -231,15 +230,6 @@ const ProjectSpending = () => {
                         />
                     ))}
             </section>
-
-            <DebugCode
-                title="Project Spending API Response"
-                data={spendingData}
-            />
-            <DebugCode
-                title="Agreements (raw list / filtered)"
-                data={{ all: allAgreements, forFY: agreementsForFY, selectedFY }}
-            />
         </App>
     );
 };

--- a/frontend/src/pages/projects/list/ProjectsList.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import { PacmanLoader } from "react-spinners";
 import { useGetProjectsQuery, useLazyGetProjectsQuery, useGetProjectsFilterOptionsQuery } from "../../../api/opsAPI";
 import App from "../../../App";
-import DebugCode from "../../../components/DebugCode";
 import TablePageLayout from "../../../components/Layouts/TablePageLayout";
 import ProjectSummaryCardsSection from "../../../components/Projects/ProjectSummaryCardsSection";
 import ProjectsTable from "../../../components/Projects/ProjectsTable";
@@ -218,9 +217,7 @@ const ProjectsList = () => {
                         )}
                     </>
                 }
-            >
-                <DebugCode data={projectsResponse} />
-            </TablePageLayout>
+            ></TablePageLayout>
         </App>
     );
 };


### PR DESCRIPTION
## What changed

Fixed two validation bugs with the COR (Project Officer) ComboBox in the Agreement Edit Form:

1. **Validation error wouldn't clear** after selecting a COR — `runValidate` was patching `project_officer` but the suite checks `project_officer_id`. Added `{ project_officer_id: value }` override so the suite validates against the correct field.
2. **Required error wouldn't appear** after clearing the COR — `ProjectOfficerComboBox.handleChange` called `user.id` which throws when `user` is `null` (on clear). Changed to `user?.id ?? null` so `onChange` fires with `null` and triggers the required-field error.

Also includes a prior commit removing unused `DebugCode` references from project pages.

## Issue

#5730

## How to test

1. Navigate to an agreement in review mode
2. Clear the COR field → required validation error should appear
3. Select a COR → validation error should clear
4. Clear the COR again → required error reappears

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [x] Form validations updated