### PR TITLE
Delete Planned/Executing budget line items via change request

### DIFF
--- a/backend/models/agreement_history.py
+++ b/backend/models/agreement_history.py
@@ -334,6 +334,41 @@ def create_change_request_history_event(
             reviewer_user = User(id=-1, full_name="Unknown User")
             logger.error(f"Reviewer user for change request {change_request['id']} is None. Using placeholder user.")
         change_request_status = "approved" if change_request["status"] == "APPROVED" else "declined"
+        if property_changed == "delete":
+            # Deletion request: distinct history_type + BLI id handling, so it cannot fall through
+            # to the shared tail return (which would crash on the unset title/message and use the
+            # wrong history_type). Handles both request-created and reviewed (approved/declined).
+            #
+            # Resolve the requestor via the created_by column (not the created_by_user dict): on
+            # approval the BLI is cascade-deleted and the CR is detached before to_dict() runs, so
+            # the relationship-derived created_by_user is None in the event payload.
+            bli_id = change_request["budget_line_item_id"]
+            requestor_user = session.get(User, change_request["created_by"])
+            requestor_name = requestor_user.full_name if requestor_user else "Unknown User"
+            if new_change_request:
+                title = "Budget Line Deletion Requested"
+                message = f"{requestor_name} requested to delete BL {bli_id} and it's currently In Review for approval."
+            else:
+                title = (
+                    "Budget Line Deleted" if change_request["status"] == "APPROVED" else "Budget Line Deletion Declined"
+                )
+                message = (
+                    f"{reviewer_user.full_name} {change_request_status} the deletion of BL {bli_id} "
+                    f"as requested by {requestor_name}."
+                )
+            agreement_id = change_request["agreement_id"]
+            agreement = session.get(Agreement, agreement_id)
+            return AgreementHistory(
+                agreement_id=agreement_id if agreement else None,
+                agreement_id_record=agreement_id,
+                budget_line_id=None,
+                budget_line_id_record=bli_id,
+                ops_event_id=event.id,
+                history_title=title,
+                history_message=message,
+                timestamp=event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                history_type=AgreementHistoryType.BUDGET_LINE_ITEM_DELETED,
+            )
         if property_changed == "status":
             title = f"Status Change to {fix_stringified_enum_values(change_request['requested_change_data']['status'])} {fix_stringified_enum_values(change_request['status'])}"
             if new_change_request:

--- a/backend/models/change_requests.py
+++ b/backend/models/change_requests.py
@@ -113,11 +113,20 @@ class BudgetLineItemChangeRequest(AgreementChangeRequest):
     def has_status_change(cls):
         return cls.requested_change_data.has_key("status")
 
+    @hybrid_property
+    def has_delete_change(self):
+        return "delete" in self.requested_change_data
+
+    @has_delete_change.expression
+    def has_delete_change(cls):
+        return cls.requested_change_data.has_key("delete")
+
     def to_dict(self):
         """Override to_dict to include hybrid properties."""
         data = super().to_dict()
         data["has_budget_change"] = bool(self.has_budget_change)
         data["has_status_change"] = bool(self.has_status_change)
+        data["has_delete_change"] = bool(self.has_delete_change)
         return data
 
 

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -4486,10 +4486,15 @@ paths:
       tags:
         - Budget Line Items
       operationId: deleteBudgetLineItem
-      description: Delete a budget line item
+      description: >-
+        Delete a budget line item. A DRAFT budget line item (and any delete by a super user) is
+        hard-deleted immediately and returns 200. A PLANNED or IN_EXECUTION budget line item routes
+        through an approval workflow: a deletion change request is created and 202 is returned; the
+        budget line item is deleted only once that request is approved. Deletion is blocked (400)
+        once the agreement reaches Pre-Award/Award or while the budget line item is already in review.
       responses:
         "200":
-          description: OK
+          description: OK — budget line item deleted
           content:
             application/json:
               schema:
@@ -4499,6 +4504,19 @@ paths:
                     type: string
                   id:
                     type: integer
+        "202":
+          description: Accepted — a deletion change request was created and is awaiting approval
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  id:
+                    type: integer
+        "400":
+          description: Bad Request
         "401":
           description: Unauthorized
         "404":
@@ -7508,6 +7526,12 @@ components:
         has_status_change:
           type: boolean
           example: false
+        has_delete_change:
+          type: boolean
+          example: false
+          description: >-
+            True when the change request is a request to delete the budget line item (carries a
+            {"delete": true} sentinel in requested_change_data). On approval the BLI is deleted.
         has_proc_shop_change:
           type: boolean
           example: false

--- a/backend/ops_api/ops/resources/budget_line_items.py
+++ b/backend/ops_api/ops/resources/budget_line_items.py
@@ -8,7 +8,7 @@ from loguru import logger
 from marshmallow import ValidationError
 from marshmallow.experimental.context import Context
 
-from models import BaseModel, BudgetLineItem, OpsEventType
+from models import BaseModel, BudgetLineItem, BudgetLineItemStatus, OpsEventType
 from models.utils import generate_events_update
 from ops_api.ops.auth.auth_types import Permission, PermissionType
 from ops_api.ops.auth.decorators import is_authorized
@@ -106,12 +106,26 @@ class BudgetLineItemsItemAPI(BaseItemAPI):
         Permission.BUDGET_LINE_ITEM,
     )
     def delete(self, id: int) -> Response:
-        with OpsEventHandler(OpsEventType.DELETE_BLI) as meta:
-            service: OpsService[BudgetLineItem] = BudgetLineItemService(current_app.db_session)
-            old_bli: BudgetLineItem = service.get(id)
-            service.delete(id)
-            meta.metadata.update({"deleted_bli": old_bli.to_dict()})
-            return make_response_with_headers({"message": "BudgetLineItem deleted", "id": id}, 200)
+        service: OpsService[BudgetLineItem] = BudgetLineItemService(current_app.db_session)
+        old_bli: BudgetLineItem = service.get(id)
+        old_bli_dict = old_bli.to_dict()
+
+        # Peek at how the delete will be handled so we only emit a DELETE_BLI audit event for an
+        # actual hard-delete. PLANNED/IN_EXECUTION deletions route to a change request (202) and
+        # emit their own CREATE_CHANGE_REQUEST event inside the service; emitting DELETE_BLI here
+        # would write a spurious "Budget Line Deleted" history record on mere request submission.
+        is_immediate_delete = is_super_user(current_user, current_app) or old_bli.status == BudgetLineItemStatus.DRAFT
+
+        if is_immediate_delete:
+            with OpsEventHandler(OpsEventType.DELETE_BLI) as meta:
+                _, status_code = service.delete(id)
+                meta.metadata.update({"deleted_bli": old_bli_dict})
+                return make_response_with_headers({"message": "BudgetLineItem deleted", "id": id}, status_code)
+
+        _, status_code = service.delete(id)
+        return make_response_with_headers(
+            {"message": "BudgetLineItem deletion submitted for approval", "id": id}, status_code
+        )
 
 
 class BudgetLineItemsListAPI(BaseListAPI):

--- a/backend/ops_api/ops/resources/change_requests.py
+++ b/backend/ops_api/ops/resources/change_requests.py
@@ -26,6 +26,7 @@ def build_change_request_response(change_request: ChangeRequest):
     if isinstance(change_request, BudgetLineItemChangeRequest):
         resp["has_budget_change"] = change_request.has_budget_change
         resp["has_status_change"] = change_request.has_status_change
+        resp["has_delete_change"] = change_request.has_delete_change
     return resp
 
 

--- a/backend/ops_api/ops/schemas/change_requests.py
+++ b/backend/ops_api/ops/schemas/change_requests.py
@@ -28,6 +28,7 @@ class GenericChangeRequestResponseSchema(ChangeRequestResponseSchema):
     budget_line_item_id = fields.Int(required=False, allow_none=True)
     has_budget_change = fields.Bool(load_default=False)
     has_status_change = fields.Bool(load_default=False)
+    has_delete_change = fields.Bool(load_default=False)
     has_proc_shop_change = fields.Bool(load_default=False)
 
     class Meta:

--- a/backend/ops_api/ops/services/budget_line_items.py
+++ b/backend/ops_api/ops/services/budget_line_items.py
@@ -131,9 +131,14 @@ class BudgetLineItemService:
         self.db_session.commit()
         return new_bli
 
-    def delete(self, id: int) -> None:
+    def delete(self, id: int) -> tuple[BudgetLineItem, int]:
         """
         Delete a Budget Line Item with the given id.
+
+        DRAFT BLIs (and any delete by a super user) are hard-deleted immediately and 200 is
+        returned. PLANNED and IN_EXECUTION BLIs route through an approval workflow: a deletion
+        change request is created and 202 is returned (the BLI is left intact until the request
+        is approved).
         """
         bli = self.db_session.get(BudgetLineItem, id)
 
@@ -149,9 +154,23 @@ class BudgetLineItemService:
                 "BudgetLineItem",
             )
 
-        self.db_session.delete(bli)
-        self.db_session.commit()
-        return bli
+        is_super = is_super_user(current_user, current_app)
+        if is_super or bli.status == BudgetLineItemStatus.DRAFT:
+            self.db_session.delete(bli)
+            self.db_session.commit()
+            return bli, 200
+
+        # PLANNED / IN_EXECUTION: deletion is a budget change and must be reviewed. Reuse the
+        # shared editability gate (in_review + OBE + Pre-Award/Award step block) so the rules
+        # cannot drift from the edit path.
+        if not compute_bli_editable(bli, bli.in_review, is_super):
+            raise ValidationError(
+                {"status": "Budget Line Item is not in a deletable state."},
+            )
+
+        change_request_service = ChangeRequestService(self.db_session)
+        change_request_service.add_bli_delete_change_request(bli)
+        return bli, 202
 
     def get(self, id: int) -> BudgetLineItem:
         """

--- a/backend/ops_api/ops/services/change_requests.py
+++ b/backend/ops_api/ops/services/change_requests.py
@@ -78,11 +78,13 @@ class ChangeRequestService(OpsService[ChangeRequest]):
         reviewer_notes = updated_fields.pop("reviewer_notes", None)
 
         model_to_update = None
+        bli_to_delete = None
 
         # Handle review action if present
         if action:
             result = self._handle_review_action(change_request, action, reviewer_notes)
             model_to_update = result.get("model_to_update")
+            bli_to_delete = result.get("bli_to_delete")
 
         # Apply any direct field updates to the change request
         for key, value in updated_fields.items():
@@ -96,6 +98,25 @@ class ChangeRequestService(OpsService[ChangeRequest]):
 
         self.db_session.commit()
         self._notify_submitter_of_review_outcome(change_request)
+
+        # Deletion-on-approval must happen LAST. The change_request row has
+        # budget_line_item_id ON DELETE CASCADE, so deleting the BLI removes the CR row too, yet the
+        # resource still serializes the change request (via to_dict()) after this returns. We:
+        #   1. finalize the CR (status/reviewed fields above) and notify the submitter — done while
+        #      the CR row still exists;
+        #   2. capture the CR's full serialized form NOW, while it is still attached, so every
+        #      relationship the auto-schema touches (agreement, managing_division, and the
+        #      continuum-injected lazy="dynamic" ``versions``) serializes correctly;
+        #   3. detach (expunge) the CR so the final commit can neither expire nor cascade-refresh it;
+        #   4. delete the BLI last, and pin the CR's to_dict() to the captured snapshot so the
+        #      resource never re-serializes a detached/cascade-deleted instance.
+        # The durable record of the deletion is the AgreementHistory + automatic OpsDBHistory trail.
+        if bli_to_delete is not None:
+            snapshot = change_request.to_dict()
+            self.db_session.expunge(change_request)
+            self.db_session.delete(bli_to_delete)
+            self.db_session.commit()
+            change_request.to_dict = lambda: snapshot
 
         return change_request, 200
 
@@ -177,15 +198,23 @@ class ChangeRequestService(OpsService[ChangeRequest]):
         change_request.status = ChangeRequestStatus.APPROVED if action == "APPROVE" else ChangeRequestStatus.REJECTED
 
         model_to_update = None
+        bli_to_delete = None
 
         if change_request.status == ChangeRequestStatus.APPROVED:
             if change_request.change_request_type == ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST:
-                model_to_update = self._apply_budget_line_item_changes(change_request)
+                if getattr(change_request, "has_delete_change", False):
+                    # A deletion request: don't re-add the BLI (model_to_update stays None).
+                    # The BLI is deleted last in update(), after the CR is finalized — see the
+                    # ordering note there.
+                    bli_to_delete = self.db_session.get(BudgetLineItem, change_request.budget_line_item_id)
+                else:
+                    model_to_update = self._apply_budget_line_item_changes(change_request)
             elif change_request.change_request_type == ChangeRequestType.AGREEMENT_CHANGE_REQUEST:
                 model_to_update = self._apply_agreement_changes(change_request)
 
         return {
             "model_to_update": model_to_update,
+            "bli_to_delete": bli_to_delete,
         }
 
     # --- Notification Handling ---
@@ -304,6 +333,35 @@ class ChangeRequestService(OpsService[ChangeRequest]):
                 cr_meta.metadata.update({"bli_id": bli_id, "change_request": change_request.to_dict()})
 
         return change_request_ids
+
+    def add_bli_delete_change_request(self, budget_line_item: BudgetLineItem) -> int:
+        """
+        Create a single change request representing a request to delete a budget line item.
+
+        The request is marked with a ``{"delete": True}`` sentinel in ``requested_change_data``;
+        the ``requested_change_diff`` carries the current amount (so the reviewer card can show it
+        as currency) against the literal "Deleted".
+        """
+        with OpsEventHandler(OpsEventType.CREATE_CHANGE_REQUEST) as cr_meta:
+            managing_division = get_division_for_budget_line_item(budget_line_item.id)
+
+            # amount is a Decimal; store it as a JSON-native float so the diff serializes to JSONB
+            # (and the frontend formats it as currency), mirroring the amount diff in edit CRs.
+            old_amount = float(budget_line_item.amount) if budget_line_item.amount is not None else None
+
+            change_request_data = {
+                "budget_line_item_id": budget_line_item.id,
+                "agreement_id": budget_line_item.agreement_id,
+                "managing_division_id": (managing_division.id if managing_division else None),
+                "requested_change_data": {"delete": True},
+                "requested_change_diff": {"delete": {"old": old_amount, "new": "Deleted"}},
+                "requested_change_info": {"target_display_name": budget_line_item.display_name},
+                "change_request_type": ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+            }
+
+            change_request = self.create(change_request_data)
+            cr_meta.metadata.update({"bli_id": budget_line_item.id, "change_request": change_request.to_dict()})
+            return change_request.id
 
     def _apply_budget_line_item_changes(self, change_request: BudgetLineItemChangeRequest) -> BudgetLineItem:
         budget_line_item = self.db_session.get(BudgetLineItem, change_request.budget_line_item_id)

--- a/backend/ops_api/ops/utils/budget_line_items_helpers.py
+++ b/backend/ops_api/ops/utils/budget_line_items_helpers.py
@@ -133,26 +133,17 @@ def get_bli_locked_message(budget_line_item, in_review: bool, is_super: bool) ->
     return None
 
 
-# Statuses that can be deleted immediately (hard delete) without an approval workflow.
-IMMEDIATE_DELETE_STATUSES = [
-    BudgetLineItemStatus.DRAFT,
-    BudgetLineItemStatus.PLANNED,
-]
-
-
 def compute_bli_is_deletable(budget_line_item, in_review: bool, is_super: bool) -> bool:
     """Single source of truth for whether the delete control should be enabled.
 
-    PR1 preserves today's delete behavior: a BLI is deletable when it is editable AND its
-    status is one of the immediate-delete statuses (DRAFT/PLANNED), or the user is a super
-    user. This deliberately keeps IN_EXECUTION non-deletable even though it is now editable,
-    so making executing BLIs editable does not auto-enable their delete button.
+    A BLI is deletable whenever it is editable (DRAFT/PLANNED/IN_EXECUTION, not in review, not
+    OBE, agreement not at Pre-Award/Award), or the user is a super user. DRAFT deletes
+    immediately; PLANNED/IN_EXECUTION deletions route through an approval change request (handled
+    in the service). The delete control is therefore enabled in exactly the same cases as edit.
     """
     if budget_line_item is None:
         return False
-    if not compute_bli_editable(budget_line_item, in_review, is_super):
-        return False
-    return is_super or budget_line_item.status in IMMEDIATE_DELETE_STATUSES
+    return compute_bli_editable(budget_line_item, in_review, is_super)
 
 
 def is_bli_editable(budget_line_item):

--- a/backend/ops_api/ops/utils/change_requests_helpers.py
+++ b/backend/ops_api/ops/utils/change_requests_helpers.py
@@ -40,6 +40,9 @@ def build_approve_url(change_request: ChangeRequest, agreement_id: int, fe_url: 
         change_type = "status-change"
     elif getattr(change_request, "has_budget_change", False):
         change_type = "budget-change"
+    elif getattr(change_request, "has_delete_change", False):
+        # A deletion request reviews on the budget-change surface (BudgetChangeReviewCard).
+        change_type = "budget-change"
     elif getattr(change_request, "has_proc_shop_change", False):
         change_type = "procurement-shop-change"
     else:

--- a/backend/ops_api/tests/ops/budget_line_items/test_delete_budget_line_change_request.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_delete_budget_line_change_request.py
@@ -180,6 +180,23 @@ def test_delete_draft_bli_is_immediate(budget_team_auth_client, loaded_db, delet
         _cleanup_bli(loaded_db, bli_id, sc)
 
 
+@pytest.mark.parametrize("status", [BudgetLineItemStatus.PLANNED, BudgetLineItemStatus.IN_EXECUTION])
+def test_super_user_delete_bypasses_change_request(
+    power_user_auth_client, loaded_db, deletable_agreement, test_can, status, app_ctx
+):
+    """A super user deleting a PLANNED/IN_EXECUTION BLI hard-deletes it immediately (200), skipping
+    the change-request approval flow that a non-super-user would be routed through."""
+    bli, sc = _make_bli(loaded_db, deletable_agreement, test_can, status)
+    bli_id = bli.id
+    try:
+        response = power_user_auth_client.delete(url_for("api.budget-line-items-item", id=bli_id))
+        assert response.status_code == 200
+        assert loaded_db.get(ContractBudgetLineItem, bli_id) is None
+        assert loaded_db.query(BudgetLineItemChangeRequest).filter_by(budget_line_item_id=bli_id).count() == 0
+    finally:
+        _cleanup_bli(loaded_db, bli_id, sc)
+
+
 def test_delete_executing_bli_blocked_at_pre_award(
     budget_team_auth_client, loaded_db, deletable_agreement, test_can, make_tracker_at_step, app_ctx
 ):

--- a/backend/ops_api/tests/ops/budget_line_items/test_delete_budget_line_change_request.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_delete_budget_line_change_request.py
@@ -1,0 +1,329 @@
+"""Integration tests for deleting Budget Line Items as a change request (issue #5819, PR2).
+
+Deletion eligibility now mirrors editability:
+  - DRAFT (and any delete by a super user) is hard-deleted immediately (200),
+  - PLANNED and IN_EXECUTION deletions create an approval change request (202); the BLI is left
+    intact until the request is approved,
+  - approving a deletion request deletes the BLI and records a "Budget Line Deleted" history entry,
+  - rejecting it leaves the BLI intact,
+  - deletion is blocked once the agreement reaches Pre-Award (procurement tracker step >= 5).
+
+The CR is a normal BUDGET_LINE_ITEM_CHANGE_REQUEST carrying a ``{"delete": true}`` sentinel, so it
+keeps marking the BLI ``in_review`` and reuses the existing review/approval/notification plumbing.
+
+``budget_team_auth_client`` (BUDGET_TEAM role) creates the request — associated with every agreement
+but not a super user, so the deletion routes to a change request. ``division_director_auth_client`` is
+the reviewer for managing division 5 (the division of CAN 500 used by ``test_can``).
+"""
+
+import datetime
+
+import pytest
+from flask import url_for
+from sqlalchemy import text
+
+from models import (
+    AgreementReason,
+    AgreementType,
+    BudgetLineItemChangeRequest,
+    BudgetLineItemStatus,
+    ChangeRequestStatus,
+    ChangeRequestType,
+    ContractAgreement,
+    ContractBudgetLineItem,
+    ContractType,
+    ProcurementTracker,
+    ProcurementTrackerStatus,
+    ProcurementTrackerType,
+    ServicesComponent,
+)
+
+SYSTEM_OWNER_USER_ID = 503
+
+
+@pytest.fixture()
+def deletable_agreement(loaded_db, test_project):
+    agreement = ContractAgreement(
+        name="Delete BLI Test Agreement",
+        contract_number="CT5819D",
+        contract_type=ContractType.FIRM_FIXED_PRICE,
+        agreement_type=AgreementType.CONTRACT,
+        project_id=test_project.id,
+        product_service_code_id=2,
+        description="Agreement for deleting BLIs as change requests",
+        agreement_reason=AgreementReason.NEW_REQ,
+        project_officer_id=SYSTEM_OWNER_USER_ID,
+        awarding_entity_id=1,
+    )
+    loaded_db.add(agreement)
+    loaded_db.commit()
+
+    yield agreement
+
+    loaded_db.rollback()
+    loaded_db.delete(agreement)
+    loaded_db.commit()
+
+
+def _make_bli(loaded_db, agreement, test_can, status):
+    sc = ServicesComponent(agreement_id=agreement.id, number=1, optional=False)
+    loaded_db.add(sc)
+    loaded_db.commit()
+
+    bli = ContractBudgetLineItem(
+        agreement_id=agreement.id,
+        line_description="BLI to delete",
+        comments="original comment",
+        amount=500000.00,
+        can_id=test_can.id,
+        date_needed=datetime.date(2043, 1, 1),
+        status=status,
+        proc_shop_fee_percentage=1.23,
+        created_by=SYSTEM_OWNER_USER_ID,
+        services_component_id=sc.id,
+    )
+    loaded_db.add(bli)
+    loaded_db.commit()
+    return bli, sc
+
+
+def _cleanup_bli(loaded_db, bli_id, sc):
+    """Remove any change request referencing the BLI, then the BLI and its services component.
+    Safe whether or not the BLI was actually deleted by the test."""
+    loaded_db.rollback()
+    loaded_db.execute(text("DELETE FROM change_request WHERE budget_line_item_id = :id"), {"id": bli_id})
+    loaded_db.commit()
+    bli = loaded_db.get(ContractBudgetLineItem, bli_id)
+    if bli is not None:
+        loaded_db.delete(bli)
+        loaded_db.commit()
+    loaded_db.delete(sc)
+    loaded_db.commit()
+
+
+@pytest.fixture()
+def make_tracker_at_step(loaded_db):
+    """Factory that attaches an ACTIVE procurement tracker at a given step to an agreement.
+
+    ProcurementTracker is a versioned model (sqlalchemy-continuum); ORM-deleting it in teardown
+    races the version bookkeeping, so we clean up with raw SQL."""
+    created_ids = []
+
+    def _make(agreement_id, step_number):
+        tracker = ProcurementTracker(
+            agreement_id=agreement_id,
+            status=ProcurementTrackerStatus.ACTIVE,
+            tracker_type=ProcurementTrackerType.DEFAULT,
+            active_step_number=step_number,
+        )
+        loaded_db.add(tracker)
+        loaded_db.commit()
+        created_ids.append(tracker.id)
+        return tracker
+
+    yield _make
+
+    loaded_db.rollback()
+    for tracker_id in created_ids:
+        loaded_db.execute(text("DELETE FROM default_procurement_tracker WHERE id = :id"), {"id": tracker_id})
+        loaded_db.execute(text("DELETE FROM procurement_tracker WHERE id = :id"), {"id": tracker_id})
+    loaded_db.commit()
+
+
+@pytest.mark.parametrize("status", [BudgetLineItemStatus.PLANNED, BudgetLineItemStatus.IN_EXECUTION])
+def test_delete_planned_or_executing_bli_creates_change_request(
+    budget_team_auth_client, division_director_auth_client, loaded_db, deletable_agreement, test_can, status, app_ctx
+):
+    """Deleting a PLANNED/IN_EXECUTION BLI returns 202 and creates a deletion CR; the BLI survives."""
+    bli, sc = _make_bli(loaded_db, deletable_agreement, test_can, status)
+    bli_id = bli.id
+    agreement_id = deletable_agreement.id
+    try:
+        response = budget_team_auth_client.delete(url_for("api.budget-line-items-item", id=bli_id))
+        assert response.status_code == 202
+
+        # The BLI is still present (only the request was created).
+        assert loaded_db.get(ContractBudgetLineItem, bli_id) is not None
+
+        cr = (
+            loaded_db.query(BudgetLineItemChangeRequest)
+            .filter_by(budget_line_item_id=bli_id, status=ChangeRequestStatus.IN_REVIEW)
+            .one()
+        )
+        assert cr.has_delete_change is True
+        assert cr.requested_change_data == {"delete": True}
+        assert cr.requested_change_diff == {"delete": {"old": 500000.0, "new": "Deleted"}}
+
+        # Submitting the request records a "Budget Line Deletion Requested" history entry naming
+        # the requestor (guards the request-created arm of the history builder).
+        hist = division_director_auth_client.get(url_for("api.agreement-history", id=agreement_id, limit=100))
+        assert hist.status_code == 200
+        requested_entries = [h for h in hist.json["data"] if h["history_title"] == "Budget Line Deletion Requested"]
+        assert len(requested_entries) >= 1
+        message = requested_entries[0]["history_message"]
+        assert f"requested to delete BL {bli_id}" in message
+        assert "Unknown User" not in message
+    finally:
+        _cleanup_bli(loaded_db, bli_id, sc)
+
+
+def test_delete_draft_bli_is_immediate(budget_team_auth_client, loaded_db, deletable_agreement, test_can, app_ctx):
+    """A DRAFT BLI is hard-deleted immediately (200), no change request."""
+    bli, sc = _make_bli(loaded_db, deletable_agreement, test_can, BudgetLineItemStatus.DRAFT)
+    bli_id = bli.id
+    try:
+        response = budget_team_auth_client.delete(url_for("api.budget-line-items-item", id=bli_id))
+        assert response.status_code == 200
+        assert loaded_db.get(ContractBudgetLineItem, bli_id) is None
+        assert loaded_db.query(BudgetLineItemChangeRequest).filter_by(budget_line_item_id=bli_id).count() == 0
+    finally:
+        _cleanup_bli(loaded_db, bli_id, sc)
+
+
+def test_delete_executing_bli_blocked_at_pre_award(
+    budget_team_auth_client, loaded_db, deletable_agreement, test_can, make_tracker_at_step, app_ctx
+):
+    """Once the agreement reaches Pre-Award (step 5), an executing BLI can't be deleted."""
+    bli, sc = _make_bli(loaded_db, deletable_agreement, test_can, BudgetLineItemStatus.IN_EXECUTION)
+    bli_id = bli.id
+    make_tracker_at_step(deletable_agreement.id, 5)
+    try:
+        response = budget_team_auth_client.delete(url_for("api.budget-line-items-item", id=bli_id))
+        assert response.status_code == 400
+        assert "not in a deletable state" in str(response.json)
+        assert loaded_db.get(ContractBudgetLineItem, bli_id) is not None
+    finally:
+        _cleanup_bli(loaded_db, bli_id, sc)
+
+
+def test_delete_bli_blocked_when_already_in_review(
+    budget_team_auth_client, loaded_db, deletable_agreement, test_can, app_ctx
+):
+    """A BLI that already has a pending change request can't get a second (deletion) request."""
+    bli, sc = _make_bli(loaded_db, deletable_agreement, test_can, BudgetLineItemStatus.PLANNED)
+    bli_id = bli.id
+    existing_cr = BudgetLineItemChangeRequest(
+        agreement_id=deletable_agreement.id,
+        budget_line_item_id=bli_id,
+        change_request_type=ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+        status=ChangeRequestStatus.IN_REVIEW,
+        requested_change_data={"amount": 123.45},
+    )
+    loaded_db.add(existing_cr)
+    loaded_db.commit()
+    try:
+        response = budget_team_auth_client.delete(url_for("api.budget-line-items-item", id=bli_id))
+        assert response.status_code == 400
+        assert loaded_db.get(ContractBudgetLineItem, bli_id) is not None
+    finally:
+        _cleanup_bli(loaded_db, bli_id, sc)
+
+
+def test_approving_deletion_request_deletes_bli_and_records_history(
+    budget_team_auth_client, division_director_auth_client, loaded_db, deletable_agreement, test_can, app_ctx
+):
+    """Approving a deletion CR deletes the BLI, returns 200, and records a BUDGET_LINE_ITEM_DELETED
+    history entry.
+
+    BLOCKER-1 guard: the approval finalizes the CR and notifies the submitter while the CR row still
+    exists, then deletes the BLI last. The 200 below proves the post-commit reads (the submitter
+    notification and the response's re-serialization of the change request) do not crash on the
+    cascade-deleted CR. The durable record of the deletion is the AgreementHistory entry asserted
+    here plus the automatic OpsDBHistory trail; the ChangeRequest row and its notification row are
+    intentionally cascade-removed with the BLI."""
+    bli, sc = _make_bli(loaded_db, deletable_agreement, test_can, BudgetLineItemStatus.PLANNED)
+    bli_id = bli.id
+    agreement_id = deletable_agreement.id
+    try:
+        # Submit the deletion request.
+        response = budget_team_auth_client.delete(url_for("api.budget-line-items-item", id=bli_id))
+        assert response.status_code == 202
+        cr = (
+            loaded_db.query(BudgetLineItemChangeRequest)
+            .filter_by(budget_line_item_id=bli_id, status=ChangeRequestStatus.IN_REVIEW)
+            .one()
+        )
+        cr_id = cr.id
+
+        prev_hist = division_director_auth_client.get(url_for("api.agreement-history", id=agreement_id, limit=100))
+        prev_hist_count = len(prev_hist.json["data"])
+
+        # Approve it.
+        response = division_director_auth_client.patch(
+            url_for("api.change-requests-item", id=cr_id),
+            json={"action": "APPROVE", "reviewer_notes": "ok to delete"},
+        )
+        assert response.status_code == 200
+        # BLOCKER-1: the response must be a clean serialization of the (now cascade-deleted) CR,
+        # not a degraded/error body — the snapshot captured before deletion drives this.
+        assert "error" not in response.json
+        assert response.json["id"] == cr_id
+        assert response.json["has_delete_change"] is True
+
+        # The BLI (and, via cascade, the CR row) are gone.
+        assert loaded_db.get(ContractBudgetLineItem, bli_id) is None
+        assert loaded_db.get(BudgetLineItemChangeRequest, cr_id) is None
+
+        # A "Budget Line Deleted" history entry was recorded on approval, and its message names the
+        # reviewer and requestor (guards the "Unknown User" fallback in the history builder).
+        hist = division_director_auth_client.get(url_for("api.agreement-history", id=agreement_id, limit=100))
+        assert hist.status_code == 200
+        assert len(hist.json["data"]) > prev_hist_count
+        deletion_entries = [h for h in hist.json["data"] if h["history_title"] == "Budget Line Deleted"]
+        assert len(deletion_entries) >= 1
+        message = deletion_entries[0]["history_message"]
+        assert f"approved the deletion of BL {bli_id}" in message
+        assert "requested by" in message
+        assert "Unknown User" not in message
+    finally:
+        _cleanup_bli(loaded_db, bli_id, sc)
+
+
+def test_rejecting_deletion_request_keeps_bli(
+    budget_team_auth_client, division_director_auth_client, loaded_db, deletable_agreement, test_can, app_ctx
+):
+    """Rejecting a deletion CR leaves the BLI intact and records a decline history entry."""
+    bli, sc = _make_bli(loaded_db, deletable_agreement, test_can, BudgetLineItemStatus.PLANNED)
+    bli_id = bli.id
+    agreement_id = deletable_agreement.id
+    try:
+        response = budget_team_auth_client.delete(url_for("api.budget-line-items-item", id=bli_id))
+        assert response.status_code == 202
+        cr = (
+            loaded_db.query(BudgetLineItemChangeRequest)
+            .filter_by(budget_line_item_id=bli_id, status=ChangeRequestStatus.IN_REVIEW)
+            .one()
+        )
+
+        response = division_director_auth_client.patch(
+            url_for("api.change-requests-item", id=cr.id),
+            json={"action": "REJECT", "reviewer_notes": "keep it"},
+        )
+        assert response.status_code == 200
+
+        assert loaded_db.get(ContractBudgetLineItem, bli_id) is not None
+        loaded_db.refresh(cr)
+        assert cr.status == ChangeRequestStatus.REJECTED
+
+        # A "Budget Line Deletion Declined" history entry was recorded on rejection.
+        hist = division_director_auth_client.get(url_for("api.agreement-history", id=agreement_id, limit=100))
+        assert hist.status_code == 200
+        declined_entries = [h for h in hist.json["data"] if h["history_title"] == "Budget Line Deletion Declined"]
+        assert len(declined_entries) >= 1
+        message = declined_entries[0]["history_message"]
+        assert f"declined the deletion of BL {bli_id}" in message
+        assert "Unknown User" not in message
+    finally:
+        _cleanup_bli(loaded_db, bli_id, sc)
+
+
+def test_delete_unauthorized_user(basic_user_auth_client, loaded_db, deletable_agreement, test_can, app_ctx):
+    """A user not associated with the agreement cannot delete (or request deletion of) the BLI."""
+    bli, sc = _make_bli(loaded_db, deletable_agreement, test_can, BudgetLineItemStatus.PLANNED)
+    bli_id = bli.id
+    try:
+        response = basic_user_auth_client.delete(url_for("api.budget-line-items-item", id=bli_id))
+        assert response.status_code == 403
+        assert loaded_db.get(ContractBudgetLineItem, bli_id) is not None
+    finally:
+        _cleanup_bli(loaded_db, bli_id, sc)

--- a/backend/ops_api/tests/ops/budget_line_items/test_edit_executing_budget_line.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_edit_executing_budget_line.py
@@ -222,14 +222,15 @@ def test_executing_bli_list_meta_at_pre_award(auth_client, executing_bli, make_t
     assert "Pre-Award" in meta["lockedMessage"]
 
 
-def test_edit_executing_bli_meta_is_editable_not_deletable(auth_client, executing_bli, app_ctx):
-    """The GET _meta exposes isEditable True but isDeletable False for an executing BLI (non-super)."""
+def test_edit_executing_bli_meta_is_editable_and_deletable(auth_client, executing_bli, app_ctx):
+    """The GET _meta exposes isEditable and isDeletable True for an executing BLI (non-super).
+    Deletion routes through an approval request (see the deletion tests), but the control is live."""
     response = auth_client.get(url_for("api.budget-line-items-item", id=executing_bli.id))
 
     assert response.status_code == 200
     meta = response.json["_meta"]
     assert meta["isEditable"] is True
-    assert meta["isDeletable"] is False
+    assert meta["isDeletable"] is True
     assert meta["lockedMessage"] is None
 
 

--- a/backend/ops_api/tests/ops/features/delete_budget_line_change_request.feature
+++ b/backend/ops_api/tests/ops/features/delete_budget_line_change_request.feature
@@ -1,0 +1,51 @@
+Feature: Delete a Budget Line Item as a Change Request
+  As an OPRE staff member, deleting a Planned or Executing budget line item should require
+  Division Director approval, while a Draft budget line item is still deleted immediately.
+
+  See: (Submitting changes on BLs in Executing status)[https://github.com/HHS/OPRE-OPS/issues/5819]
+
+  Scenario: Deleting a draft budget line is immediate
+    Given I am logged in as an OPS user
+    And I have a Contract Agreement as the Project Officer
+    And I have a budget line item in Draft status
+    When I delete the budget line item
+    Then the budget line item should be deleted immediately
+
+  Scenario: Deleting a planned budget line creates a change request
+    Given I am logged in as an OPS user
+    And I have a Contract Agreement as the Project Officer
+    And I have a budget line item in Planned status
+    When I delete the budget line item
+    Then the deletion should be sent to approval
+    And the budget line item should still exist
+
+  Scenario: Deleting an executing budget line creates a change request
+    Given I am logged in as an OPS user
+    And I have a Contract Agreement as the Project Officer
+    And I have a budget line item in Executing status
+    When I delete the budget line item
+    Then the deletion should be sent to approval
+    And the budget line item should still exist
+
+  Scenario: Deletion is blocked once the agreement reaches Pre-Award
+    Given I am logged in as an OPS user
+    And I have a Contract Agreement as the Project Officer
+    And I have a budget line item in Executing status
+    And the agreement has reached Pre-Award
+    When I delete the budget line item
+    Then I should get a validation error
+
+  Scenario: Deletion is blocked while a change request is pending
+    Given I am logged in as an OPS user
+    And I have a Contract Agreement as the Project Officer
+    And I have a budget line item in Planned status
+    And the budget line item has a change request in review
+    When I delete the budget line item
+    Then I should get a validation error
+
+  Scenario: Unauthorized user cannot delete a budget line
+    Given I am logged in as a basic user
+    And I have a Contract Agreement without the user as a team member
+    And I have a budget line item in Planned status
+    When I delete the budget line item
+    Then I should get an error that I am not authorized

--- a/backend/ops_api/tests/ops/features/test_delete_budget_line_change_request.py
+++ b/backend/ops_api/tests/ops/features/test_delete_budget_line_change_request.py
@@ -1,0 +1,212 @@
+import datetime
+
+import pytest
+from pytest_bdd import given, parsers, scenario, then, when
+from sqlalchemy import text
+
+from models import (
+    AgreementReason,
+    AgreementType,
+    BudgetLineItemChangeRequest,
+    BudgetLineItemStatus,
+    ChangeRequestStatus,
+    ChangeRequestType,
+    ContractAgreement,
+    ContractBudgetLineItem,
+    ContractType,
+    ProcurementTracker,
+    ProcurementTrackerStatus,
+    ProcurementTrackerType,
+    ServicesComponent,
+)
+
+_STATUS_BY_NAME = {
+    "Draft": BudgetLineItemStatus.DRAFT,
+    "Planned": BudgetLineItemStatus.PLANNED,
+    "Executing": BudgetLineItemStatus.IN_EXECUTION,
+}
+
+
+@pytest.fixture
+def original_agreement(test_user, test_project):
+    return {
+        "name": "CT5819-DEL-BDD",
+        "contract_number": "CT5819DEL",
+        "contract_type": ContractType.FIRM_FIXED_PRICE,
+        "agreement_type": AgreementType.CONTRACT,
+        "project_id": test_project.id,
+        "product_service_code_id": 2,
+        "description": "Deleting budget lines as change requests",
+        "agreement_reason": AgreementReason.NEW_REQ,
+        "project_officer_id": test_user.id,
+        "awarding_entity_id": 1,
+        "created_by": test_user.id,
+    }
+
+
+@given("I am logged in as an OPS user", target_fixture="bdd_client")
+def bdd_client(auth_client):
+    yield auth_client
+
+
+@given("I am logged in as a basic user", target_fixture="bdd_client")
+def bdd_basic_user_client(basic_user_auth_client):
+    yield basic_user_auth_client
+
+
+@scenario("delete_budget_line_change_request.feature", "Deleting a draft budget line is immediate")
+def test_delete_draft_immediate(): ...
+
+
+@scenario("delete_budget_line_change_request.feature", "Deleting a planned budget line creates a change request")
+def test_delete_planned_creates_cr(): ...
+
+
+@scenario("delete_budget_line_change_request.feature", "Deleting an executing budget line creates a change request")
+def test_delete_executing_creates_cr(): ...
+
+
+@scenario("delete_budget_line_change_request.feature", "Deletion is blocked once the agreement reaches Pre-Award")
+def test_delete_blocked_pre_award(): ...
+
+
+@scenario("delete_budget_line_change_request.feature", "Deletion is blocked while a change request is pending")
+def test_delete_blocked_in_review(): ...
+
+
+@scenario("delete_budget_line_change_request.feature", "Unauthorized user cannot delete a budget line")
+def test_delete_unauthorized(): ...
+
+
+@given("I have a Contract Agreement as the Project Officer", target_fixture="agreement")
+def agreement_project_officer(loaded_db, original_agreement, test_admin_user):
+    original_agreement["project_officer_id"] = test_admin_user.id
+    contract_agreement = ContractAgreement(**original_agreement)
+    loaded_db.add(contract_agreement)
+    loaded_db.commit()
+
+    yield contract_agreement
+
+    loaded_db.rollback()
+    loaded_db.delete(contract_agreement)
+    loaded_db.commit()
+
+
+@given("I have a Contract Agreement without the user as a team member", target_fixture="agreement")
+def agreement_unauthorized(loaded_db, original_agreement):
+    contract_agreement = ContractAgreement(**original_agreement)
+    loaded_db.add(contract_agreement)
+    loaded_db.commit()
+
+    yield contract_agreement
+
+    loaded_db.rollback()
+    loaded_db.delete(contract_agreement)
+    loaded_db.commit()
+
+
+@given(parsers.parse("I have a budget line item in {status_name} status"), target_fixture="bli")
+def bli_with_status(loaded_db, agreement, test_user, test_can, status_name):
+    sc = ServicesComponent(agreement_id=agreement.id, number=1, optional=False)
+    loaded_db.add(sc)
+    loaded_db.commit()
+
+    bli = ContractBudgetLineItem(
+        agreement_id=agreement.id,
+        comments="blah blah",
+        line_description="LI 1",
+        amount=500000.00,
+        can_id=test_can.id,
+        date_needed=datetime.date(2043, 1, 1),
+        status=_STATUS_BY_NAME[status_name],
+        proc_shop_fee_percentage=1.23,
+        created_by=test_user.id,
+        services_component_id=sc.id,
+    )
+    loaded_db.add(bli)
+    loaded_db.commit()
+    bli_id = bli.id
+
+    yield bli
+
+    # A deletion request may have created a change request referencing this BLI; remove it first.
+    loaded_db.rollback()
+    loaded_db.execute(text("DELETE FROM change_request WHERE budget_line_item_id = :id"), {"id": bli_id})
+    loaded_db.commit()
+    persisted = loaded_db.get(ContractBudgetLineItem, bli_id)
+    if persisted is not None:
+        loaded_db.delete(persisted)
+        loaded_db.commit()
+    loaded_db.delete(sc)
+    loaded_db.commit()
+
+
+@given("the agreement has reached Pre-Award")
+def agreement_at_pre_award(loaded_db, agreement, bli):
+    tracker = ProcurementTracker(
+        agreement_id=agreement.id,
+        status=ProcurementTrackerStatus.ACTIVE,
+        tracker_type=ProcurementTrackerType.DEFAULT,
+        active_step_number=5,
+    )
+    loaded_db.add(tracker)
+    loaded_db.commit()
+    tracker_id = tracker.id
+
+    yield
+
+    # ProcurementTracker is versioned; clean up with raw SQL to avoid continuum StaleDataError.
+    loaded_db.rollback()
+    loaded_db.execute(text("DELETE FROM default_procurement_tracker WHERE id = :id"), {"id": tracker_id})
+    loaded_db.execute(text("DELETE FROM procurement_tracker WHERE id = :id"), {"id": tracker_id})
+    loaded_db.commit()
+
+
+@given("the budget line item has a change request in review")
+def bli_with_change_request_in_review(loaded_db, agreement, bli, test_user):
+    cr = BudgetLineItemChangeRequest(
+        budget_line_item_id=bli.id,
+        agreement_id=agreement.id,
+        change_request_type=ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+        status=ChangeRequestStatus.IN_REVIEW,
+        requested_change_data={"amount": 200.50},
+        created_by=test_user.id,
+    )
+    loaded_db.add(cr)
+    loaded_db.commit()
+
+    yield
+
+    loaded_db.delete(cr)
+    loaded_db.commit()
+
+
+@when("I delete the budget line item", target_fixture="delete_response")
+def delete_bli(bdd_client, bli):
+    return bdd_client.delete(f"/api/v1/budget-line-items/{bli.id}")
+
+
+@then("the budget line item should be deleted immediately")
+def deleted_immediately(delete_response, loaded_db, bli):
+    assert delete_response.status_code == 200
+    assert loaded_db.get(ContractBudgetLineItem, bli.id) is None
+
+
+@then("the deletion should be sent to approval")
+def sent_to_approval(delete_response):
+    assert delete_response.status_code == 202
+
+
+@then("the budget line item should still exist")
+def bli_still_exists(loaded_db, bli):
+    assert loaded_db.get(ContractBudgetLineItem, bli.id) is not None
+
+
+@then("I should get a validation error")
+def validation_error(delete_response):
+    assert delete_response.status_code == 400
+
+
+@then("I should get an error that I am not authorized")
+def unauthorized(delete_response):
+    assert delete_response.status_code == 403

--- a/backend/ops_api/tests/ops/utils/test_budget_line_items_helpers.py
+++ b/backend/ops_api/tests/ops/utils/test_budget_line_items_helpers.py
@@ -253,12 +253,13 @@ def test_compute_bli_editable_obligated_super_can_edit():
     [
         (BudgetLineItemStatus.DRAFT, True),
         (BudgetLineItemStatus.PLANNED, True),
-        (BudgetLineItemStatus.IN_EXECUTION, False),
+        (BudgetLineItemStatus.IN_EXECUTION, True),
         (BudgetLineItemStatus.OBLIGATED, False),
     ],
 )
 def test_compute_bli_is_deletable_by_status_non_super(status, expected):
-    """PR1 keeps today's delete eligibility: DRAFT/PLANNED deletable, IN_EXECUTION not (yet)."""
+    """Deletability now mirrors editability: DRAFT/PLANNED/IN_EXECUTION deletable (PLANNED/EXECUTING
+    route through an approval request), OBLIGATED not. DRAFT deletes immediately."""
     bli = _FakeBLI(status)
     assert compute_bli_is_deletable(bli, in_review=False, is_super=False) is expected
 

--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -440,7 +440,10 @@ export const opsApi = createApi({
                 url: `/budget-line-items/${id}`,
                 method: "DELETE"
             }),
-            invalidatesTags: ["Agreements", "BudgetLineItems", "AgreementHistory"]
+            // Surface the HTTP status so callers can distinguish an immediate delete (200) from a
+            // deletion routed to an approval change request (202, PLANNED/IN_EXECUTION).
+            transformResponse: (response, meta) => ({ ...response, statusCode: meta?.response?.status }),
+            invalidatesTags: ["Agreements", "BudgetLineItems", "AgreementHistory", "ChangeRequests"]
         }),
         getAgreementsByResearchProjectFilter: builder.query({
             query: (id) => `/agreements/?project_id=${id}`,

--- a/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBudgetLinesTable.hooks.js
+++ b/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBudgetLinesTable.hooks.js
@@ -29,11 +29,22 @@ function useAllBudgetLinesTable(budgetLines) {
                     .unwrap()
                     .then((fulfilled) => {
                         console.log("Deleted BLI:", fulfilled);
-                        setAlert({
-                            type: "success",
-                            heading: "Budget Line Deleted",
-                            message: `The budget line ${budgetLineDisplayName} has been successfully deleted.`
-                        });
+                        if (fulfilled?.statusCode === 202) {
+                            // PLANNED/IN_EXECUTION deletions route to an approval change request.
+                            // Reuse the edit-via-CR alert copy verbatim.
+                            setAlert({
+                                type: "success",
+                                heading: "Changes Sent to Approval",
+                                message:
+                                    "Your changes have been successfully sent to your Division Director to review. Once approved, they will update on the agreement."
+                            });
+                        } else {
+                            setAlert({
+                                type: "success",
+                                heading: "Budget Line Deleted",
+                                message: `The budget line ${budgetLineDisplayName} has been successfully deleted.`
+                            });
+                        }
                     })
                     .catch((rejected) => {
                         console.error("Error Deleting Budget Line");

--- a/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBudgetLinesTable.hooks.test.js
+++ b/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBudgetLinesTable.hooks.test.js
@@ -1,0 +1,69 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import useAllBudgetLinesTable from "./AllBudgetLinesTable.hooks";
+
+const deleteBudgetLineItemMock = vi.fn();
+const setAlertMock = vi.fn();
+
+vi.mock("../../../api/opsAPI", () => ({
+    useDeleteBudgetLineItemMutation: () => [deleteBudgetLineItemMock]
+}));
+
+vi.mock("../../../hooks/use-alert.hooks", () => ({
+    default: () => ({ setAlert: setAlertMock })
+}));
+
+const budgetLines = [{ id: 1 }];
+
+describe("useAllBudgetLinesTable handleDeleteBudgetLine", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const confirmDelete = (result) => {
+        act(() => {
+            result.current.handleDeleteBudgetLine(1);
+        });
+        return result.current.modalProps.handleConfirm;
+    };
+
+    it("shows the immediate-delete alert on a 200 response", async () => {
+        deleteBudgetLineItemMock.mockReturnValue({ unwrap: () => Promise.resolve({ statusCode: 200 }) });
+        const { result } = renderHook(() => useAllBudgetLinesTable(budgetLines));
+
+        const handleConfirm = confirmDelete(result);
+        await act(async () => {
+            await handleConfirm();
+        });
+
+        expect(setAlertMock).toHaveBeenCalledWith(
+            expect.objectContaining({ type: "success", heading: "Budget Line Deleted" })
+        );
+    });
+
+    it("shows the sent-to-approval alert on a 202 response", async () => {
+        deleteBudgetLineItemMock.mockReturnValue({ unwrap: () => Promise.resolve({ statusCode: 202 }) });
+        const { result } = renderHook(() => useAllBudgetLinesTable(budgetLines));
+
+        const handleConfirm = confirmDelete(result);
+        await act(async () => {
+            await handleConfirm();
+        });
+
+        expect(setAlertMock).toHaveBeenCalledWith(
+            expect.objectContaining({ type: "success", heading: "Changes Sent to Approval" })
+        );
+    });
+
+    it("shows an error alert when the delete fails", async () => {
+        deleteBudgetLineItemMock.mockReturnValue({ unwrap: () => Promise.reject(new Error("boom")) });
+        const { result } = renderHook(() => useAllBudgetLinesTable(budgetLines));
+
+        const handleConfirm = confirmDelete(result);
+        await act(async () => {
+            await handleConfirm();
+        });
+
+        expect(setAlertMock).toHaveBeenCalledWith(expect.objectContaining({ type: "error" }));
+    });
+});

--- a/frontend/src/components/ChangeRequests/BudgetChangeReviewCard/BudgetChangeReviewCard.test.jsx
+++ b/frontend/src/components/ChangeRequests/BudgetChangeReviewCard/BudgetChangeReviewCard.test.jsx
@@ -124,4 +124,26 @@ describe("BudgetChangeReviewCard", () => {
         expect(screen.getByText("6/1/2044")).toBeInTheDocument();
         expect(screen.getByText("6/13/2045")).toBeInTheDocument();
     });
+    it("should render a deletion change with Change To and To = Deleted and From = the BLI amount", () => {
+        const changeTo = {
+            delete: {
+                old: 500000,
+                new: "Deleted"
+            }
+        };
+        render(
+            <BrowserRouter>
+                <BudgetChangeReviewCard
+                    {...initialProps}
+                    key={1}
+                    changeTo={changeTo}
+                />
+            </BrowserRouter>
+        );
+
+        // "Change To" label value and "To" value both read "Deleted".
+        expect(screen.getAllByText("Deleted")).toHaveLength(2);
+        // "From" shows the current BLI amount formatted as currency.
+        expect(screen.getByText("$500,000.00")).toBeInTheDocument();
+    });
 });

--- a/frontend/src/components/ChangeRequests/ChangeRequests.constants.js
+++ b/frontend/src/components/ChangeRequests/ChangeRequests.constants.js
@@ -41,5 +41,6 @@ export const KEY_NAMES = {
     CAN: "can_id",
     DATE_NEEDED: "date_needed",
     STATUS: "status",
-    PROC_SHOP: "awarding_entity_id"
+    PROC_SHOP: "awarding_entity_id",
+    DELETE: "delete"
 };

--- a/frontend/src/components/ChangeRequests/ChangeRequestsList/ChangeRequestsList.jsx
+++ b/frontend/src/components/ChangeRequests/ChangeRequestsList/ChangeRequestsList.jsx
@@ -156,7 +156,7 @@ function ChangeRequestsList({ handleReviewChangeRequest }) {
                                 />
                             </>
                         )}
-                        {changeRequest.has_budget_change && (
+                        {(changeRequest.has_budget_change || changeRequest.has_delete_change) && (
                             <BudgetChangeReviewCard
                                 key={changeRequest.id}
                                 changeRequestId={changeRequest.id}

--- a/frontend/src/helpers/changeRequests.helpers.js
+++ b/frontend/src/helpers/changeRequests.helpers.js
@@ -41,6 +41,11 @@ export function renderChangeValues(keyName, changeTo, oldCan = "", newCan = "") 
             oldValue = renderField(keyName, "status", changeTo.status.old);
             newValue = renderField(keyName, "status", changeTo.status.new);
             break;
+        case KEY_NAMES.DELETE:
+            // Deletion request: "From" shows the BLI's current amount as currency, "To" is "Deleted".
+            oldValue = renderField(keyName, "amount", changeTo.delete.old);
+            newValue = changeTo.delete.new;
+            break;
         default:
             break;
     }

--- a/frontend/src/helpers/changeRequests.helpers.test.js
+++ b/frontend/src/helpers/changeRequests.helpers.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { renderChangeValues } from "./changeRequests.helpers";
+
+describe("renderChangeValues", () => {
+    it("renders an amount change as currency", () => {
+        const { oldValue, newValue } = renderChangeValues("amount", { amount: { old: 300000, new: 333333 } });
+        expect(oldValue).toBe("$300,000.00");
+        expect(newValue).toBe("$333,333.00");
+    });
+
+    it("renders a CAN change using the resolved CAN names", () => {
+        const { oldValue, newValue } = renderChangeValues("can_id", { can_id: { old: 13, new: 10 } }, "CAN 1", "CAN 2");
+        expect(oldValue).toBe("CAN 1");
+        expect(newValue).toBe("CAN 2");
+    });
+
+    it("renders a deletion change with the amount as From and 'Deleted' as To", () => {
+        const { oldValue, newValue } = renderChangeValues("delete", { delete: { old: 500000, new: "Deleted" } });
+        expect(oldValue).toBe("$500,000.00");
+        expect(newValue).toBe("Deleted");
+    });
+});

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -203,7 +203,8 @@ export const codesToDisplayText = {
         amount: "Amount",
         can_id: "CAN",
         date_needed: "Obligate By Date",
-        status: "Status"
+        status: "Status",
+        delete: "Deleted"
     },
     methodOfTransfer: {
         DIRECT: "Direct",

--- a/frontend/src/types/ChangeRequestsTypes.d.ts
+++ b/frontend/src/types/ChangeRequestsTypes.d.ts
@@ -12,6 +12,7 @@ export type ChangeRequest = {
     has_budget_change?: boolean;
     has_status_change?: boolean;
     has_proc_shop_change?: boolean;
+    has_delete_change?: boolean;
     id: number;
     managing_division_id: number | null;
     requested_change_data: {
@@ -20,6 +21,7 @@ export type ChangeRequest = {
         can_id?: number;
         status?: string;
         awarding_entity_id?: number;
+        delete?: boolean;
     };
     requested_change_diff: {
         amount?: {
@@ -40,6 +42,10 @@ export type ChangeRequest = {
         };
         awarding_entity_id?: {
             new: number;
+            old: number;
+        };
+        delete?: {
+            new: string;
             old: number;
         };
     };


### PR DESCRIPTION
> ⚠️ **Stacked PR — review/merge [#5832](https://github.com/HHS/OPRE-OPS/pull/5832) FIRST.**
> This branch (`OPS-5819/delete-budget-line-change-request`) is stacked on top of PR #5832
> (`OPS-5819/edit-executing-budget-lines`), **not** `main`. Its base is set to the #5832 branch so
> this PR's diff shows **only** the deletion work. Once #5832 merges, GitHub will auto-retarget this
> PR's base to `main` (or retarget it manually). Do not merge this before #5832.

## What changed

This is **PR 2 of 2** for issue #5819. PR 1 (#5832) made IN_EXECUTION budget line items (BLIs)
editable. This PR makes **deleting** a PLANNED or IN_EXECUTION BLI go through a Division Director
**approval change request** instead of a hard delete. DRAFT BLIs — and any delete by a super user —
still delete immediately, unchanged.

**Backend**
- **`models/change_requests.py`** — `BudgetLineItemChangeRequest` gains a `has_delete_change` hybrid
  (and exposes it in `to_dict()`). A deletion request is a normal `BUDGET_LINE_ITEM_CHANGE_REQUEST`
  carrying a `{"delete": true}` sentinel in `requested_change_data`, with
  `requested_change_diff = {"delete": {"old": <bli amount>, "new": "Deleted"}}`.
- **`services/budget_line_items.py`** — `delete()` now returns `(bli, status_code)`. DRAFT/super →
  `200` immediate hard delete; PLANNED/IN_EXECUTION → `202` + a deletion CR, gated by the **same**
  shared `compute_bli_editable` rules as editing (blocked while in review, OBE, or once the agreement
  reaches Pre-Award/Award, i.e. procurement tracker step ≥ 5).
- **`resources/budget_line_items.py`** — the delete handler unpacks `(bli, status_code)` and emits
  the `DELETE_BLI` audit event **only** on the immediate (200) path; the 202 path emits
  `CREATE_CHANGE_REQUEST` inside the service, so submitting a request does not write a spurious
  "Budget Line Deleted" history record.
- **`services/change_requests.py`** — `add_bli_delete_change_request()` creates the CR; the approval
  flow deletes the BLI **last** (see BLOCKER-1 below).
- **`models/agreement_history.py`** — `create_change_request_history_event` handles the `"delete"`
  sentinel for request-created / approved / declined, emitting `BUDGET_LINE_ITEM_DELETED` history.
- **`utils/change_requests_helpers.py`** — `build_approve_url` learns the delete case.
- **`schemas/change_requests.py`**, **`resources/change_requests.py`**, **`openapi.yml`** — surface
  `has_delete_change` and document the DELETE 202 path.

**Frontend**
- **`api/opsAPI.js`** — the delete mutation surfaces the HTTP status so callers distinguish 200
  (immediate) from 202 (request created); invalidates `ChangeRequests`.
- **`AllBudgetLinesTable.hooks.js`** — on 202 shows the **same** "Changes Sent to Approval" alert the
  edit-via-CR path uses (verbatim); on 200 keeps "...successfully deleted."
- **CR-review card** — the For-Review `BudgetChangeReviewCard` now renders deletion CRs (gate is
  `has_budget_change || has_delete_change`); `changeToTypes.delete = "Deleted"`,
  `KEY_NAMES.DELETE`, and a `renderChangeValues` delete case render **Change To = "Deleted"**,
  **From = the BLI amount as currency**, **To = "Deleted"** (matches the approved design).

### Key design decisions / assumptions (for reviewers without context)

- **Reuse, don't fork.** The deletion request reuses `BudgetLineItemChangeRequest` with a JSONB
  `{"delete": true}` sentinel — **no new `ChangeRequestType`, no enum migration**, and it rides the
  existing routing / approval / notification / `in_review` plumbing.
- **BLOCKER-1 (approval ordering).** `change_request.budget_line_item_id` is `ON DELETE CASCADE`, and
  the resource re-serializes the CR (`to_dict()`) after approval. Naively deleting the BLI mid-flow
  would cascade-delete the CR row and crash the post-commit reads. So on approve we finalize the CR
  and notify the submitter while it still exists, **snapshot `to_dict()` while the CR is still
  attached** (capturing every relationship the auto-schema serializes, including the
  sqlalchemy-continuum `versions` dynamic relationship), detach the CR, then delete the BLI last and
  pin the CR's `to_dict()` to the snapshot. The response/event never serialize a detached instance.
- **BLOCKER-2 (audit trail).** The user-facing "Budget Line Deleted" history is event/diff-driven, so
  `create_change_request_history_event` needed an explicit `"delete"` branch (it would otherwise hit
  an `UnboundLocalError` on the unset title/message). The requestor is resolved via the `created_by`
  column, not the relationship-derived dict (which is `None` once the CR is detached/cascade-deleted).
- **Deletability now mirrors editability** (PR 1 introduced `isDeletable` as the seam): DRAFT /
  PLANNED / IN_EXECUTION are deletable when editable; OBLIGATED is not; super users always.
- **The deletion CR's notification row is intentionally cascade-removed** with the CR when the BLI is
  deleted on approval. The durable record of the deletion is the `AgreementHistory`
  `BUDGET_LINE_ITEM_DELETED` entry plus the automatic `OpsDBHistory` trail.

### Review process

Two rounds of adversarial multi-agent consensus review were run against this diff. Round 1 surfaced
1 MAJOR (the detached-CR `versions` serialization gap — fixed via the snapshot approach above) + 3
MINOR (history-message test-coverage gaps — all added) + 1 NIT (response-body assertion — added).
Round 2 returned zero confirmed issues.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5819

## How to test

Backend (from `backend/ops_api/`, with the test stack):
```
pytest tests/ops/budget_line_items/test_delete_budget_line_change_request.py \
       tests/ops/features/test_delete_budget_line_change_request.py
```
Covers: DRAFT → 200 immediate; PLANNED/IN_EXECUTION → 202 + deletion CR (BLI survives); blocked at
Pre-Award (400); blocked while a CR is pending (400); approving deletes the BLI + records the
"Budget Line Deleted" history (and the response/notification do not crash on the cascade — BLOCKER-1
guard); rejecting keeps the BLI + records "Budget Line Deletion Declined"; unauthorized → 403.

Frontend (from `frontend/`):
```
bun run test --watch=false src/components/ChangeRequests src/helpers/changeRequests.helpers.test.js \
  src/components/BudgetLineItems/AllBudgetLinesTable src/components/BudgetLineItems/ChangeIcons
```

Manual: as an associated user, on an agreement's budget-lines table, delete a PLANNED or EXECUTING
BLI → confirm the existing modal → expect the "Changes Sent to Approval" alert and the BLI still
present. As the Division Director, open **For Review** → the deletion shows on a Budget Change card
with **Change To / To = "Deleted"** and **From = the BLI amount**; approving removes the BLI.

## A11y impact

- [x] No accessibility-impacting changes in this PR

(Frontend changes reuse existing components/alerts/cards; no new UI primitives or markup patterns.)

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — reuses the existing confirmation modal, the existing "Changes Sent to Approval" alert, and the
existing `BudgetChangeReviewCard`.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed

## Links

- Stacked on / depends on: https://github.com/HHS/OPRE-OPS/pull/5832 (PR 1 — edit Executing BLIs)
- Plan/decisions: two-PR delivery for #5819 (edit, then deletion-as-change-request)