### PR TITLE
Add numeric display conventions to frontend/CLAUDE.md

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -177,7 +177,7 @@ When using `react-currency-format`, set both `decimalScale={2}` and `fixedDecima
 <CurrencyFormat value={amount} fixedDecimalScale={true} prefix="$" />
 ```
 
-For prominent summary totals, `src/components/UI/CurrencyWithSmallCents/CurrencyWithSmallCents.jsx` is available as an option to render dollars in a larger font and cents in a smaller font (used by some Portfolio and Agreement summary cards). It is not required — use it when you want that visual hierarchy.
+For card totals rendered at large font sizes (`font-sans-xl` / 2 rem or larger), use `src/components/UI/CurrencyWithSmallCents/CurrencyWithSmallCents.jsx` to render dollars in the large font and cents in a smaller font. This is required — large bold cents at 32 px+ look disproportionate. See `BudgetCard`, `BigBudgetCard`, `CurrencyCard`, and `ReceivedFundingCard` for existing usage. Cards with smaller text sizes for amounts (e.g., legend rows, table cells) can render cents at the same size as the dollars using standard `CurrencyFormat`.
 
 ### Percentages: Use the `<1%` and 99-Cap Conventions
 
@@ -211,7 +211,7 @@ The `Tag` component renders these values verbatim, so a `percent` of `"<1"` disp
 - `src/api/opsAuthAPI.js`: Authentication-specific endpoints
 - `src/store.js`: Redux store configuration
 - `src/components/UI/`: Shared UI components
-- `src/components/UI/CurrencyWithSmallCents/CurrencyWithSmallCents.jsx`: Optional component for rendering dollars and cents at different font sizes
+- `src/components/UI/CurrencyWithSmallCents/CurrencyWithSmallCents.jsx`: Required for large-font (font-sans-xl+) currency totals on cards
 - `src/helpers/agreement.helpers.js`: Agreement calculation helpers
 - `src/helpers/utils.js`: Shared helpers including `computeDisplayPercents` / `computeDisplayPercent` and `convertToCurrency`
 - `src/helpers/currencyFormat.helpers.js`: `getDecimalScale` and other currency-formatting helpers

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -142,7 +142,9 @@ navigate("/agreements");
 
 Import from `src/helpers/scrollToTop.helper`. Do NOT call `scrollToTop()` on error paths.
 
-## Fee Percentage Format Convention
+## Numeric Display Conventions
+
+### Fee Percentage Storage
 
 **CRITICAL**: Fee percentages are whole numbers (e.g., `5.0` = 5%). The `calculateTotal` helper in `src/helpers/agreement.helpers.js` divides by 100 internally.
 
@@ -154,13 +156,65 @@ const fee = calculateTotal(budgetLines, 5.0); // 5% fee rate
 const fee = calculateTotal(budgetLines, 5.0 / 100); // Results in 0.05% fee rate
 ```
 
+### Currency Display: Always Show Two-Digit Cents
+
+Currency values in the UI must render with exactly two decimal places (rounded, not truncated). Never display a raw float like `$130,143,958.5836`.
+
+When using `react-currency-format`, set both `decimalScale={2}` and `fixedDecimalScale={true}`. Match the existing codebase pattern of suppressing cents only on a true zero by using `decimalScale={value === 0 ? 0 : 2}`, so `$0` (not `$0.00`) shows for empty states — see `src/components/UI/Cards/LineGraphWithLegendCard/LegendItem.jsx` and `src/components/Portfolios/PortfolioSummaryCards/PortfolioLegend.jsx`.
+
+```jsx
+// CORRECT — rounds to 2 decimals, $0 for zero
+<CurrencyFormat
+    value={amount}
+    displayType="text"
+    thousandSeparator={true}
+    prefix="$"
+    decimalScale={amount === 0 ? 0 : 2}
+    fixedDecimalScale
+/>
+
+// INCORRECT — fixedDecimalScale without decimalScale leaks raw float digits
+<CurrencyFormat value={amount} fixedDecimalScale={true} prefix="$" />
+```
+
+For prominent summary totals, `src/components/UI/CurrencyWithSmallCents/CurrencyWithSmallCents.jsx` is available as an option to render dollars in a larger font and cents in a smaller font (used by some Portfolio and Agreement summary cards). It is not required — use it when you want that visual hierarchy.
+
+### Percentages: Use the `<1%` and 99-Cap Conventions
+
+Multi-segment legends and summary breakdowns must follow these display rules:
+
+1. A non-zero value that rounds down to 0% displays as `<1%`, never `0%`. `0%` is reserved for values that are truly zero.
+2. When one segment would round to 100% but other non-zero segments exist, cap the dominant segment at `99%` (per Figma spec — never `>99%`).
+3. When all segments round to whole numbers, the displayed integers should sum to exactly 100 via the largest-remainder algorithm.
+
+Use the helpers in `src/helpers/utils.js`:
+
+- `computeDisplayPercents(items)` — apply this to the **full array** of legend/segment items. It performs cross-item normalization (rules 1–3 above) and is the right choice for any multi-item legend, donut, or stacked bar. Examples: `BLIStatusSummaryCard`, `PortfolioLegend`, `AgreementSpendingCards`.
+- `computeDisplayPercent(value, total)` — single-item helper. Only handles rule 1 (`<1%`). Use this only when the surrounding context already guarantees rules 2 and 3 don't apply (e.g., a standalone metric, not a legend).
+
+```javascript
+// CORRECT — cross-item normalization for a legend
+const legendData = computeDisplayPercents(rawItems);
+
+// INCORRECT — per-item calls in a loop lose the 99-cap and sum-to-100 rules
+const legendData = rawItems.map((item) => ({
+    ...item,
+    percent: computeDisplayPercent(item.value, total)
+}));
+```
+
+The `Tag` component renders these values verbatim, so a `percent` of `"<1"` displays as `<1%` and `99` displays as `99%` without further string handling.
+
 ## Important Files
 
 - `src/api/opsAPI.js`: RTK Query API with all endpoints
 - `src/api/opsAuthAPI.js`: Authentication-specific endpoints
 - `src/store.js`: Redux store configuration
 - `src/components/UI/`: Shared UI components
+- `src/components/UI/CurrencyWithSmallCents/CurrencyWithSmallCents.jsx`: Optional component for rendering dollars and cents at different font sizes
 - `src/helpers/agreement.helpers.js`: Agreement calculation helpers
+- `src/helpers/utils.js`: Shared helpers including `computeDisplayPercents` / `computeDisplayPercent` and `convertToCurrency`
+- `src/helpers/currencyFormat.helpers.js`: `getDecimalScale` and other currency-formatting helpers
 - `src/pages/`: Page-level components (route targets)
 - `cypress/e2e/`: E2E test specs
 - `cypress/support/commands.js`: Custom Cypress commands

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -160,24 +160,21 @@ const fee = calculateTotal(budgetLines, 5.0 / 100); // Results in 0.05% fee rate
 
 Currency values in the UI must render with exactly two decimal places (rounded, not truncated). Never display a raw float like `$130,143,958.5836`.
 
-When using `react-currency-format`, set both `decimalScale={2}` and `fixedDecimalScale={true}`. Match the existing codebase pattern of suppressing cents only on a true zero by using `decimalScale={value === 0 ? 0 : 2}`, so `$0` (not `$0.00`) shows for empty states — see `src/components/UI/Cards/LineGraphWithLegendCard/LegendItem.jsx` and `src/components/Portfolios/PortfolioSummaryCards/PortfolioLegend.jsx`.
+For **display-only** (read-only) currency, use the `formatCurrency()` helper from `src/helpers/currencyFormat.helpers.js`. It already enforces the project convention: zero renders as `$0` (no decimals), non-zero renders with exactly two decimals (e.g., `$1,234.50`). Null, undefined, NaN, and Infinity coerce to `$0`.
 
 ```jsx
-// CORRECT — rounds to 2 decimals, $0 for zero
-<CurrencyFormat
-    value={amount}
-    displayType="text"
-    thousandSeparator={true}
-    prefix="$"
-    decimalScale={amount === 0 ? 0 : 2}
-    fixedDecimalScale
-/>
+import { formatCurrency } from "../../helpers/currencyFormat.helpers";
 
-// INCORRECT — fixedDecimalScale without decimalScale leaks raw float digits
-<CurrencyFormat value={amount} fixedDecimalScale={true} prefix="$" />
+// CORRECT — handles zero suppression and 2-decimal rounding internally
+<span>{formatCurrency(amount)}</span>
+
+// INCORRECT — manual Intl.NumberFormat without the zero-suppression rule
+<span>{new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(amount)}</span>
 ```
 
-For card totals rendered at large font sizes (`font-sans-xl` / 2 rem or larger), use `src/components/UI/CurrencyWithSmallCents/CurrencyWithSmallCents.jsx` to render dollars in the large font and cents in a smaller font. This is required — large bold cents at 32 px+ look disproportionate. See `BudgetCard`, `BigBudgetCard`, `CurrencyCard`, and `ReceivedFundingCard` for existing usage. Cards with smaller text sizes for amounts (e.g., legend rows, table cells) can render cents at the same size as the dollars using standard `CurrencyFormat`.
+For **form inputs** accepting currency, use the `CurrencyInput` component (`src/components/UI/Form/CurrencyInput/CurrencyInput.jsx`), which wraps `react-currency-input-field`.
+
+For card totals rendered at large font sizes (`font-sans-xl` / 2 rem or larger), use `src/components/UI/CurrencyWithSmallCents/CurrencyWithSmallCents.jsx` to render dollars in the large font and cents in a smaller font. This is required — large bold cents at 32 px+ look disproportionate. See `BudgetCard`, `BigBudgetCard`, `CurrencyCard`, and `ReceivedFundingCard` for existing usage. Cards with smaller text sizes for amounts (e.g., legend rows, table cells) can render cents at the same size as the dollars using `formatCurrency()`.
 
 ### Percentages: Use the `<1%` and 99-Cap Conventions
 
@@ -214,7 +211,7 @@ The `Tag` component renders these values verbatim, so a `percent` of `"<1"` disp
 - `src/components/UI/CurrencyWithSmallCents/CurrencyWithSmallCents.jsx`: Required for large-font (font-sans-xl+) currency totals on cards
 - `src/helpers/agreement.helpers.js`: Agreement calculation helpers
 - `src/helpers/utils.js`: Shared helpers including `computeDisplayPercents` / `computeDisplayPercent` and `convertToCurrency`
-- `src/helpers/currencyFormat.helpers.js`: `getDecimalScale` and other currency-formatting helpers
+- `src/helpers/currencyFormat.helpers.js`: `formatCurrency` helper for display-only currency rendering
 - `src/pages/`: Page-level components (route targets)
 - `cypress/e2e/`: E2E test specs
 - `cypress/support/commands.js`: Custom Cypress commands


### PR DESCRIPTION
## What changed

Adds a **Numeric Display Conventions** section to `frontend/CLAUDE.md` that codifies three frontend UI standards discovered while investigating procurement dashboard formatting bugs:

**`frontend/CLAUDE.md`**

- **Fee Percentage Storage** — existing "Fee Percentage Format Convention" restructured as a subsection under the new heading. No content change.
- **Currency Display: Always Show Two-Digit Cents** — documents the `formatCurrency()` helper as the standard for display-only currency, the zero-suppression rule (`$0` not `$0.00`), and the requirement to use `CurrencyWithSmallCents` for card totals at `font-sans-xl` (2 rem+) to avoid disproportionate large-font cents. References existing usage in `BudgetCard`, `BigBudgetCard`, `CurrencyCard`, and `ReceivedFundingCard`.
- **Percentages: Use the `<1%` and 99-Cap Conventions** — documents the three cross-item normalization rules (`<1%` for non-zero sub-1, dominant cap at 99, largest-remainder sum-to-100) and steers developers to `computeDisplayPercents` (plural) for any multi-segment legend, with `computeDisplayPercent` (singular) reserved for standalone metrics only. Includes correct/incorrect code examples.
- **Important Files** — adds entries for `currencyFormat.helpers.js`, `utils.js`, and `CurrencyWithSmallCents.jsx`.

### Dependency on PR #5776

The currency display guidance references the `formatCurrency()` helper and `react-currency-input-field` CurrencyInput component introduced in [PR #5776](https://github.com/HHS/OPRE-OPS/pull/5776) (replaces `react-currency-format`). If that PR lands as proposed, this documentation is accurate on merge. If its approach changes materially, a follow-up update to `frontend/CLAUDE.md` would be needed.

## Issue

N/A — discovered during investigation of procurement dashboard formatting issues (related to #5722).

## How to test

This is a documentation-only change (`frontend/CLAUDE.md`). No runtime behavior is affected.

```bash
cd frontend
cat CLAUDE.md  # verify the new sections read correctly
```

Optionally confirm no lint/format issues:
```bash
bun run lint
bun run format
```

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Screenshots

N/A — documentation only.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [-] Automated unit tests updated and passed
- [-] Automated integration tests updated and passed
- [-] Automated quality tests updated and passed
- [-] Automated load tests updated and passed
- [-] Automated a11y tests updated and passed
- [-] Automated security tests updated and passed
- [-] 90%+ Code coverage achieved
- [-] Form validations updated

## Links

- [PR #5776 — Replace react-currency-format with formatCurrency helper](https://github.com/HHS/OPRE-OPS/pull/5776)
- [Issue #5722 — Procurement Dashboard Production Bug](https://github.com/HHS/OPRE-OPS/issues/5722)