### PR TITLE
Reference backend skills in ops_api CLAUDE.md

### DIFF
--- a/backend/ops_api/CLAUDE.md
+++ b/backend/ops_api/CLAUDE.md
@@ -74,6 +74,10 @@ class AgreementItemAPI(BaseItemAPI):
 
 Scopes are defined in `ops/auth/authorization_providers.py`.
 
+### API Documentation (OpenAPI)
+
+`backend/openapi.yml` documents the API and must stay in sync with the Flask routes in `ops/urls.py`. **After adding, changing, or removing any endpoint (route, resource method, or request/response schema), run the `/sync-openapi` skill** to update the spec — it is NOT auto-invoked (model invocation is disabled), so it must be run explicitly. Validate with `./backend/validate_openapi.sh`.
+
 ### MessageBus (Domain Events)
 
 The app uses a synchronous MessageBus for domain event side effects (history records, notifications, etc.). It is **not** async — subscribers run within the same request transaction.
@@ -156,6 +160,7 @@ agreement.fee_percentage = 0.05
 - `ops/resources/base_views.py`: Base classes for API resources
 - `ops/auth/decorators.py`: Authorization decorators
 - `ops/auth/authorization_providers.py`: Permission definitions
+- `openapi.yml` (in `backend/`): OpenAPI spec — keep in sync via the `/sync-openapi` skill
 - `models/base.py`: Base model with audit fields and event listeners
 - `models/__init__.py`: Database initialization and model imports
 - `tests/conftest.py`: Pytest fixtures and test configuration

--- a/backend/ops_api/CLAUDE.md
+++ b/backend/ops_api/CLAUDE.md
@@ -20,6 +20,8 @@ Coverage is not enabled by default so that running individual tests stays fast. 
 
 Test files mirror source structure: `ops/resources/agreements.py` → `tests/ops/resources/test_agreements.py`.
 
+For the full CI check suite across both packages (ops_api + data_tools, including lint, format, and Docker pre-flight for data_tools), use the `/backend-tests` skill — it is NOT auto-invoked, so invoke it explicitly (e.g., `/backend-tests all`).
+
 ### Code Quality
 
 ```bash
@@ -39,7 +41,7 @@ alembic upgrade head
 alembic downgrade -1   # Rollback
 ```
 
-Migration files are in `backend/alembic/versions/`. Always review auto-generated migrations before applying.
+Migration files are in `backend/alembic/versions/`. Always review auto-generated migrations before applying. Use the `/db-migrations` skill for the full workflow — it includes Docker pre-flight checks, a review checklist (renamed columns, enum value changes, NOT NULL two-step migrations), and a critical reminder that new models inheriting `BaseModel` also need a `*_history` table. The skill is NOT auto-invoked.
 
 ## Architecture
 


### PR DESCRIPTION
## What changed

Documentation-only changes to `backend/ops_api/CLAUDE.md` so future Claude sessions know about the three backend skills in this repo — all of which have `disable-model-invocation: true` and must be invoked explicitly.

**`backend/ops_api/CLAUDE.md`**
- Adds an **API Documentation (OpenAPI)** subsection under Architecture pointing to the `/sync-openapi` skill. After adding, changing, or removing any endpoint, `/sync-openapi` should be run to update `backend/openapi.yml` and validated with `./backend/validate_openapi.sh`.
- Appends a reference to `/backend-tests` at the end of the Tests section. The skill covers both `ops_api` and `data_tools` packages, includes Docker pre-flight for data_tools, and has an `all`/`ci` mode that mirrors the full CI check suite.
- Augments the Database Migrations section with a reference to `/db-migrations`. The skill adds Docker pre-flight checks, a review checklist (renamed columns → `op.alter_column()`, enum value changes, NOT NULL two-step migrations), and a reminder that new models inheriting `BaseModel` also need a `*_history` table.
- Adds `openapi.yml` to the **Important Files** list.

None of these skills were previously referenced by any CLAUDE.md. Because model invocation is disabled on all three, a future session only uses them if CLAUDE.md points the way.

## Issue

N/A — self-directed documentation improvement, no associated ticket.

## How to test

- Review the rendered markdown in `backend/ops_api/CLAUDE.md`.
- Confirm all three references are present:
  ```bash
  grep -i 'sync-openapi\|backend-tests\|db-migrations\|openapi' backend/ops_api/CLAUDE.md
  ```
- No application code or tests are affected.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — documentation-only change.

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

- `.claude/skills/sync-openapi/SKILL.md`
- `.claude/skills/backend-tests/SKILL.md`
- `.claude/skills/db-migrations/SKILL.md`