### PR TITLE
feat: show CAN nickname alongside number in CanComboBox dropdown

### DIFF
--- a/frontend/src/components/CANs/CanComboBox/CanComboBox.jsx
+++ b/frontend/src/components/CANs/CanComboBox/CanComboBox.jsx
@@ -89,7 +89,7 @@ const CanComboBox = ({
                     selectedData={selectedCan}
                     setSelectedData={handleChange}
                     defaultString={defaultString}
-                    optionText={(can) => can.display_name || can.number}
+                    optionText={(can) => (can.nick_name ? `${can.number} (${can.nick_name})` : can.number)}
                     overrideStyles={overrideStyles}
                     messages={messages}
                     isDisabled={isDisabled}

--- a/frontend/src/components/CANs/CanComboBox/CanComboBox.test.js
+++ b/frontend/src/components/CANs/CanComboBox/CanComboBox.test.js
@@ -8,7 +8,8 @@ import { MemoryRouter } from "react-router-dom";
 
 const mockFn = TestApplicationContext.helpers().mockFn;
 
-// Mock the ComboBox component
+// Mock the ComboBox component — render option text via the production ``optionText``
+// prop so the test exercises the real formatter rather than re-implementing it.
 vi.mock("../../UI/Form/ComboBox", () => ({
     default: vi.fn((props) => (
         <div data-testid="mocked-combobox">
@@ -23,7 +24,7 @@ vi.mock("../../UI/Form/ComboBox", () => ({
                         key={can.id}
                         value={can.id}
                     >
-                        {can.display_name || can.number}
+                        {props.optionText(can)}
                     </option>
                 ))}
             </select>
@@ -38,14 +39,13 @@ vi.mock("../../../hooks/useGetAllCans", () => ({
             {
                 id: 500,
                 number: "G99HRF2",
-                display_name: "G99HRF2",
-                description: "Test CAN 1"
+                nick_name: "HS",
+                description: "Test CAN with nickname"
             },
             {
                 id: 501,
                 number: "G99IA14",
-                display_name: "G99IA14",
-                description: "Test CAN 2"
+                description: "Test CAN without nickname"
             }
         ],
         error: null,
@@ -124,7 +124,7 @@ describe("CanComboBox", () => {
         expect(selectElement.disabled).toBe(false);
     });
 
-    it("should pass the correct data to ComboBox", () => {
+    it("should render CAN options as 'number (nickname)' when a nickname exists, and just the number otherwise", () => {
         render(
             <MemoryRouter>
                 <Provider store={store}>
@@ -133,8 +133,7 @@ describe("CanComboBox", () => {
             </MemoryRouter>
         );
 
-        // Verify that CAN options are rendered
-        expect(screen.getByText("G99HRF2")).toBeInTheDocument();
+        expect(screen.getByText("G99HRF2 (HS)")).toBeInTheDocument();
         expect(screen.getByText("G99IA14")).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## What changed

- Updated `CanComboBox` so each dropdown option renders as `"<number> (<nickname>)"` when a CAN has a nickname, falling back to just the CAN number otherwise. This makes it easier for users to recognize the right CAN by name rather than having to memorize opaque CAN numbers.
- Updated the co-located unit test fixture to mix CANs with and without nicknames, and asserted the new label format. The mock `<select>` now renders option text via the production `optionText` prop so the test exercises the real formatter.

## Issue

#4638

## How to test

1. Navigate to an agreement and create or edit a budget line item so the CAN combobox is rendered.
1. Open the CAN dropdown.
   - Confirm CANs with a `nick_name` render as `"<number> (<nickname>)"` (e.g., `G99HRF2 (HMRF-OPRE)`).
   - Confirm CANs without a `nick_name` render as just `<number>`.
1. Type a nickname fragment into the combobox and confirm matching options surface (the formatter is also the search string).

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Screenshots
<img width="332" height="391" alt="Screenshot 2026-06-09 at 1 49 55 PM" src="https://github.com/user-attachments/assets/73f3a7af-9a11-479b-953b-bde1c14a7565" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated