### PR TITLE
feat: rename Temp Year End Role to Administrative Power User

### DIFF
--- a/backend/data_tools/data/user_data.json5
+++ b/backend/data_tools/data/user_data.json5
@@ -681,10 +681,10 @@
       status: "ACTIVE"
     },
     { // 528
-      first_name: "Power",
-      last_name: "User",
+      first_name: "Admin",
+      last_name: "Power User",
       division: 1,
-      email: "power.user@email.com",
+      email: "admin.power.user@email.com",
       oidc_id: "00000000-0000-1111-a111-000000000028",
       roles: [{"tablename":  "role", "id": 7}],
       status: "ACTIVE"

--- a/backend/ops_api/ops/auth/authentication_provider/fake_auth_provider.py
+++ b/backend/ops_api/ops/auth/authentication_provider/fake_auth_provider.py
@@ -46,9 +46,9 @@ class FakeAuthProvider(AuthenticationProvider):
                 "sub": "00000000-0000-1111-a111-000000000027",
             },
             "power_user": {
-                "given_name": "Power",
-                "family_name": "User",
-                "email": "power.user@email.com",
+                "given_name": "Admin",
+                "family_name": "Power User",
+                "email": "admin.power.user@email.com",
                 "sub": "00000000-0000-1111-a111-000000000028",
             },
             "read_only_user": {

--- a/backend/ops_api/tests/auth_client.py
+++ b/backend/ops_api/tests/auth_client.py
@@ -209,9 +209,9 @@ class PowerUserAuthClient(FlaskClient):
         user, additional_claims = _get_user_for_auth(
             528,
             oidc_id="00000000-0000-1111-a111-000000000028",
-            email="power.user@email.com",
-            first_name="Power",
-            last_name="Owner",
+            email="admin.power.user@email.com",
+            first_name="Admin",
+            last_name="Power User",
             division=1,
         )
         access_token = create_access_token(identity=user, additional_claims=additional_claims)

--- a/frontend/cypress/e2e/agreementDetailsEdit.cy.js
+++ b/frontend/cypress/e2e/agreementDetailsEdit.cy.js
@@ -485,7 +485,7 @@ describe("Awarded Agreement", () => {
         checkAgreementHistory();
         cy.get('[data-cy="agreement-history-list"] > :nth-child(1) > [data-cy="log-item-message"]').should(
             "have.text",
-            "Power User changed the notes."
+            "Admin Power User changed the notes."
         );
     });
 });

--- a/frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js
+++ b/frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js
@@ -90,8 +90,8 @@ describe("Power User tests", () => {
 
     it("can login as a power user", () => {
         cy.visit(`/users/528`);
-        cy.get(".usa-card__body").should("contain", "Temp Year End Role");
-        cy.get(".usa-card__body").should("contain", "power.user@email.com");
+        cy.get(".usa-card__body").should("contain", "Administrative Power User");
+        cy.get(".usa-card__body").should("contain", "admin.power.user@email.com");
     });
 
     it("can edit an CONTRACT agreement budget lines", () => {

--- a/frontend/src/components/Auth/MultiAuthSection.jsx
+++ b/frontend/src/components/Auth/MultiAuthSection.jsx
@@ -270,7 +270,7 @@ const MultiAuthSection = () => {
                                     onClick={() => handleFakeAuthLogin("power_user")}
                                     disabled={isAuthenticating}
                                 >
-                                    Power User
+                                    Administrative Power User
                                 </button>
                             </p>
                             <p>

--- a/frontend/src/components/Users/UserInfo/UserInfo.test.js
+++ b/frontend/src/components/Users/UserInfo/UserInfo.test.js
@@ -106,7 +106,7 @@ vi.mock("../../../constants.js", () => ({
             { name: "USER_ADMIN", label: "User Admin" },
             { name: "BUDGET_TEAM", label: "Budget Team" },
             { name: "PROCUREMENT_TEAM", label: "Procurement Team" },
-            { name: "SUPER_USER", label: "Temp Year End Role" }
+            { name: "SUPER_USER", label: "Administrative Power User" }
         ]
     }
 }));

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -48,7 +48,7 @@ const constants = {
         { name: "BUDGET_TEAM", label: "Budget Team" },
         { name: "READ_ONLY", label: "Read Only" },
         { name: "PROCUREMENT_TEAM", label: "Procurement Team" },
-        { name: "SUPER_USER", label: "Temp Year End Role" }
+        { name: "SUPER_USER", label: "Administrative Power User" }
     ]
 };
 

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -98,7 +98,7 @@ export const authHandlers = [
             { id: 4, name: "budget_team", is_superuser: false, description: "Budget Team Member" },
             { id: 5, name: "procurement_team", is_superuser: false, description: "Procurement Team Member" },
             { id: 6, name: "division_director", is_superuser: false, description: "Division Director" },
-            { id: 7, name: "super_user", is_superuser: true, description: "Power User" }
+            { id: 7, name: "super_user", is_superuser: true, description: "Administrative Power User" }
         ]);
     })
 ];


### PR DESCRIPTION
## What changed

Renames the human-facing display label for the `SUPER_USER` role from **"Temp Year End Role"** (placeholder) to **"Administrative Power User"** everywhere it appears in the UI. The FakeAuth dev login user for this role is refreshed to a consistent identity: `Admin Power User` / `admin.power.user@email.com`.

No DB migration is needed — the internal role identifier `SUPER_USER`, role id `7`, FakeAuth `sub`/`oidc_id`, and all permission/authorization wiring are unchanged.

Files changed (8):
- `frontend/src/constants.js` — role label
- `frontend/src/components/Users/UserInfo/UserInfo.test.js` — mocked label mirrors constants
- `frontend/src/components/Auth/MultiAuthSection.jsx` — FakeAuth button text
- `frontend/src/mocks/handlers.js` — MSW `/auth/roles/` description for id 7
- `frontend/cypress/e2e/editBudgetLineByPowerUser.cy.js` — assertion strings (label + email)
- `backend/ops_api/ops/auth/authentication_provider/fake_auth_provider.py` — FakeAuth user identity
- `backend/data_tools/data/user_data.json5` — seed user 528 identity
- `backend/ops_api/tests/auth_client.py` — `PowerUserAuthClient` identity (also fixes a pre-existing `last_name="Owner"` inconsistency)

## Issue

#5824

## How to test

1. Start the stack: `podman compose up --build -d` (or `docker compose up --build -d`). Wait for `data-import` to finish seeding.
2. Visit http://localhost:3000/login. Verify the FakeAuth column shows a button labeled **"Administrative Power User"** (no plain "Power User"). The other six FakeAuth buttons are unchanged.
3. Click **Administrative Power User**. Confirm successful login.
4. Navigate to http://localhost:3000/users/528. In the user card, verify:
   - Name renders as `Admin Power User`
   - Email renders as `admin.power.user@email.com`
   - Role badge renders as `Administrative Power User` (not "Temp Year End Role", not "Power User")
5. Visit `/users` and spot-check that the other role labels (System Owner, Viewer/Editor, Reviewer/Approver, User Admin, Budget Team, Read Only, Procurement Team) are unchanged.
6. Perform one privileged action as this user (e.g., edit a BLI on an awarded agreement that normally bypasses validation for SUPER_USER). Confirm permissions are intact.
7. Log out, log back in as **User Demo**. Confirm non-superuser flows are unaffected.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated