### PR TITLE
Remove team-member requirement for budget-line status changes

### DIFF
--- a/.claude/skills/dead-code-after-removal-sweep/SKILL.md
+++ b/.claude/skills/dead-code-after-removal-sweep/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: dead-code-after-removal-sweep
+description: Use after deleting a feature, function, component, validation rule, config flag, enum value, or any symbol — to find the downstream artifacts the deletion orphaned. Covers orphaned string keys in object/label/i18n maps, dead branches, now-unused imports/props, stale comments, and test fixtures that ESLint and code review miss. Trigger when you removed code and want a clean, zero-dead-code diff.
+---
+
+# Dead-Code-After-Removal Sweep
+
+## Overview
+
+When you delete something, the thing you deleted usually had **dependents** — code and data elsewhere that only existed to serve it. Deleting the definition without sweeping its dependents leaves dead code: it compiles, it lints, all tests pass, and the reviewer often misses it too. It just sits there, quietly wrong, until it confuses the next person.
+
+**Core principle:** A removal is not "the definition." A removal is "the definition **and everything that only existed for it**." Sweep for dependents on the same commit that deletes the definition.
+
+## Why lint and review are not enough
+
+`bun run lint` (ESLint `no-unused-vars`) catches unused **bindings** — a variable, import, or parameter no longer referenced. It does **not** catch:
+
+- **Orphaned entries in object/dictionary maps** — a key like `"team-members": "Team Members"` in a label map is not a binding; nothing flags it when its only consumer disappears.
+- **String-keyed lookups** — `errors["team-members"]`, `labels[key]`, `dispatch({ type: "X" })`. The key is data, not a symbol.
+- **Now-unreachable branches** — an `if (mode === "legacy")` whose only caller you removed.
+- **Stale comments and JSDoc** — prose describing behavior that no longer exists.
+- **Test fixtures / mock data** — fields set only to satisfy the rule you deleted.
+
+This repo has **no** `knip` / `ts-prune` / `depcheck`. ESLint is the only static safety net, so the orphan classes above must be swept **manually**. (This is exactly the class of miss that survives review: a reviewer verifies the binding-level cleanup ESLint already guarantees, and the data-level orphan slips through.)
+
+## The Sweep
+
+Run this checklist on the **same branch** as the deletion, before you call the work done.
+
+### 1. Name the tokens you removed
+
+List every identifier and **string literal** tied to the deleted thing:
+
+- Symbol names: function/component/const/type names.
+- **String keys**: error keys, action types, label-map keys, route paths, `data-cy` attributes, event names, feature-flag strings, enum string values.
+
+The string keys are the ones that bite. Write them down explicitly.
+
+### 2. Grep each token repo-wide
+
+```bash
+# For each removed symbol AND each removed string key:
+grep -rn "team-members" src/ --include="*.js" --include="*.jsx" | grep -v "\.test\."
+```
+
+For every hit, classify it:
+
+- **Producer gone, consumer remains** → the consumer is now dead or renders nothing. Fix or remove it.
+- **Sibling data entry** (e.g. a label/i18n value for the key you deleted) → orphaned. Remove it.
+- **Still live for another reason** (a different producer of the same key exists) → leave it, and note why.
+
+### 3. Trace the producer→consumer chain both directions
+
+For a removed **producer** (e.g. a validation rule that emitted an error key), find who **consumed** its output:
+
+```bash
+# Who reads this key / renders this error / maps this label?
+grep -rn 'getErrors("team-members")\|convertCodeForDisplay("validation"' src/
+```
+
+For a removed **consumer** (e.g. a component), find data that existed only to feed it — fixtures, selector maps, mock builders.
+
+### 4. Run the static net and read the diff
+
+```bash
+bun run lint          # binding-level orphans (unused import/var/param)
+git diff main         # read every hunk: any comment, fixture field, or
+                      # branch that referenced the removed thing?
+```
+
+ESLint clearing is necessary, not sufficient. The `git diff` read is where you catch the data-level orphans by eye.
+
+### 5. Confirm no test asserts the orphan
+
+Before deleting an orphaned key/label, grep tests for it. If a test asserts its presence, that test is testing the dead thing — update or remove it in the same sweep.
+
+## Quick Reference
+
+| Orphan class | Caught by ESLint? | How to find |
+|---|---|---|
+| Unused import / var / param | ✅ Yes | `bun run lint` |
+| Object-map / label / i18n key | ❌ No | grep the string literal |
+| String-keyed lookup (`errors[k]`, action type) | ❌ No | grep the string literal |
+| Unreachable branch after caller removed | ❌ No | trace callers, read diff |
+| Stale comment / JSDoc | ❌ No | read the diff |
+| Fixture field for a deleted rule | ❌ No | grep field name in fixtures/tests |
+
+## Common Mistakes
+
+- **"Lint passed, so it's clean."** Lint only proves binding-level cleanliness. Data-level orphans (map keys, string lookups) pass lint. Grep the strings.
+- **Only grepping symbol names.** The expensive orphans are keyed by **string literals**, not symbols. List and grep the strings too.
+- **Only searching the file you edited.** Dependents live in other files — label maps in a `helpers/` module, fixtures in a test dir, renderers in a page component. Grep repo-wide.
+- **Deleting an orphaned key that a test still asserts.** Sweep tests in the same pass, or you trade a dead key for a red build.
+- **Leaving it "because it's out of scope."** If the deletion *created* the orphan, removing it *is* the scope. A one-line map-key deletion is zero-risk and completes the change.
+
+## Real-World Impact
+
+On OPS-5882 (removing the team-member Vest validation), ESLint and a first code review both passed. A second review caught an orphaned `"team-members": "Team Members"` entry in the `validation` label map in `src/helpers/utils.js` — dead the moment the Vest test that produced the `team-members` error key was deleted, because its only consumer was `convertCodeForDisplay("validation", key)` in `ReviewAgreement.jsx`. Grepping the removed **string key** repo-wide (step 2) would have surfaced it immediately.

--- a/.claude/skills/vest-error-key-lifecycle/SKILL.md
+++ b/.claude/skills/vest-error-key-lifecycle/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: vest-error-key-lifecycle
+description: Use when adding, removing, or renaming a Vest validation `test(...)` in this repo's suite.js / *Suite.js files, or when touching a validation error key like "team-members" / "project-officer". Maps the full producer→consumer chain (test → getErrors() → convertCodeForDisplay("validation", key) → error-list render → button gating) so a suite edit updates every dependent label, renderer, and test. Trigger on any Vest suite change.
+---
+
+# Vest Error-Key Lifecycle
+
+## Overview
+
+A Vest `test("some-key", ...)` in this repo does not just validate — it **produces an error key** (`"some-key"`) that flows through several other files that never import the suite. Add, rename, or delete a test and you touch that whole chain, but nothing links the files at compile time, so a partial edit leaves a broken label, an orphaned rendered error, or a stale button-gate.
+
+**Core principle:** The Vest error key is a **contract string** shared across the suite, the display-label map, the error-list renderer, and the button-gating logic. Treat every suite edit as a change to that contract, and update all four ends.
+
+## The Chain
+
+For a key like `"team-members"`, the lifecycle is:
+
+```
+1. PRODUCE   test("team-members", "msg", () => enforce(...))   in suite.js / *Suite.js
+                    │  emits the key into the result
+                    ▼
+2. READ      suite.get() / result.getErrors()                  → { "team-members": [...] }
+                    │
+                    ├─▶ 3a. GATE   res.hasErrors() disables Continue / Send-to-Approval
+                    │             (e.g. shouldDisableBtn in AgreementEditForm.hooks.js)
+                    │
+                    ├─▶ 3b. REVALIDATE  handlers call runValidate("team-members", ...)
+                    │             on field change (add/remove item)
+                    │
+                    └─▶ 3c. RENDER  Object.entries(pageErrors).map(([key]) =>
+                                     convertCodeForDisplay("validation", key))
+                                     in ReviewAgreement.jsx  (error list)
+                                          │
+                                          ▼
+4. LABEL     codesToDisplayText.validation[key] in src/helpers/utils.js
+             maps "team-members" → "Team Members" for display
+```
+
+Each numbered node is a **different file**. A grep of the key string is how you find them all — imports won't lead you there.
+
+## When you edit a suite
+
+### Removing a `test("key", ...)`
+
+Grep the key string repo-wide and clean up every dependent:
+
+```bash
+grep -rn '"team-members"\|team-members' src/ | grep -v "\.test\."
+```
+
+- **3a Gate** — usually self-heals: `hasErrors()` just stops seeing the key. Verify no code special-cases the key by name.
+- **3b Revalidate** — remove now-dead `runValidate("key", ...)` calls in change handlers; the test they targeted is gone.
+- **3c Render** — `getErrors("key")` / the error-list map now yields nothing for the key; confirm nothing renders an empty shell.
+- **4 Label** — the `validation[key]` entry in `utils.js` is now **orphaned**. Remove it. (ESLint will NOT flag it — it's an object key, not a binding.)
+- **Tests** — update any co-located suite test asserting `toHaveProperty("key")`; flip "fails if empty" → "passes if empty" when removing a completeness rule.
+
+### Adding a `test("key", ...)`
+
+- Add a matching label to `codesToDisplayText.validation` in `src/helpers/utils.js`, or the error list renders the raw key (`convertCodeForDisplay` falls back to the code itself when unmapped).
+- If a change handler should revalidate the field live, add a `runValidate("key", value)` call.
+- Add a suite unit test asserting the key appears/absent as expected.
+
+### Renaming a key
+
+Rename at **all four** nodes atomically: the `test()` name, any `runValidate`/`getErrors` string, the `validation` label key, and test assertions.
+
+## Vest v6 rules (repo convention — see frontend/CLAUDE.md)
+
+These are easy to break while editing a suite:
+
+- `suite.run(data)` — **not** `suite(data)` (v5 API throws in v6).
+- `isNotBlank()` fails on **numbers** — for numeric fields (ids, amounts) use `enforce(n).isNotNullish().greaterThan(0)`.
+- Do **not** call `only(dataObject)` with the whole form object — skipped tests retain prior failed state → phantom errors. Pass a field-name string or omit `only()`.
+- Don't call `suite.reset()` during render — store results via `useEffect` (see `ReviewAgreement.hooks.js`).
+
+## Quick Reference
+
+| Node | File (representative) | Update on remove? | ESLint catches a miss? |
+|---|---|---|---|
+| Produce (`test`) | `pages/agreements/review/suite.js`, `AgreementEditFormSuite.js` | delete the block | n/a |
+| Gate (`hasErrors`) | `AgreementEditForm.hooks.js` (`shouldDisableBtn`) | usually self-heals | — |
+| Revalidate (`runValidate`) | `AgreementEditForm.hooks.js` handlers | remove dead calls | ✅ if arg var unused |
+| Render (`convertCodeForDisplay`) | `pages/agreements/review/ReviewAgreement.jsx` | verify no empty render | ❌ |
+| Label (`validation` map) | `src/helpers/utils.js` | **remove orphaned key** | ❌ |
+| Tests | co-located `suite.test.js` | flip/remove assertions | test run catches |
+
+## Common Mistakes
+
+- **Deleting the `test()` and stopping.** The label in `utils.js` and any `runValidate("key")` calls are now dead. Grep the key string.
+- **Trusting lint to find the orphaned label.** `validation["team-members"]` is object data, not a binding — ESLint never flags it. Grep the string, remove by hand.
+- **Adding a `test()` without a label.** The error list will render the raw key (e.g. `team-members`) instead of `Team Members`, because `convertCodeForDisplay` returns the code when unmapped.
+- **Confusing completeness with authorization.** A Vest `test()` checks whether the form *has* data (completeness). "Only team members can send to approval" tooltips are a separate backend **authorization** check (`check_user_association`) — do not conflate them when editing a suite.
+- **Singular vs plural key drift.** `utils.js` may carry both `"team-member"` and `"team-members"`. Only remove the one your deleted test actually produced; leave unrelated siblings.
+
+## Real-World Impact
+
+OPS-5882 removed the `team-members` Vest test from two suites. Lint passed and a first review passed, but the `"team-members": "Team Members"` label in `utils.js` (node 4) was left orphaned — its only consumer was `convertCodeForDisplay("validation", key)` in `ReviewAgreement.jsx` (node 3c). Walking the chain above catches all four nodes in one pass. For the general technique beyond Vest, see the `dead-code-after-removal-sweep` skill.

--- a/frontend/cypress/e2e/createAgreementWithValidations.cy.js
+++ b/frontend/cypress/e2e/createAgreementWithValidations.cy.js
@@ -16,7 +16,6 @@ const agreementDetailsData = {
     awarding_entity_id: 2,
     agreement_reason: "NEW_REQ",
     project_officer_id: 500,
-    team_members: [{ id: 502 }, { id: 504 }],
     notes: "This is a note.",
     vendor: "Test Vendor"
 };
@@ -292,13 +291,6 @@ const fillRequiredAgreementDetails = () => {
         "Chris Fortunato",
         0
     );
-    selectComboboxOption(
-        "#team-member-combobox-input",
-        ".team-member-combobox__menu",
-        ".team-member-combobox__option",
-        "System Owner",
-        1
-    );
     cy.get("#agreementNotes").clear().type(agreementDetailsData.notes);
 };
 
@@ -400,8 +392,19 @@ describe("create agreement and test validations", () => {
         });
     });
 
-    it("enables review status transitions when valid data exists", () => {
+    it("enables review status transitions with a COR but no team members", () => {
         createValidAgreement().then((agreementId) => {
+            // The agreement is created with a COR (project_officer_id) but no team members.
+            // Confirm the send-to-approval flow proves team members are not required.
+            cy.request({
+                method: "GET",
+                url: `http://localhost:8080/api/v1/agreements/${agreementId}`,
+                headers: getAuthHeaders()
+            }).then((response) => {
+                expect(response.body.project_officer_id).to.eq(agreementDetailsData.project_officer_id);
+                expect(response.body.team_members).to.have.length(0);
+            });
+
             createServicesComponent(agreementId).then((servicesComponentId) => {
                 createBudgetLineItem(agreementId, servicesComponentId).then(() => {
                     cy.visit(`/agreements/${agreementId}/budget-lines`);

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
@@ -343,10 +343,6 @@ const useAgreementEditForm = (
             type: "ADD_TEAM_MEMBER",
             payload: teamMember
         });
-        if (isReviewMode) {
-            const newTeamMembers = [...(selectedTeamMembers ?? []), teamMember];
-            runValidate("team-members", newTeamMembers, { team_members: newTeamMembers });
-        }
     };
 
     const removeTeamMember = (teamMember) => {
@@ -354,10 +350,6 @@ const useAgreementEditForm = (
             type: "REMOVE_TEAM_MEMBER",
             payload: teamMember
         });
-        if (isReviewMode) {
-            const newTeamMembers = (selectedTeamMembers ?? []).filter((member) => member.id !== teamMember.id);
-            runValidate("team-members", newTeamMembers, { team_members: newTeamMembers });
-        }
     };
 
     const setResearchMethodology = (researchMethodologies) => {

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -594,7 +594,6 @@ const AgreementEditForm = ({
             </div>
             <div className="margin-top-3 width-card-lg">
                 <TeamMemberComboBox
-                    messages={res.getErrors("team-members")}
                     legendClassname="usa-label margin-top-0 margin-bottom-1"
                     selectedTeamMembers={selectedTeamMembers}
                     selectedProjectOfficer={selectedProjectOfficer}

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.js
@@ -53,9 +53,6 @@ const suite = create((data = {}, fieldName) => {
         enforce(data.contract_type).notEquals("-Select an option-");
         enforce(data.contract_type).isNotEmpty();
     });
-    test("team-members", "This is required information", () => {
-        enforce(data.team_members).lengthNotEquals(0);
-    });
     test("procurement-shop-select", "This is required information", () => {
         enforce(data["procurement-shop-select"]).isNotEmpty();
         enforce(data["procurement-shop-select"]?.id).greaterThan(0);

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -144,8 +144,7 @@ export const codesToDisplayText = {
         cor: "COR",
         "team-member": "Team Members",
         "budget-line-items": "Budget Line Items",
-        "contract-type": "Contract Type",
-        "team-members": "Team Members"
+        "contract-type": "Contract Type"
     },
     classNameLabels: {
         ContractAgreement: "Contract Agreement",

--- a/frontend/src/pages/agreements/review/suite.js
+++ b/frontend/src/pages/agreements/review/suite.js
@@ -38,10 +38,6 @@ const suite = create((data = {}, fieldName = undefined) => {
         enforce(data.contract_type).notEquals("-Select an option-");
         enforce(data.contract_type).isNotEmpty();
     });
-    test("team-members", "This information is required to submit for approval", () => {
-        const teamMembers = Array.isArray(data.team_members) ? data.team_members : [];
-        enforce(teamMembers).longerThan(0);
-    });
     // test to ensure at least one budget line item exists
     test("budget-line-items", "Must have at least one budget line item", () => {
         const budgetLines = Array.isArray(data.budget_line_items) ? data.budget_line_items : [];

--- a/frontend/src/pages/agreements/review/suite.test.js
+++ b/frontend/src/pages/agreements/review/suite.test.js
@@ -35,7 +35,6 @@ describe("Agreement Review Suite", () => {
         expect(result.getErrors()).toHaveProperty("reason");
         expect(result.getErrors()).toHaveProperty("project-officer");
         expect(result.getErrors()).toHaveProperty("contract-type");
-        expect(result.getErrors()).toHaveProperty("team-members");
         expect(result.getErrors()).toHaveProperty("budget-line-items");
     });
 
@@ -90,13 +89,13 @@ describe("Agreement Review Suite", () => {
         expect(result.getErrors()).toHaveProperty("contract-type");
     });
 
-    it("fails if team_members is empty", () => {
+    it("passes if team_members is empty (team members are not required for approval)", () => {
         const data = { ...validData, team_members: [] };
         suite.reset();
         suite.run(data);
         const result = suite.get();
-        expect(result.isValid()).toBe(false);
-        expect(result.getErrors()).toHaveProperty("team-members");
+        expect(result.isValid()).toBe(true);
+        expect(result.getErrors()).not.toHaveProperty("team-members");
     });
 
     it("fails if budget_line_items is empty", () => {


### PR DESCRIPTION
## What changed

Stakeholders decided that submitting a status change (`ChangeRequest`) for one or more budget lines on an Agreement (e.g. Draft → Planned) should **not** require team members to be added to the agreement. Having a COR (`project_officer_id`) is sufficient — and that requirement was already enforced.

The team-member requirement was implemented **entirely as frontend Vest validation** (the backend already only requires the COR for a status change, and no backend test asserts team members). This PR removes that frontend requirement and updates the tests to prove the COR-only path. No backend or DB change was needed.

**`frontend/src/pages/agreements/review/suite.js`** — Deleted the `team-members` completeness test that gated the "Send to Approval" button on the Review page.

**`frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.js`** — Deleted the `team-members` completeness test (fired in review mode).

**`frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js`** — Removed the now-dead `runValidate("team-members", ...)` calls in the `setSelectedTeamMembers` / `removeTeamMember` handlers (they referenced the deleted Vest test). Adding/removing team members still dispatches correctly.

**`frontend/src/helpers/utils.js`** — Removed the orphaned `"team-members": "Team Members"` entry from the `validation` display-label map. Its only consumer was the deleted error key (rendered via `convertCodeForDisplay("validation", key)` in `ReviewAgreement.jsx`).

**`frontend/src/pages/agreements/review/suite.test.js`** — Removed the `team-members` assertion from the "missing required fields" test, and converted "fails if team_members is empty" into a positive "passes if team_members is empty" test.

**`frontend/cypress/e2e/createAgreementWithValidations.cy.js`** — Removed `team_members` from the API fixture and the team-member UI step, and added a positive API assertion (COR present, zero team members) to the Draft → Planned send-to-approval test, proving COR-only submission.

**`.claude/skills/`** — Added two reusable skills surfaced by this change: `dead-code-after-removal-sweep` (finding artifacts orphaned by a deletion) and `vest-error-key-lifecycle` (the producer→consumer chain a Vest error key travels).

_Explicitly out of scope:_ the "Only team members on this agreement can send to approval" authorization tooltips are a separate authorization check (`check_user_association()`, which already treats the COR as authorized). The Team Members UI field stays optional with no styling changes.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5882

## How to test

**Unit tests:**
```bash
cd frontend
bun run test --watch=false src/pages/agreements/review/suite.test.js
bun run test --watch=false src/components/Agreements/AgreementEditor/
```
Expect all to pass, including the new "passes if team_members is empty" test.

**Lint/format:**
```bash
cd frontend && bun run format && bun run lint
```

**Cypress E2E** (Docker stack running):
```bash
cd frontend && bun run test:e2e
```
Confirm `createAgreementWithValidations.cy.js` passes — specifically "enables review status transitions with a COR but no team members".

**Manual (Docker stack up):**
1. Open an agreement that has a COR assigned but **no** team members, with at least one Draft budget line.
2. Go to Review / request a Draft → Planned status change; select the Draft budget line(s).
3. Confirm there is no "Team Members … required to submit for approval" error and the **Send to Approval** button is enabled (assuming all other required fields + the COR are present).

## A11y impact

- [ ] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — this change removes a validation requirement; no visual changes.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [x] Form validations updated


## Links

N/A