### PR TITLE
feat: tests for Power User past obligate-by date on budget lines

### DIFF
--- a/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_power_user.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_power_user.py
@@ -901,10 +901,6 @@ def test_power_user_create_bli_with_past_obligate_by_date(
         in budget_team_transition_response.json["errors"]["date_needed"]
     )
 
-    loaded_db.delete(loaded_db.get(ContractBudgetLineItem, power_user_bli_id))
-    loaded_db.delete(loaded_db.get(ContractBudgetLineItem, budget_team_bli_id))
-    loaded_db.commit()
-
 
 @pytest.mark.parametrize(
     "bli_status",

--- a/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_power_user.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_power_user.py
@@ -849,6 +849,63 @@ def test_power_user_update_obligate_by_date(
     loaded_db.commit()
 
 
+def test_power_user_create_bli_with_past_obligate_by_date(
+    power_user_auth_client,
+    budget_team_auth_client,
+    loaded_db,
+    test_can,
+    test_contract,
+):
+    """Administrative Power Users can POST a new BLI and transition it past DRAFT with a past
+    `date_needed`. Budget Team users hit the same endpoint successfully on POST (status is DRAFT)
+    but are blocked when they attempt to transition past DRAFT with a past date.
+    """
+    agreement = test_contract
+    past_date = "2020-06-21"
+    target_status = BudgetLineItemStatus.PLANNED
+
+    payload = {
+        "agreement_id": agreement.id,
+        "line_description": f"Past date BLI for {target_status.name}",
+        "can_id": test_can.id,
+        "amount": 3500,
+        "status": "DRAFT",
+        "date_needed": past_date,
+        "proc_shop_fee_percentage": 1.23,
+        "services_component_id": agreement.awarding_entity_id,
+    }
+
+    # Power user POST + transition: should succeed.
+    post_response = power_user_auth_client.post("/api/v1/budget-line-items/", json=payload)
+    assert post_response.status_code == 201
+    power_user_bli_id = post_response.json["id"]
+
+    transition_response = power_user_auth_client.patch(
+        url_for("api.budget-line-items-item", id=power_user_bli_id),
+        json={"status": target_status.name},
+    )
+    assert transition_response.status_code == 200
+
+    # Budget team user POST succeeds (DRAFT), but transition with the past date is rejected.
+    budget_team_post_response = budget_team_auth_client.post("/api/v1/budget-line-items/", json=payload)
+    assert budget_team_post_response.status_code == 201
+    budget_team_bli_id = budget_team_post_response.json["id"]
+
+    budget_team_transition_response = budget_team_auth_client.patch(
+        url_for("api.budget-line-items-item", id=budget_team_bli_id),
+        json={"status": target_status.name},
+    )
+    assert budget_team_transition_response.status_code == 400
+    assert (
+        "BLI must have a Need By Date in the future when status is not DRAFT"
+        in budget_team_transition_response.json["errors"]["date_needed"]
+    )
+
+    loaded_db.delete(loaded_db.get(ContractBudgetLineItem, power_user_bli_id))
+    loaded_db.delete(loaded_db.get(ContractBudgetLineItem, budget_team_bli_id))
+    loaded_db.commit()
+
+
 @pytest.mark.parametrize(
     "bli_status",
     [

--- a/backend/ops_api/tests/ops/features/past_obligate_by_date_budget_line.feature
+++ b/backend/ops_api/tests/ops/features/past_obligate_by_date_budget_line.feature
@@ -1,0 +1,43 @@
+Feature: Administrative Power User Can Set a Past Obligate-By Date on Budget Lines
+  As an Administrative Power User (SUPER_USER), I want to be able to set an obligate-by date in
+  the past when creating or editing a budget line so that I can record budget lines for obligations
+  that occurred in a prior fiscal period. Non-admin users must continue to be blocked from setting
+  an obligate-by date in the past.
+
+  Scenario: Administrative Power User edits a planned BLI's obligate-by date to a past date
+    Given I am logged in as an Administrative Power User
+    And I have a valid Agreement
+    And I have a PLANNED BLI with a future Need By Date
+
+    When the Administrative Power User PATCHes the BLI with a past Need By Date
+
+    Then the PATCH response is successful for the Administrative Power User
+
+  Scenario: Administrative Power User creates a BLI and transitions it with a past obligate-by date
+    Given I am logged in as an Administrative Power User
+    And I have a valid Agreement
+
+    When the Administrative Power User POSTs a DRAFT BLI with a past Need By Date
+    And the Administrative Power User PATCHes the new BLI to PLANNED status
+
+    Then the POST response creates the BLI successfully
+    And the transition to PLANNED is successful for the Administrative Power User
+
+  Scenario: Standard user is blocked from editing a planned BLI's obligate-by date to a past date
+    Given I am logged in as a Budget Team user
+    And I have a valid Agreement
+    And I have a PLANNED BLI with a future Need By Date
+
+    When the Budget Team user PATCHes the BLI with a past Need By Date
+
+    Then the PATCH is rejected with a Need By Date in the future error
+
+  Scenario: Standard user is blocked from transitioning a BLI to PLANNED with a past obligate-by date
+    Given I am logged in as a Budget Team user
+    And I have a valid Agreement
+
+    When the Budget Team user POSTs a DRAFT BLI with a past Need By Date
+    And the Budget Team user PATCHes the new BLI to PLANNED status
+
+    Then the POST response creates the BLI successfully
+    And the transition to PLANNED is rejected with a Need By Date in the future error

--- a/backend/ops_api/tests/ops/features/test_past_obligate_by_date_budget_line.py
+++ b/backend/ops_api/tests/ops/features/test_past_obligate_by_date_budget_line.py
@@ -1,0 +1,243 @@
+import datetime
+
+import pytest
+from pytest_bdd import given, scenario, then, when
+
+from models import (
+    AgreementReason,
+    AgreementType,
+    BudgetLineItem,
+    BudgetLineItemStatus,
+    ContractAgreement,
+    ContractBudgetLineItem,
+    ContractType,
+    ServicesComponent,
+)
+
+
+@pytest.fixture(scope="function")
+def context():
+    return {}
+
+
+def cleanup(loaded_db, context):
+    if "created_bli_id" in context:
+        bli = loaded_db.get(BudgetLineItem, context["created_bli_id"])
+        if bli is not None:
+            loaded_db.delete(bli)
+
+    if "bli" in context:
+        bli = loaded_db.get(BudgetLineItem, context["bli"].id)
+        if bli is not None:
+            loaded_db.delete(bli)
+
+    if "services_component" in context:
+        sc = loaded_db.get(ServicesComponent, context["services_component"].id)
+        if sc is not None:
+            loaded_db.delete(sc)
+
+    if "agreement" in context:
+        agreement = loaded_db.get(ContractAgreement, context["agreement"].id)
+        if agreement is not None:
+            loaded_db.delete(agreement)
+
+    loaded_db.commit()
+
+
+@pytest.fixture()
+def setup_and_teardown(loaded_db, context):
+    yield
+    cleanup(loaded_db, context)
+
+
+@scenario(
+    "past_obligate_by_date_budget_line.feature",
+    "Administrative Power User edits a planned BLI's obligate-by date to a past date",
+)
+def test_power_user_edit_with_past_date(loaded_db, context): ...
+
+
+@scenario(
+    "past_obligate_by_date_budget_line.feature",
+    "Administrative Power User creates a BLI and transitions it with a past obligate-by date",
+)
+def test_power_user_create_then_transition_with_past_date(loaded_db, context): ...
+
+
+@scenario(
+    "past_obligate_by_date_budget_line.feature",
+    "Standard user is blocked from editing a planned BLI's obligate-by date to a past date",
+)
+def test_budget_team_edit_with_past_date_rejected(loaded_db, context): ...
+
+
+@scenario(
+    "past_obligate_by_date_budget_line.feature",
+    "Standard user is blocked from transitioning a BLI to PLANNED with a past obligate-by date",
+)
+def test_budget_team_create_then_transition_with_past_date_rejected(loaded_db, context): ...
+
+
+@given(
+    "I am logged in as an Administrative Power User",
+    target_fixture="bdd_client",
+)
+def bdd_power_user_client(power_user_auth_client):
+    return power_user_auth_client
+
+
+@given(
+    "I am logged in as a Budget Team user",
+    target_fixture="bdd_client",
+)
+def bdd_budget_team_client(budget_team_auth_client):
+    return budget_team_auth_client
+
+
+@given("I have a valid Agreement")
+def valid_agreement(loaded_db, context, test_user, test_project):
+    contract_agreement = ContractAgreement(
+        name="CTXX12399",
+        contract_number="CT0002",
+        contract_type=ContractType.FIRM_FIXED_PRICE,
+        agreement_type=AgreementType.CONTRACT,
+        project_id=test_project.id,
+        product_service_code_id=2,
+        description="Using Innovative Data...",
+        agreement_reason=AgreementReason.NEW_REQ,
+        project_officer_id=test_user.id,
+        awarding_entity_id=1,
+    )
+    contract_agreement.team_members.append(test_user)
+    loaded_db.add(contract_agreement)
+    loaded_db.commit()
+
+    sc = ServicesComponent(agreement_id=contract_agreement.id, number=99, optional=False)
+    loaded_db.add(sc)
+    loaded_db.commit()
+
+    context["agreement"] = contract_agreement
+    context["services_component"] = sc
+
+
+@given("I have a PLANNED BLI with a future Need By Date")
+def planned_bli(loaded_db, context, test_user, test_can):
+    bli = ContractBudgetLineItem(
+        agreement_id=context["agreement"].id,
+        line_description="Planned LI",
+        amount=1000.0,
+        can_id=test_can.id,
+        date_needed=datetime.date(2043, 1, 1),
+        status=BudgetLineItemStatus.PLANNED,
+        proc_shop_fee_percentage=1.23,
+        created_by=test_user.id,
+        services_component_id=context["services_component"].id,
+    )
+    loaded_db.add(bli)
+    loaded_db.commit()
+
+    context["bli"] = bli
+
+
+@when("the Administrative Power User PATCHes the BLI with a past Need By Date")
+def power_user_patch_past_date(bdd_client, context):
+    context["response_patch"] = bdd_client.patch(
+        f"/api/v1/budget-line-items/{context['bli'].id}",
+        json={"date_needed": "2020-06-21"},
+    )
+
+
+@when("the Budget Team user PATCHes the BLI with a past Need By Date")
+def budget_team_patch_past_date(bdd_client, context):
+    context["response_patch"] = bdd_client.patch(
+        f"/api/v1/budget-line-items/{context['bli'].id}",
+        json={"date_needed": "2020-06-21"},
+    )
+
+
+@when("the Administrative Power User POSTs a DRAFT BLI with a past Need By Date")
+def power_user_post_draft_with_past_date(bdd_client, context, test_can):
+    context["response_post"] = bdd_client.post(
+        "/api/v1/budget-line-items/",
+        json={
+            "agreement_id": context["agreement"].id,
+            "line_description": "New LI with past date",
+            "can_id": test_can.id,
+            "amount": 2000.0,
+            "status": "DRAFT",
+            "date_needed": "2020-06-21",
+            "proc_shop_fee_percentage": 1.23,
+            "services_component_id": context["services_component"].id,
+        },
+    )
+    if context["response_post"].status_code == 201:
+        context["created_bli_id"] = context["response_post"].json["id"]
+
+
+@when("the Budget Team user POSTs a DRAFT BLI with a past Need By Date")
+def budget_team_post_draft_with_past_date(bdd_client, context, test_can):
+    context["response_post"] = bdd_client.post(
+        "/api/v1/budget-line-items/",
+        json={
+            "agreement_id": context["agreement"].id,
+            "line_description": "New LI with past date",
+            "can_id": test_can.id,
+            "amount": 2000.0,
+            "status": "DRAFT",
+            "date_needed": "2020-06-21",
+            "proc_shop_fee_percentage": 1.23,
+            "services_component_id": context["services_component"].id,
+        },
+    )
+    if context["response_post"].status_code == 201:
+        context["created_bli_id"] = context["response_post"].json["id"]
+
+
+@when("the Administrative Power User PATCHes the new BLI to PLANNED status")
+def power_user_transition_new_bli_to_planned(bdd_client, context):
+    context["response_patch"] = bdd_client.patch(
+        f"/api/v1/budget-line-items/{context['created_bli_id']}",
+        json={"status": "PLANNED"},
+    )
+
+
+@when("the Budget Team user PATCHes the new BLI to PLANNED status")
+def budget_team_transition_new_bli_to_planned(bdd_client, context):
+    context["response_patch"] = bdd_client.patch(
+        f"/api/v1/budget-line-items/{context['created_bli_id']}",
+        json={"status": "PLANNED"},
+    )
+
+
+@then("the PATCH response is successful for the Administrative Power User")
+def patch_success_power_user(context, setup_and_teardown):
+    assert context["response_patch"].status_code == 200
+
+
+@then("the POST response creates the BLI successfully")
+def post_creates_bli(context):
+    assert context["response_post"].status_code == 201
+    assert context["response_post"].json["id"] is not None
+
+
+@then("the transition to PLANNED is successful for the Administrative Power User")
+def transition_success_power_user(context, setup_and_teardown):
+    assert context["response_patch"].status_code == 200
+
+
+@then("the PATCH is rejected with a Need By Date in the future error")
+def patch_rejected_future_date_error(context, setup_and_teardown):
+    assert context["response_patch"].status_code == 400
+    assert (
+        "BLI must have a Need By Date in the future when status is not DRAFT"
+        in context["response_patch"].json["errors"]["date_needed"]
+    )
+
+
+@then("the transition to PLANNED is rejected with a Need By Date in the future error")
+def transition_rejected_future_date_error(context, setup_and_teardown):
+    assert context["response_patch"].status_code == 400
+    assert (
+        "BLI must have a Need By Date in the future when status is not DRAFT"
+        in context["response_patch"].json["errors"]["date_needed"]
+    )

--- a/backend/ops_api/tests/ops/features/test_past_obligate_by_date_budget_line.py
+++ b/backend/ops_api/tests/ops/features/test_past_obligate_by_date_budget_line.py
@@ -6,7 +6,6 @@ from pytest_bdd import given, scenario, then, when
 from models import (
     AgreementReason,
     AgreementType,
-    BudgetLineItem,
     BudgetLineItemStatus,
     ContractAgreement,
     ContractBudgetLineItem,
@@ -18,36 +17,6 @@ from models import (
 @pytest.fixture(scope="function")
 def context():
     return {}
-
-
-def cleanup(loaded_db, context):
-    if "created_bli_id" in context:
-        bli = loaded_db.get(BudgetLineItem, context["created_bli_id"])
-        if bli is not None:
-            loaded_db.delete(bli)
-
-    if "bli" in context:
-        bli = loaded_db.get(BudgetLineItem, context["bli"].id)
-        if bli is not None:
-            loaded_db.delete(bli)
-
-    if "services_component" in context:
-        sc = loaded_db.get(ServicesComponent, context["services_component"].id)
-        if sc is not None:
-            loaded_db.delete(sc)
-
-    if "agreement" in context:
-        agreement = loaded_db.get(ContractAgreement, context["agreement"].id)
-        if agreement is not None:
-            loaded_db.delete(agreement)
-
-    loaded_db.commit()
-
-
-@pytest.fixture()
-def setup_and_teardown(loaded_db, context):
-    yield
-    cleanup(loaded_db, context)
 
 
 @scenario(
@@ -210,7 +179,7 @@ def budget_team_transition_new_bli_to_planned(bdd_client, context):
 
 
 @then("the PATCH response is successful for the Administrative Power User")
-def patch_success_power_user(context, setup_and_teardown):
+def patch_success_power_user(context):
     assert context["response_patch"].status_code == 200
 
 
@@ -221,12 +190,12 @@ def post_creates_bli(context):
 
 
 @then("the transition to PLANNED is successful for the Administrative Power User")
-def transition_success_power_user(context, setup_and_teardown):
+def transition_success_power_user(context):
     assert context["response_patch"].status_code == 200
 
 
 @then("the PATCH is rejected with a Need By Date in the future error")
-def patch_rejected_future_date_error(context, setup_and_teardown):
+def patch_rejected_future_date_error(context):
     assert context["response_patch"].status_code == 400
     assert (
         "BLI must have a Need By Date in the future when status is not DRAFT"
@@ -235,7 +204,7 @@ def patch_rejected_future_date_error(context, setup_and_teardown):
 
 
 @then("the transition to PLANNED is rejected with a Need By Date in the future error")
-def transition_rejected_future_date_error(context, setup_and_teardown):
+def transition_rejected_future_date_error(context):
     assert context["response_patch"].status_code == 400
     assert (
         "BLI must have a Need By Date in the future when status is not DRAFT"

--- a/frontend/src/components/BudgetLineItems/BudgetLinesForm/datePickerSuite.test.js
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesForm/datePickerSuite.test.js
@@ -1,0 +1,97 @@
+import { beforeEach } from "vitest";
+import suite from "./datePickerSuite";
+
+describe("datePickerSuite Validation", () => {
+    const getFutureDate = () => {
+        const futureDate = new Date();
+        futureDate.setDate(futureDate.getDate() + 90);
+        const month = String(futureDate.getMonth() + 1).padStart(2, "0");
+        const day = String(futureDate.getDate()).padStart(2, "0");
+        const year = futureDate.getFullYear();
+        return `${month}/${day}/${year}`;
+    };
+
+    const getPastDate = () => {
+        const pastDate = new Date();
+        pastDate.setDate(pastDate.getDate() - 1);
+        const month = String(pastDate.getMonth() + 1).padStart(2, "0");
+        const day = String(pastDate.getDate()).padStart(2, "0");
+        const year = pastDate.getFullYear();
+        return `${month}/${day}/${year}`;
+    };
+
+    beforeEach(() => {
+        suite.reset();
+    });
+
+    describe("Regular User Validations", () => {
+        it("should pass validation with a future date", () => {
+            const result = suite.run({ needByDate: getFutureDate() });
+
+            expect(result.hasErrors()).toBe(false);
+            expect(result.getErrors("needByDate")).toHaveLength(0);
+        });
+
+        it("should fail validation with a past date", () => {
+            const result = suite.run({ needByDate: getPastDate() });
+
+            expect(result.hasErrors()).toBe(true);
+            expect(result.getErrors("needByDate")).toContain("Date must be in the future");
+        });
+
+        it("should fail validation with an invalid date format", () => {
+            const result = suite.run({ needByDate: "not-a-date" });
+
+            expect(result.hasErrors()).toBe(true);
+            expect(result.getErrors("needByDate")).toContain("Date must be MM/DD/YYYY");
+        });
+
+        it("should skip validation when needByDate is null", () => {
+            const result = suite.run({ needByDate: null });
+
+            expect(result.hasErrors()).toBe(false);
+        });
+
+        it("should skip validation when needByDate is empty string", () => {
+            const result = suite.run({ needByDate: "" });
+
+            expect(result.hasErrors()).toBe(false);
+        });
+    });
+
+    describe("SUPER_USER Validations", () => {
+        it("should skip validation for SUPER_USER with a past date", () => {
+            const result = suite.run({ needByDate: "01/01/2020" }, true);
+
+            expect(result.hasErrors()).toBe(false);
+            expect(result.getErrors("needByDate")).toHaveLength(0);
+        });
+
+        it("should skip validation for SUPER_USER with an invalid date format", () => {
+            const result = suite.run({ needByDate: "not-a-date" }, true);
+
+            expect(result.hasErrors()).toBe(false);
+        });
+
+        it("should skip validation for SUPER_USER with a future date", () => {
+            const result = suite.run({ needByDate: getFutureDate() }, true);
+
+            expect(result.hasErrors()).toBe(false);
+        });
+    });
+
+    describe("Edge Cases", () => {
+        it("should default to non-super-user behavior when isSuperUser is undefined", () => {
+            const result = suite.run({ needByDate: getPastDate() }, undefined);
+
+            expect(result.hasErrors()).toBe(true);
+            expect(result.getErrors("needByDate")).toContain("Date must be in the future");
+        });
+
+        it("should default to non-super-user behavior when isSuperUser is false", () => {
+            const result = suite.run({ needByDate: getPastDate() }, false);
+
+            expect(result.hasErrors()).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## What changed

Adds test coverage formalizing that Administrative Power Users (`SUPER_USER`) can set a past obligate-by date (`date_needed`) on budget lines, while non-admin users remain blocked. The SUPER_USER bypass already exists in production code at all three layers (backend service `budget_line_items.py:799-803`, frontend `suite.js:7-9`, frontend `datePickerSuite.js:5-7`); this PR adds the tests called out in the story to lock that behavior in.

**New test files**
- `backend/ops_api/tests/ops/features/past_obligate_by_date_budget_line.feature` — 4 BDD scenarios (power user create/edit success, budget team create/edit blocked)
- `backend/ops_api/tests/ops/features/test_past_obligate_by_date_budget_line.py` — pytest-bdd runner
- `frontend/src/components/BudgetLineItems/BudgetLinesForm/datePickerSuite.test.js` — 10 unit tests covering past/future/invalid/empty dates for both roles

**Extended**
- `backend/ops_api/tests/ops/budget_line_items/test_budget_line_item_power_user.py` — adds `test_power_user_create_bli_with_past_obligate_by_date` covering POST + transition-to-PLANNED for both roles (existing tests only covered PATCH)

No production code changes.

## Issue

#5827

## How to test

**Automated**
- Backend: `cd backend/ops_api && pipenv run pytest tests/ops/features/test_past_obligate_by_date_budget_line.py tests/ops/budget_line_items/test_budget_line_item_power_user.py` — 5 new test cases pass
- Frontend: `cd frontend && bun run test --watch=false src/components/BudgetLineItems/BudgetLinesForm/datePickerSuite.test.js` — 10 new test cases pass

**Manual (optional smoke check)**
1. `podman compose up --build`
2. Log in as a `SUPER_USER` seed user, open an agreement, create a new BLI with `date_needed` in 2020, save — succeeds
3. Edit the BLI's `date_needed` to another past date, save — succeeds
4. Log out, log back in as a Budget Team user, attempt the same — date picker shows "Date must be in the future"

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated