### PR TITLE
fix: corrected agreement filtering for dashboard details

### DIFF
--- a/frontend/cypress/e2e/procurementDashboard.cy.js
+++ b/frontend/cypress/e2e/procurementDashboard.cy.js
@@ -25,6 +25,32 @@ describe("Procurement Dashboard - Role-Based Access", () => {
     });
 });
 
+describe("Procurement Dashboard - Summary/Details Consistency", () => {
+    beforeEach(() => {
+        testLogin("procurement-team");
+        cy.visit("/procurement-dashboard");
+        cy.get("[data-cy='procurement-overview-card']", { timeout: 30000 }).should("exist");
+    });
+
+    it("step accordion agreement counts match summary card counts", () => {
+        getAgreementCount().then((totalFromOverview) => {
+            // Expand all detail accordions
+            cy.get("[data-cy^='step-builder-accordion-']").each(($accordion) => {
+                cy.wrap($accordion).find("button.usa-accordion__button").click();
+            });
+
+            // Sum agreement counts from each expanded step
+            cy.get("[data-cy='details-step-agreements-count']").then(($counts) => {
+                let totalFromDetails = 0;
+                $counts.each((_, el) => {
+                    totalFromDetails += parseInt(el.textContent, 10) || 0;
+                });
+                expect(totalFromDetails).to.equal(totalFromOverview);
+            });
+        });
+    });
+});
+
 describe("Procurement Dashboard - Authorized User", () => {
     beforeEach(() => {
         testLogin("procurement-team");

--- a/frontend/src/pages/procurementDashboard/details/ProcurementDetails.jsx
+++ b/frontend/src/pages/procurementDashboard/details/ProcurementDetails.jsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { useGetUsersQuery } from "../../../api/opsAPI";
+import { BLI_STATUS } from "../../../helpers/budgetLines.helpers";
 import DetailsBuilderAccordion from "./DetailsBuilderAccordion";
 import ProcurementDetailsStep from "./ProcurementDetailsStep";
 
@@ -51,21 +52,25 @@ const ProcurementDetails = ({
     const daysInStep = procurementDaysInStep ?? {};
 
     const agreementsByStep = useMemo(() => {
-        const stepToAgreementIds = {};
+        const agreementById = Object.fromEntries(agreements.map((agreement) => [agreement.id, agreement]));
+        const result = {};
+
         for (const tracker of procurementTrackers) {
-            if (!stepToAgreementIds[tracker.active_step_number]) {
-                stepToAgreementIds[tracker.active_step_number] = new Set();
-            }
-            stepToAgreementIds[tracker.active_step_number].add(tracker.agreement_id);
+            const agreement = agreementById[tracker.agreement_id];
+            if (!agreement) continue;
+
+            const hasExecutingBli = (agreement.budget_line_items || []).some(
+                (bli) => bli.fiscal_year === fiscalYear && bli.status === BLI_STATUS.EXECUTING
+            );
+            if (!hasExecutingBli) continue;
+
+            const step = tracker.active_step_number;
+            if (!result[step]) result[step] = [];
+            result[step].push(agreement);
         }
 
-        const result = {};
-        for (const stepNumber of Object.keys(stepToAgreementIds)) {
-            const ids = stepToAgreementIds[stepNumber];
-            result[stepNumber] = agreements.filter((a) => ids.has(a.id));
-        }
         return result;
-    }, [agreements, procurementTrackers]);
+    }, [agreements, procurementTrackers, fiscalYear]);
 
     return (
         <>

--- a/frontend/src/pages/procurementDashboard/details/ProcurementDetails.test.jsx
+++ b/frontend/src/pages/procurementDashboard/details/ProcurementDetails.test.jsx
@@ -99,9 +99,10 @@ describe("ProcurementDetails", () => {
     });
 
     it("groups agreements into steps based on tracker active_step_number", () => {
+        const executingBli = { fiscal_year: 2025, status: "IN_EXECUTION", amount: 100, fees: 0 };
         const agreements = [
-            makeAgreement({ id: 1, display_name: "Agreement Step 1" }),
-            makeAgreement({ id: 2, display_name: "Agreement Step 3" })
+            makeAgreement({ id: 1, display_name: "Agreement Step 1", budget_line_items: [executingBli] }),
+            makeAgreement({ id: 2, display_name: "Agreement Step 3", budget_line_items: [executingBli] })
         ];
 
         const procurementTrackers = [
@@ -115,12 +116,26 @@ describe("ProcurementDetails", () => {
         expect(rows).toHaveLength(2);
     });
 
+    it("excludes agreements without executing BLIs in the fiscal year", () => {
+        const draftBli = { fiscal_year: 2025, status: "DRAFT", amount: 100, fees: 0 };
+        const agreements = [
+            makeAgreement({ id: 1, display_name: "Draft Only", budget_line_items: [draftBli] })
+        ];
+
+        const procurementTrackers = [{ agreement_id: 1, active_step_number: 1, steps: [] }];
+
+        renderComponent({ agreements, procurementTrackers });
+
+        expect(screen.queryByTestId("expandable-row")).not.toBeInTheDocument();
+    });
+
     it("resolves user display names from the users query", () => {
         mockUseGetUsersQuery.mockReturnValue({
             data: [{ id: 500, display_name: "Jane Doe" }]
         });
 
-        const agreements = [makeAgreement({ id: 1, project_officer_id: 500 })];
+        const executingBli = { fiscal_year: 2025, status: "IN_EXECUTION", amount: 100, fees: 0 };
+        const agreements = [makeAgreement({ id: 1, project_officer_id: 500, budget_line_items: [executingBli] })];
         const procurementTrackers = [{ agreement_id: 1, active_step_number: 1, steps: [] }];
 
         renderComponent({ agreements, procurementTrackers });
@@ -133,7 +148,8 @@ describe("ProcurementDetails", () => {
             data: [{ id: 500, full_name: "Jane M. Doe" }]
         });
 
-        const agreements = [makeAgreement({ id: 1, project_officer_id: 500 })];
+        const executingBli = { fiscal_year: 2025, status: "IN_EXECUTION", amount: 100, fees: 0 };
+        const agreements = [makeAgreement({ id: 1, project_officer_id: 500, budget_line_items: [executingBli] })];
         const procurementTrackers = [{ agreement_id: 1, active_step_number: 1, steps: [] }];
 
         renderComponent({ agreements, procurementTrackers });

--- a/frontend/src/pages/procurementDashboard/details/ProcurementDetails.test.jsx
+++ b/frontend/src/pages/procurementDashboard/details/ProcurementDetails.test.jsx
@@ -118,9 +118,7 @@ describe("ProcurementDetails", () => {
 
     it("excludes agreements without executing BLIs in the fiscal year", () => {
         const draftBli = { fiscal_year: 2025, status: "DRAFT", amount: 100, fees: 0 };
-        const agreements = [
-            makeAgreement({ id: 1, display_name: "Draft Only", budget_line_items: [draftBli] })
-        ];
+        const agreements = [makeAgreement({ id: 1, display_name: "Draft Only", budget_line_items: [draftBli] })];
 
         const procurementTrackers = [{ agreement_id: 1, active_step_number: 1, steps: [] }];
 

--- a/frontend/src/pages/procurementDashboard/details/ProcurementDetailsStep.jsx
+++ b/frontend/src/pages/procurementDashboard/details/ProcurementDetailsStep.jsx
@@ -58,7 +58,10 @@ const ProcurementDetailsStep = ({
                     >
                         <dl className="margin-0 font-12px">
                             <dt className="margin-0 text-base-dark margin-top-3">Agreements</dt>
-                            <dd className="margin-0 margin-top-1">
+                            <dd
+                                className="margin-0 margin-top-1"
+                                data-cy="details-step-agreements-count"
+                            >
                                 <Tag
                                     tagStyle="primaryDarkTextLightBackground"
                                     text={agreementsPerStep}

--- a/frontend/src/pages/procurementDashboard/summary/StepLegendItem.jsx
+++ b/frontend/src/pages/procurementDashboard/summary/StepLegendItem.jsx
@@ -35,7 +35,12 @@ const StepLegendItem = ({ id, activeId, label, value, color, percent }) => {
                 />
                 <span className={isActive ? "fake-bold" : ""}>{label}</span>
             </div>
-            <span className={`flex-1 text-center ${isActive ? "fake-bold" : ""}`}>{value}</span>
+            <span
+                className={`flex-1 text-center ${isActive ? "fake-bold" : ""}`}
+                data-cy="step-legend-agreement-count"
+            >
+                {value}
+            </span>
             <div className="flex-1 text-right">
                 <Tag
                     tagStyle="darkTextWhiteBackground"


### PR DESCRIPTION
## What changed

Added an executing BLI filter to agreementsByStep in ProcurementDetails.jsx so only agreements with an IN_EXECUTION budget line in the current fiscal year appear in procurement step details.

## Issue

#5722 

## How to test

- Frontend tests pass

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated