### PR TITLE
fix: removed edit button for read only user and alert now closes

### DIFF
--- a/frontend/src/components/Users/UserInfo/UserInfo.jsx
+++ b/frontend/src/components/Users/UserInfo/UserInfo.jsx
@@ -1,10 +1,8 @@
 import React, { useEffect } from "react";
-import { useDispatch } from "react-redux";
 import { useGetDivisionsQuery, useUpdateUserMutation } from "../../../api/opsAPI.js";
 import { useGetRolesQuery } from "../../../api/opsAuthAPI.js";
 import constants from "../../../constants.js";
 import useAlert from "../../../hooks/use-alert.hooks.js";
-import { setIsActive } from "../../UI/Alert/alertSlice.js";
 import ComboBox from "../../UI/Form/ComboBox/index.js";
 import { USER_STATUS } from "./UserInfo.constants.js";
 import { useNavigate } from "react-router-dom";
@@ -28,7 +26,6 @@ const STATUS_DATA = [
 const UserInfo = ({ user, isEditable }) => {
     const navigate = useNavigate();
     const { setAlert } = useAlert();
-    const dispatch = useDispatch();
 
     const [selectedDivision, setSelectedDivision] = React.useState({});
     const [selectedStatus, setSelectedStatus] = React.useState({});
@@ -92,7 +89,7 @@ const UserInfo = ({ user, isEditable }) => {
                 heading: "User Updated",
                 message: "The user has been updated successfully."
             });
-            dispatch(setIsActive(true));
+            updateUserResult.reset();
         }
 
         if (updateUserResult.isError) {
@@ -101,9 +98,9 @@ const UserInfo = ({ user, isEditable }) => {
                 heading: "Error",
                 message: "An error occurred while updating the user."
             });
-            dispatch(setIsActive(true));
+            updateUserResult.reset();
         }
-    }, [updateUserResult, dispatch, setAlert]);
+    }, [updateUserResult, setAlert]);
     const handleDivisionChange = (division) => {
         setSelectedDivision(division);
         updateUser({ id: user.id, data: { division: division ? division.id : null } });

--- a/frontend/src/components/Users/UserInfo/UserInfo.test.js
+++ b/frontend/src/components/Users/UserInfo/UserInfo.test.js
@@ -4,6 +4,22 @@ import { renderWithProviders } from "../../../test-utils.js";
 import { vi, beforeEach } from "vitest";
 import UserInfo from "./UserInfo";
 
+// Stable mock references so tests can assert on them and control the
+// mutation result to exercise the success/error alert-lifecycle branches.
+const { mockSetAlert, mockUpdateUser, mockResetMutation, mockUseUpdateUserMutation } = vi.hoisted(() => {
+    const mockUpdateUser = vi.fn();
+    const mockResetMutation = vi.fn();
+    return {
+        mockSetAlert: vi.fn(),
+        mockUpdateUser,
+        mockResetMutation,
+        mockUseUpdateUserMutation: vi.fn(() => [
+            mockUpdateUser,
+            { isSuccess: false, isError: false, reset: mockResetMutation }
+        ])
+    };
+});
+
 // Mock React Router navigate
 vi.mock("react-router-dom", async () => {
     const actual = await vi.importActual("react-router-dom");
@@ -16,7 +32,7 @@ vi.mock("react-router-dom", async () => {
 // Mock the useAlert hook
 vi.mock("../../../hooks/use-alert.hooks.js", () => ({
     default: vi.fn(() => ({
-        setAlert: vi.fn()
+        setAlert: mockSetAlert
     }))
 }));
 
@@ -74,10 +90,7 @@ vi.mock("../../../api/opsAPI.js", () => ({
         error: null,
         isLoading: false
     })),
-    useUpdateUserMutation: vi.fn(() => [
-        vi.fn(), // updateUser function
-        { isSuccess: false, isError: false } // result object
-    ])
+    useUpdateUserMutation: mockUseUpdateUserMutation
 }));
 
 vi.mock("../../../api/opsAuthAPI.js", () => ({
@@ -115,6 +128,76 @@ describe("UserInfo", () => {
     beforeEach(() => {
         // Reset all mocks before each test
         vi.clearAllMocks();
+        // Restore the default mutation result after clearAllMocks wiped the implementation
+        mockUseUpdateUserMutation.mockReturnValue([
+            mockUpdateUser,
+            { isSuccess: false, isError: false, reset: mockResetMutation }
+        ]);
+    });
+
+    test("fires a success alert and resets the mutation when the update succeeds", async () => {
+        // Simulate a successful mutation so the success branch of the effect runs
+        mockUseUpdateUserMutation.mockReturnValue([
+            mockUpdateUser,
+            { isSuccess: true, isError: false, reset: mockResetMutation }
+        ]);
+
+        const user = {
+            id: 1,
+            full_name: "Test User",
+            email: "test.user@example.com",
+            division: 1,
+            status: "ACTIVE",
+            roles: [{ id: 1, name: "SYSTEM_OWNER", is_superuser: false }]
+        };
+        renderWithProviders(
+            <App
+                user={user}
+                isEditable={true}
+            />
+        );
+
+        await waitFor(() => {
+            expect(mockSetAlert).toHaveBeenCalledWith({
+                type: "success",
+                heading: "User Updated",
+                message: "The user has been updated successfully."
+            });
+        });
+        // reset() guards against the alert re-firing on subsequent renders
+        expect(mockResetMutation).toHaveBeenCalled();
+    });
+
+    test("fires an error alert and resets the mutation when the update fails", async () => {
+        // Simulate a failed mutation so the error branch of the effect runs
+        mockUseUpdateUserMutation.mockReturnValue([
+            mockUpdateUser,
+            { isSuccess: false, isError: true, reset: mockResetMutation }
+        ]);
+
+        const user = {
+            id: 1,
+            full_name: "Test User",
+            email: "test.user@example.com",
+            division: 1,
+            status: "ACTIVE",
+            roles: [{ id: 1, name: "SYSTEM_OWNER", is_superuser: false }]
+        };
+        renderWithProviders(
+            <App
+                user={user}
+                isEditable={true}
+            />
+        );
+
+        await waitFor(() => {
+            expect(mockSetAlert).toHaveBeenCalledWith({
+                type: "error",
+                heading: "Error",
+                message: "An error occurred while updating the user."
+            });
+        });
+        expect(mockResetMutation).toHaveBeenCalled();
     });
 
     test("renders correctly (read only)", async () => {

--- a/frontend/src/pages/cans/detail/CanFunding.hooks.js
+++ b/frontend/src/pages/cans/detail/CanFunding.hooks.js
@@ -13,7 +13,6 @@ import { NO_DATA } from "../../../constants.js";
 import { scrollToTop } from "../../../helpers/scrollToTop.helper.js";
 import { getCurrentFiscalYear } from "../../../helpers/utils.js";
 import useAlert from "../../../hooks/use-alert.hooks";
-import { useIsUserReadOnly } from "../../../hooks/user.hooks";
 import useNavigationBlocker from "../../../hooks/useNavigationBlocker.hooks";
 import suite from "./CanFundingSuite.js";
 
@@ -103,9 +102,7 @@ export default function useCanFunding(
     isExpired
 ) {
     const currentFiscalYear = getCurrentFiscalYear();
-    const isReadOnly = useIsUserReadOnly();
-    const showButton =
-        !isReadOnly && isBudgetTeamMember && !isExpired && fiscalYear === Number(currentFiscalYear) && !isEditMode;
+    const showButton = isBudgetTeamMember && !isExpired && fiscalYear === Number(currentFiscalYear) && !isEditMode;
     const [showModal, setShowModal] = React.useState(false);
     const [totalReceived, setTotalReceived] = React.useState(receivedFunding || 0);
     const [enteredFundingReceived, setEnteredFundingReceived] = React.useState([...fundingReceived]);

--- a/frontend/src/pages/cans/detail/CanFunding.hooks.js
+++ b/frontend/src/pages/cans/detail/CanFunding.hooks.js
@@ -13,6 +13,7 @@ import { NO_DATA } from "../../../constants.js";
 import { scrollToTop } from "../../../helpers/scrollToTop.helper.js";
 import { getCurrentFiscalYear } from "../../../helpers/utils.js";
 import useAlert from "../../../hooks/use-alert.hooks";
+import { useIsUserReadOnly } from "../../../hooks/user.hooks";
 import useNavigationBlocker from "../../../hooks/useNavigationBlocker.hooks";
 import suite from "./CanFundingSuite.js";
 
@@ -102,7 +103,9 @@ export default function useCanFunding(
     isExpired
 ) {
     const currentFiscalYear = getCurrentFiscalYear();
-    const showButton = isBudgetTeamMember && !isExpired && fiscalYear === Number(currentFiscalYear) && !isEditMode;
+    const isReadOnly = useIsUserReadOnly();
+    const showButton =
+        !isReadOnly && isBudgetTeamMember && !isExpired && fiscalYear === Number(currentFiscalYear) && !isEditMode;
     const [showModal, setShowModal] = React.useState(false);
     const [totalReceived, setTotalReceived] = React.useState(receivedFunding || 0);
     const [enteredFundingReceived, setEnteredFundingReceived] = React.useState([...fundingReceived]);

--- a/frontend/src/pages/cans/detail/CanFunding.jsx
+++ b/frontend/src/pages/cans/detail/CanFunding.jsx
@@ -14,6 +14,7 @@ import SaveChangesAndExitModal from "../../../components/UI/Modals/SaveChangesAn
 import RoundedBox from "../../../components/UI/RoundedBox";
 import useCanFunding from "./CanFunding.hooks.js";
 import Tooltip from "../../../components/UI/USWDS/Tooltip";
+import { useIsUserReadOnly } from "../../../hooks/user.hooks";
 
 /**
  * @typedef {import("../../../types/CANTypes").FundingDetails} FundingDetails
@@ -75,6 +76,7 @@ const CanFunding = ({
     isExpired,
     isTableLoading = false
 }) => {
+    const isReadOnly = useIsUserReadOnly();
     const {
         handleAddBudget,
         handleAddFundingReceived,
@@ -158,48 +160,49 @@ const CanFunding = ({
             )}
             <div className="display-flex flex-justify">
                 <h2>{!isEditMode ? "CAN Funding" : `Review FY ${fiscalYear} Funding Information`}</h2>
-                {!showButton ? (
-                    <Tooltip
-                        label="Only data from the current fiscal year can be edited."
-                        position="bottom"
-                        className="display-inline-flex flex-align-center"
-                    >
+                {!isReadOnly &&
+                    (!showButton ? (
+                        <Tooltip
+                            label="Only data from the current fiscal year can be edited."
+                            position="bottom"
+                            className="display-inline-flex flex-align-center"
+                        >
+                            <button
+                                type="button"
+                                id="edit"
+                                className="cursor-not-allowed"
+                                style={{ cursor: "not-allowed", display: "inline-flex", alignItems: "center" }}
+                                disabled={!showButton}
+                                onClick={toggleEditMode}
+                            >
+                                <FontAwesomeIcon
+                                    icon={faPen}
+                                    size="2x"
+                                    className="height-2 width-2 margin-right-1 text-base-light"
+                                    title="edit"
+                                    data-position="top"
+                                />
+                                <span className="text-base-light">Edit</span>
+                            </button>
+                        </Tooltip>
+                    ) : (
                         <button
                             type="button"
                             id="edit"
-                            className="cursor-not-allowed"
-                            style={{ cursor: "not-allowed", display: "inline-flex", alignItems: "center" }}
+                            className="hover:text-underline cursor-pointer"
                             disabled={!showButton}
                             onClick={toggleEditMode}
                         >
                             <FontAwesomeIcon
                                 icon={faPen}
                                 size="2x"
-                                className="height-2 width-2 margin-right-1 text-base-light"
+                                className="height-2 width-2 margin-right-1 text-primary cursor-pointer"
                                 title="edit"
                                 data-position="top"
                             />
-                            <span className="text-base-light">Edit</span>
+                            <span className="text-primary">Edit</span>
                         </button>
-                    </Tooltip>
-                ) : (
-                    <button
-                        type="button"
-                        id="edit"
-                        className="hover:text-underline cursor-pointer"
-                        disabled={!showButton}
-                        onClick={toggleEditMode}
-                    >
-                        <FontAwesomeIcon
-                            icon={faPen}
-                            size="2x"
-                            className="height-2 width-2 margin-right-1 text-primary cursor-pointer"
-                            title="edit"
-                            data-position="top"
-                        />
-                        <span className="text-primary">Edit</span>
-                    </button>
-                )}
+                    ))}
             </div>
             <p>
                 {!isEditMode

--- a/frontend/src/pages/cans/detail/CanFunding.test.jsx
+++ b/frontend/src/pages/cans/detail/CanFunding.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import CanFunding from "./CanFunding";
 
 vi.mock("./CanFunding.hooks.js", () => ({
@@ -31,8 +31,12 @@ vi.mock("./CanFunding.hooks.js", () => ({
     })
 }));
 
+const { mockUseIsUserReadOnly } = vi.hoisted(() => ({
+    mockUseIsUserReadOnly: vi.fn(() => false)
+}));
+
 vi.mock("../../../hooks/user.hooks", () => ({
-    useIsUserReadOnly: () => false
+    useIsUserReadOnly: mockUseIsUserReadOnly
 }));
 
 vi.mock("../../../components/CANs/CANBudgetByFYCard/CANBudgetByFYCard", () => ({
@@ -53,6 +57,10 @@ vi.mock("../../../components/UI/Modals/index.js", () => ({ default: () => <div>M
 vi.mock("../../../components/UI/RoundedBox", () => ({ default: ({ children }) => <div>{children}</div> }));
 
 describe("CanFunding", () => {
+    beforeEach(() => {
+        mockUseIsUserReadOnly.mockReturnValue(false);
+    });
+
     afterEach(() => {
         vi.clearAllMocks();
     });
@@ -135,5 +143,61 @@ describe("CanFunding", () => {
         expect(screen.getByRole("button", { name: "Funding Received YTD" })).toBeInTheDocument();
         expect(screen.getByRole("table", { name: "Loading funding received" })).toBeInTheDocument();
         expect(screen.queryByText("Funding received table")).not.toBeInTheDocument();
+    });
+
+    it("renders the Edit button when the user is not read-only", () => {
+        mockUseIsUserReadOnly.mockReturnValue(false);
+
+        render(
+            <CanFunding
+                canId={1}
+                canNumber="CAN-001"
+                currentFiscalYearFundingId={11}
+                funding={{ fiscal_year: 2026, active_period: 1 }}
+                fundingBudgets={[]}
+                fiscalYear={2026}
+                totalFunding={1000}
+                receivedFunding={100}
+                fundingReceived={[]}
+                isBudgetTeamMember={false}
+                isEditMode={false}
+                toggleEditMode={() => {}}
+                carryForwardFunding={0}
+                welcomeModal={{ showModal: false }}
+                resetWelcomeModal={() => {}}
+                isExpired={false}
+                isTableLoading={false}
+            />
+        );
+
+        expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+    });
+
+    it("hides the Edit button when the user is read-only", () => {
+        mockUseIsUserReadOnly.mockReturnValue(true);
+
+        render(
+            <CanFunding
+                canId={1}
+                canNumber="CAN-001"
+                currentFiscalYearFundingId={11}
+                funding={{ fiscal_year: 2026, active_period: 1 }}
+                fundingBudgets={[]}
+                fiscalYear={2026}
+                totalFunding={1000}
+                receivedFunding={100}
+                fundingReceived={[]}
+                isBudgetTeamMember={false}
+                isEditMode={false}
+                toggleEditMode={() => {}}
+                carryForwardFunding={0}
+                welcomeModal={{ showModal: false }}
+                resetWelcomeModal={() => {}}
+                isExpired={false}
+                isTableLoading={false}
+            />
+        );
+
+        expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/cans/detail/CanFunding.test.jsx
+++ b/frontend/src/pages/cans/detail/CanFunding.test.jsx
@@ -31,6 +31,10 @@ vi.mock("./CanFunding.hooks.js", () => ({
     })
 }));
 
+vi.mock("../../../hooks/user.hooks", () => ({
+    useIsUserReadOnly: () => false
+}));
+
 vi.mock("../../../components/CANs/CANBudgetByFYCard/CANBudgetByFYCard", () => ({
     default: () => <div>Budget by FY card</div>
 }));


### PR DESCRIPTION
## What changed

Fixed the success alert bug and removed edit button from the Can Funding tab when logged in as the Read-Only User.

## Issue

#2728 

## How to test

- log in s Read-Only user
- go to any Can Funding page to verify that the edit button does not render
- log in as budget team member
- go to user admin and change a user's role
- Verify that the alert renders, is closable and disappears on its own after 6 seconds

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [x] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [ ] N/A — change is page-specific or non-visual

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
