### PR TITLE
Preserve related records during AA conversion & BLI delete history

### DIFF
--- a/backend/data_tools/src/load_aas/utils.py
+++ b/backend/data_tools/src/load_aas/utils.py
@@ -230,9 +230,6 @@ def create_models(data: AAData, sys_user: User, session: Session) -> None:
 
         session.merge(aa)
         session.flush()
-        # Set Dry Run true so that we don't commit at the end of the function
-        # This allows us to rollback the session if dry_run is enabled or not commit changes
-        # if something errors after this point
         agreement_history_trigger_func(ops_event, session, sys_user, dry_run=False)
         session.commit()
 

--- a/backend/data_tools/src/load_aas/utils.py
+++ b/backend/data_tools/src/load_aas/utils.py
@@ -259,11 +259,69 @@ def create_models(data: AAData, sys_user: User, session: Session) -> None:
 
                     session.add(new_budget_line_item)
 
+            # Repoint COR/FPO, alternate, nick_name, SRT, procurement shop, agreement reason, and PSC ID from the existin agreement
+            aa.project_officer_id = existing_agreement.project_officer_id
+            aa.alternate_project_officer_id = existing_agreement.alternate_project_officer_id
+            aa.awarding_entity_id = existing_agreement.awarding_entity_id
+            aa.product_service_code_id = existing_agreement.product_service_code_id
+            aa.nick_name = existing_agreement.nick_name
+            aa.service_requirement_type = existing_agreement.service_requirement_type
+            aa.agreement_reason = existing_agreement.agreement_reason
+
             # Repoint CLINs to the new AA so they survive the agreement delete
             # (clin.agreement_id has ondelete=CASCADE, so otherwise they'd be deleted).
             clins = session.execute(select(CLIN).where(CLIN.agreement_id == existing_agreement.id)).scalars().all()
             for clin in clins:
                 clin.agreement_id = aa.id
+            session.commit()
+
+            # Repoint procurement actions/trackers to the new AA so they survive the delete
+            # (both have agreement_id under cascade="all, delete"; deleting the old agreement
+            # would cascade-delete them and violate procurement_tracker -> procurement_action FK).
+            proc_actions = (
+                session.execute(
+                    select(ProcurementAction).where(ProcurementAction.agreement_id == existing_agreement.id)
+                )
+                .scalars()
+                .all()
+            )
+            for proc_action in proc_actions:
+                proc_action.agreement_id = aa.id
+            proc_trackers = (
+                session.execute(
+                    select(ProcurementTracker).where(ProcurementTracker.agreement_id == existing_agreement.id)
+                )
+                .scalars()
+                .all()
+            )
+            for proc_tracker in proc_trackers:
+                proc_tracker.agreement_id = aa.id
+            session.commit()
+
+            # Repoint agreement history to the new AA so it stays associated after the delete
+            # (agreement_id has ondelete=SET NULL; agreement_id_record is a durable audit int).
+            history_records = (
+                session.execute(
+                    select(AgreementHistory).where(AgreementHistory.agreement_id_record == existing_agreement.id)
+                )
+                .scalars()
+                .all()
+            )
+            for history_record in history_records:
+                history_record.agreement_id = aa.id
+                history_record.agreement_id_record = aa.id
+
+            # Repoint team-member associations to the new AA so the links survive the delete
+            # (agreement_team_members rows are otherwise removed with the old agreement).
+            team_member_rows = (
+                session.execute(
+                    select(AgreementTeamMembers).where(AgreementTeamMembers.agreement_id == existing_agreement.id)
+                )
+                .scalars()
+                .all()
+            )
+            for team_member_row in team_member_rows:
+                team_member_row.agreement_id = aa.id
             session.commit()
 
             logger.info(f"Removing existing agreement {existing_agreement.name} with ID {existing_agreement.id}")

--- a/backend/data_tools/src/load_aas/utils.py
+++ b/backend/data_tools/src/load_aas/utils.py
@@ -191,6 +191,11 @@ def create_models(data: AAData, sys_user: User, session: Session) -> None:
             aa.id = existing_aa.id
             aa.created_on = existing_aa.created_on
             aa.created_by = existing_aa.created_by
+            # Preserve fields the CSV does not carry so the upsert does not null them out
+            aa.awarding_entity_id = existing_aa.awarding_entity_id
+            aa.product_service_code_id = existing_aa.product_service_code_id
+            aa.project_officer_id = existing_aa.project_officer_id
+            aa.alternate_project_officer_id = existing_aa.alternate_project_officer_id
 
             updates = generate_agreement_events_update(
                 existing_aa.to_dict(),
@@ -228,7 +233,7 @@ def create_models(data: AAData, sys_user: User, session: Session) -> None:
         # Set Dry Run true so that we don't commit at the end of the function
         # This allows us to rollback the session if dry_run is enabled or not commit changes
         # if something errors after this point
-        agreement_history_trigger_func(ops_event, session, sys_user, dry_run=True)
+        agreement_history_trigger_func(ops_event, session, sys_user, dry_run=False)
         session.commit()
 
         # Refresh aa to ensure we have the ID (important!)
@@ -253,6 +258,13 @@ def create_models(data: AAData, sys_user: User, session: Session) -> None:
                     session.commit()
 
                     session.add(new_budget_line_item)
+
+            # Repoint CLINs to the new AA so they survive the agreement delete
+            # (clin.agreement_id has ondelete=CASCADE, so otherwise they'd be deleted).
+            clins = session.execute(select(CLIN).where(CLIN.agreement_id == existing_agreement.id)).scalars().all()
+            for clin in clins:
+                clin.agreement_id = aa.id
+            session.commit()
 
             logger.info(f"Removing existing agreement {existing_agreement.name} with ID {existing_agreement.id}")
             session.delete(existing_agreement)

--- a/backend/data_tools/src/load_master_spreadsheet_budget_lines_v2/utils.py
+++ b/backend/data_tools/src/load_master_spreadsheet_budget_lines_v2/utils.py
@@ -1,3 +1,4 @@
+import os
 from csv import DictReader
 from dataclasses import dataclass, field
 from datetime import date, datetime
@@ -34,6 +35,7 @@ from models import (
     ProcurementShop,
     ProcurementShopFee,
     User,
+    agreement_history_trigger_func,
 )
 from models.procurement_workflow import (
     get_or_create_procurement_records_for_modification,
@@ -41,6 +43,7 @@ from models.procurement_workflow import (
     has_obligated_blis,
     link_blis_to_action,
 )
+from models.utils import generate_events_update
 
 
 def _strip_or_none(val):
@@ -229,6 +232,7 @@ def create_models(data: BudgetLineItemData, sys_user: User, session: Session) ->
             logger.info(f"CREATED {bli_class.__name__} model for {bli.to_dict()}")
 
         else:
+            existing_bli_dict = existing_budget_line_item.to_dict()  # capture before mutating for diff
             bli = existing_budget_line_item
             bli.line_description = data.LINE_DESC
             bli.comments = data.COMMENTS
@@ -278,15 +282,30 @@ def create_models(data: BudgetLineItemData, sys_user: User, session: Session) ->
             link_blis_to_action(session, agreement, action, BudgetLineItemStatus.IN_EXECUTION)
             commit_or_rollback(session)
 
-        # Create an OPSEvent record for the new BLI
-        ops_event = OpsEvent(
-            event_type=OpsEventType.CREATE_BLI if not existing_budget_line_item else OpsEventType.UPDATE_BLI,
-            event_status=OpsEventStatus.SUCCESS,
-            created_by=sys_user.id,
-            event_details={"new_bli": bli.to_dict()},
-        )
+        # Create an OPSEvent record for the BLI create/update with the correct payload shape for each case.
+        if not existing_budget_line_item:
+            ops_event = OpsEvent(
+                event_type=OpsEventType.CREATE_BLI,
+                event_status=OpsEventStatus.SUCCESS,
+                created_by=sys_user.id,
+                event_details={"new_bli": bli.to_dict()},
+            )
+        else:
+            updates = generate_events_update(existing_bli_dict, bli.to_dict(), bli.id, sys_user.id)
+            ops_event = OpsEvent(
+                event_type=OpsEventType.UPDATE_BLI,
+                event_status=OpsEventStatus.SUCCESS,
+                created_by=sys_user.id,
+                event_details={"bli_updates": updates, "bli": bli.to_dict()},
+            )
         session.add(ops_event)
-        commit_or_rollback(session)
+        session.flush()  # populate ops_event.id and created_on before the history trigger reads them
+        agreement_history_trigger_func(ops_event, session, sys_user, dry_run=True)
+        if os.getenv("DRY_RUN"):
+            logger.info("Dry run enabled. Rolling back transaction.")
+            session.rollback()
+        else:
+            session.commit()
 
     except Exception as err:
         logger.error(f"Error creating models for {data}: {err}")

--- a/backend/data_tools/src/load_remove_budget_lines/utils.py
+++ b/backend/data_tools/src/load_remove_budget_lines/utils.py
@@ -1,3 +1,4 @@
+import os
 from csv import DictReader
 from dataclasses import dataclass, field
 from typing import List, Optional
@@ -5,7 +6,7 @@ from typing import List, Optional
 from loguru import logger
 from sqlalchemy.orm import Session
 
-from models import BudgetLineItem, OpsEvent, OpsEventStatus, OpsEventType, User
+from models import BudgetLineItem, OpsEvent, OpsEventStatus, OpsEventType, User, agreement_history_trigger_func
 
 
 @dataclass
@@ -101,7 +102,17 @@ def create_models(data: BudgetLineItemData, sys_user: User, session: Session) ->
     )
 
     session.add(ops_event)
-    session.commit()
+    session.flush()  # Populate ops_event.id and created_on before the history trigger reads them
+
+    # Fire the agreement-history trigger so the deletion is recorded in AgreementHistory.
+    # DRY_RUN drives both the trigger's commit and our rollback/commit (single source of truth).
+    dry_run = bool(os.getenv("DRY_RUN"))
+    agreement_history_trigger_func(ops_event, session, sys_user, dry_run=dry_run)
+    if dry_run:
+        logger.info("Dry run enabled. Rolling back transaction.")
+        session.rollback()
+    else:
+        session.commit()
 
 
 def create_all_models(data: List[BudgetLineItemData], sys_user: User, session: Session) -> None:

--- a/backend/data_tools/src/load_remove_budget_lines/utils.py
+++ b/backend/data_tools/src/load_remove_budget_lines/utils.py
@@ -81,6 +81,11 @@ def create_models(data: BudgetLineItemData, sys_user: User, session: Session) ->
         raise ValueError(f"BudgetLineItem with SYS_BUDGET_ID {data.SYS_BUDGET_ID} not found.")
 
     agreement = budget_line_item.agreement
+    bli_dict = budget_line_item.to_dict()  # capture before delete; object becomes detached after session.delete()
+
+    if os.getenv("DRY_RUN"):
+        logger.info("Dry run enabled. Skipping BLI deletion.")
+        return
 
     session.delete(budget_line_item)
     session.commit()
@@ -98,21 +103,15 @@ def create_models(data: BudgetLineItemData, sys_user: User, session: Session) ->
         event_type=OpsEventType.DELETE_BLI,
         event_status=OpsEventStatus.SUCCESS,
         created_by=sys_user.id,
-        event_details={"deleted_bli": budget_line_item.to_dict()},
+        event_details={"deleted_bli": bli_dict},
     )
 
     session.add(ops_event)
     session.flush()  # Populate ops_event.id and created_on before the history trigger reads them
 
     # Fire the agreement-history trigger so the deletion is recorded in AgreementHistory.
-    # DRY_RUN drives both the trigger's commit and our rollback/commit (single source of truth).
-    dry_run = bool(os.getenv("DRY_RUN"))
-    agreement_history_trigger_func(ops_event, session, sys_user, dry_run=dry_run)
-    if dry_run:
-        logger.info("Dry run enabled. Rolling back transaction.")
-        session.rollback()
-    else:
-        session.commit()
+    agreement_history_trigger_func(ops_event, session, sys_user, dry_run=False)
+    session.commit()
 
 
 def create_all_models(data: List[BudgetLineItemData], sys_user: User, session: Session) -> None:

--- a/backend/data_tools/tests/load_aas/test_load_aas.py
+++ b/backend/data_tools/tests/load_aas/test_load_aas.py
@@ -250,9 +250,11 @@ def test_create_models_preserves_existing_fields(db_for_aas):
         SERVICE_REQUIREMENT_TYPE=ServiceRequirementType.SEVERABLE.name,
     )
 
-    # A procurement shop to reference (the test DB does not seed these).
+    # A procurement shop and PSC to reference (the test DB does not seed these).
     proc_shop = ProcurementShop(name="Test Shop", abbr="TS")
     db_for_aas.add(proc_shop)
+    psc = ProductServiceCode(name="Test PSC")
+    db_for_aas.add(psc)
     db_for_aas.commit()
 
     # Initial import creates the AA. These fields are not present in the AA CSV.
@@ -262,6 +264,8 @@ def test_create_models_preserves_existing_fields(db_for_aas):
     # Simulate the fields being populated later (e.g. via the app/UI).
     aa_model.awarding_entity_id = proc_shop.id
     aa_model.project_officer_id = sys_user.id
+    aa_model.alternate_project_officer_id = sys_user.id
+    aa_model.product_service_code_id = psc.id
     db_for_aas.commit()
 
     # Re-import the same AA row.
@@ -270,11 +274,14 @@ def test_create_models_preserves_existing_fields(db_for_aas):
     aa_model = db_for_aas.execute(select(AaAgreement).where(AaAgreement.name == "Family Support Research")).scalar()
     assert aa_model.awarding_entity_id == proc_shop.id
     assert aa_model.project_officer_id == sys_user.id
+    assert aa_model.alternate_project_officer_id == sys_user.id
+    assert aa_model.product_service_code_id == psc.id
 
-    # cleanup created data (delete the agreement before the shop it references)
+    # cleanup created data (delete the agreement before the shop/PSC it references)
     db_for_aas.delete(aa_model)
     db_for_aas.commit()
     db_for_aas.execute(text("DELETE FROM procurement_shop"))
+    db_for_aas.execute(text("DELETE FROM product_service_code WHERE name = 'Test PSC'"))
     db_for_aas.commit()
 
 

--- a/backend/data_tools/tests/load_aas/test_load_aas.py
+++ b/backend/data_tools/tests/load_aas/test_load_aas.py
@@ -236,6 +236,48 @@ def test_create_models_upsert(db_for_aas):
     db_for_aas.commit()
 
 
+def test_create_models_preserves_existing_fields(db_for_aas):
+    """Re-importing an existing AA must not null out fields the CSV does not carry."""
+    from data_tools.src.load_aas.utils import AAData, create_models
+
+    sys_user = get_or_create_sys_user(db_for_aas)
+
+    data = AAData(
+        PROJECT_NAME="Test Project",
+        AA_NAME="Family Support Research",
+        REQUESTING_AGENCY_NAME="HHS",
+        SERVICING_AGENCY_NAME="NSF",
+        SERVICE_REQUIREMENT_TYPE=ServiceRequirementType.SEVERABLE.name,
+    )
+
+    # A procurement shop to reference (the test DB does not seed these).
+    proc_shop = ProcurementShop(name="Test Shop", abbr="TS")
+    db_for_aas.add(proc_shop)
+    db_for_aas.commit()
+
+    # Initial import creates the AA. These fields are not present in the AA CSV.
+    create_models(data, sys_user, db_for_aas)
+    aa_model = db_for_aas.execute(select(AaAgreement).where(AaAgreement.name == "Family Support Research")).scalar()
+
+    # Simulate the fields being populated later (e.g. via the app/UI).
+    aa_model.awarding_entity_id = proc_shop.id
+    aa_model.project_officer_id = sys_user.id
+    db_for_aas.commit()
+
+    # Re-import the same AA row.
+    create_models(data, sys_user, db_for_aas)
+
+    aa_model = db_for_aas.execute(select(AaAgreement).where(AaAgreement.name == "Family Support Research")).scalar()
+    assert aa_model.awarding_entity_id == proc_shop.id
+    assert aa_model.project_officer_id == sys_user.id
+
+    # cleanup created data (delete the agreement before the shop it references)
+    db_for_aas.delete(aa_model)
+    db_for_aas.commit()
+    db_for_aas.execute(text("DELETE FROM procurement_shop"))
+    db_for_aas.commit()
+
+
 def test_transform_with_csv(db_for_aas, tmp_path):
     """Test transform function with CSV data"""
     from csv import DictReader

--- a/backend/data_tools/tests/load_aas/test_load_aas.py
+++ b/backend/data_tools/tests/load_aas/test_load_aas.py
@@ -371,10 +371,12 @@ def test_existing_agreement_handling(db_for_aas):
 
     sys_user = get_or_create_sys_user(db_for_aas)
 
-    # Create an existing agreement
+    # Create an existing agreement. Its service_requirement_type is intentionally
+    # different from the CSV value below so we can assert it is copied to the new AA.
     existing_agreement = ContractAgreement(
         name="Existing Contract",
         agreement_type=AgreementType.CONTRACT,
+        service_requirement_type=ServiceRequirementType.NON_SEVERABLE,
         created_by=sys_user.id,
         updated_by=sys_user.id,
         created_on=datetime.now(),
@@ -436,7 +438,8 @@ def test_existing_agreement_handling(db_for_aas):
     assert new_agreement.project.title == "Test Project"
     assert new_agreement.requesting_agency.name == "HHS"
     assert new_agreement.servicing_agency.name == "NSF"
-    assert new_agreement.service_requirement_type == ServiceRequirementType.SEVERABLE
+    # service_requirement_type is copied from the existing agreement, not the CSV
+    assert new_agreement.service_requirement_type == ServiceRequirementType.NON_SEVERABLE
     assert new_agreement.created_by == sys_user.id
     assert new_agreement.updated_by == sys_user.id
 

--- a/backend/data_tools/tests/load_master_spreadsheet_budget_lines_v2/test_load_master_spreadsheet_budget_lines_items_v2.py
+++ b/backend/data_tools/tests/load_master_spreadsheet_budget_lines_v2/test_load_master_spreadsheet_budget_lines_items_v2.py
@@ -21,6 +21,8 @@ from models import (
     AABudgetLineItem,
     Agreement,
     AgreementAgency,
+    AgreementHistory,
+    AgreementHistoryType,
     AgreementType,
     BudgetLineItem,
     BudgetLineItemStatus,
@@ -221,6 +223,7 @@ def clean_up_db(session):
     session.execute(text("DELETE FROM role"))
     session.execute(text("DELETE FROM role_version"))
 
+    session.execute(text("DELETE FROM agreement_history"))
     session.execute(text("DELETE FROM ops_event"))
     session.execute(text("DELETE FROM ops_event_version"))
 
@@ -324,6 +327,13 @@ def test_create_model(db_with_data_v2):
     assert history_records[0].event_type == OpsDBHistoryType.NEW
     assert history_records[0].row_key == str(bli_model.id)
 
+    # Check AgreementHistory record was created by the trigger
+    agreement_history = db_with_data_v2.execute(
+        select(AgreementHistory).where(AgreementHistory.budget_line_id_record == bli_model.id)
+    ).scalar_one_or_none()
+    assert agreement_history is not None
+    assert agreement_history.history_type == AgreementHistoryType.BUDGET_LINE_ITEM_CREATED
+
     # Cleanup
     db_with_data_v2.delete(bli_model)
     db_with_data_v2.commit()
@@ -403,6 +413,18 @@ def test_create_models_upsert(db_with_data_v2):
     assert bli.versions[0].status == BudgetLineItemStatus.IN_EXECUTION
     assert bli.versions[0].date_needed == date(2025, 2, 17)
     assert bli.versions[0].proc_shop_fee_percentage == Decimal("0.01500")
+
+    # Check AgreementHistory record was created by the trigger
+    agreement_history_rows = (
+        db_with_data_v2.execute(
+            select(AgreementHistory)
+            .where(AgreementHistory.budget_line_id_record == bli.id)
+            .where(AgreementHistory.history_type == AgreementHistoryType.BUDGET_LINE_ITEM_UPDATED)
+        )
+        .scalars()
+        .all()
+    )
+    assert len(agreement_history_rows) > 0
 
     # Cleanup
     db_with_data_v2.delete(bli)

--- a/backend/data_tools/tests/load_remove_budget_lines/test_load_remove_budget_lines.py
+++ b/backend/data_tools/tests/load_remove_budget_lines/test_load_remove_budget_lines.py
@@ -15,6 +15,8 @@ from data_tools.src.load_remove_budget_lines.utils import (
 )
 from models import (
     CAN,
+    AgreementHistory,
+    AgreementHistoryType,
     AgreementType,
     BudgetLineItem,
     BudgetLineItemStatus,
@@ -221,6 +223,7 @@ def db_with_data(loaded_db):
 
     yield loaded_db
 
+    loaded_db.execute(text("DELETE FROM agreement_history"))
     loaded_db.execute(text("DELETE FROM ops_event"))
     loaded_db.execute(text("DELETE FROM ops_db_history"))
 
@@ -274,6 +277,17 @@ def test_create_model_delete(db_with_data):
     assert ops_event.created_by == 1
     assert "deleted_bli" in ops_event.event_details
     assert ops_event.event_details["deleted_bli"]["id"] == bli_id
+
+    # An AgreementHistory record should have been created by the trigger
+    agreement_id = ops_event.event_details["deleted_bli"]["agreement_id"]
+    history = db_with_data.execute(
+        select(AgreementHistory).where(AgreementHistory.budget_line_id_record == bli_id)
+    ).scalar_one_or_none()
+
+    assert history is not None
+    assert history.history_type == AgreementHistoryType.BUDGET_LINE_ITEM_DELETED
+    assert history.agreement_id_record == agreement_id
+    assert history.ops_event_id == ops_event.id
 
 
 def test_create_model_delete_nonexistent_bli(db_with_data):

--- a/backend/models/agreement_history.py
+++ b/backend/models/agreement_history.py
@@ -406,14 +406,24 @@ def create_change_request_history_event(
             if old_proc_shop:
                 old_proc_shop_abbr = old_proc_shop.abbr
                 old_proc_shop_fee_total = (
-                    sum([(item.amount * (old_proc_shop.fee_percentage / 100)) for item in agreement.budget_line_items])
+                    sum(
+                        [
+                            (item.amount or 0) * (old_proc_shop.fee_percentage / 100)
+                            for item in agreement.budget_line_items
+                        ]
+                    )
                     if agreement
                     else 0
                 )
             if new_proc_shop:
                 new_proc_shop_abbr = new_proc_shop.abbr
                 new_proc_shop_fee_total = (
-                    sum([(item.amount * (new_proc_shop.fee_percentage / 100)) for item in agreement.budget_line_items])
+                    sum(
+                        [
+                            (item.amount or 0) * (new_proc_shop.fee_percentage / 100)
+                            for item in agreement.budget_line_items
+                        ]
+                    )
                     if agreement
                     else 0
                 )
@@ -671,7 +681,7 @@ def create_agreement_update_history_event(
                     old_proc_shop_fee_total = (
                         sum(
                             [
-                                (item.amount * (old_proc_shop.fee_percentage / 100))
+                                (item.amount or 0) * (old_proc_shop.fee_percentage / 100)
                                 for item in agreement.budget_line_items
                             ]
                         )
@@ -684,7 +694,7 @@ def create_agreement_update_history_event(
                     new_proc_shop_fee_total = (
                         sum(
                             [
-                                (item.amount * (new_proc_shop.fee_percentage / 100))
+                                (item.amount or 0) * (new_proc_shop.fee_percentage / 100)
                                 for item in agreement.budget_line_items
                             ]
                         )

--- a/backend/models/agreement_history.py
+++ b/backend/models/agreement_history.py
@@ -132,9 +132,9 @@ def agreement_history_trigger_func(event: OpsEvent, session: Session, system_use
                     ops_event_id=event.id,
                     history_title="Budget Line Deleted",
                     history_message=(
-                        f"Changes made to the OPRE budget spreadsheet deleted the Draft BL {event.event_details['deleted_bli']['id']}."
+                        f"Changes made to the OPRE budget spreadsheet deleted the BL {event.event_details['deleted_bli']['id']}."
                         if updated_by_system_user
-                        else f"{event_user.full_name} deleted the Draft BL {event.event_details['deleted_bli']['id']}."
+                        else f"{event_user.full_name} deleted the BL {event.event_details['deleted_bli']['id']}."
                     ),
                     timestamp=event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     history_type=AgreementHistoryType.BUDGET_LINE_ITEM_DELETED,

--- a/backend/ops_api/tests/ops/agreement/test_agreement_history.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement_history.py
@@ -666,7 +666,7 @@ def test_agreement_history_bli_deletion(loaded_db, app_ctx):
 
     assert new_agreement_history_item.history_type == AgreementHistoryType.BUDGET_LINE_ITEM_DELETED
     assert new_agreement_history_item.history_title == "Budget Line Deleted"
-    assert new_agreement_history_item.history_message == "Steve Tekell deleted the Draft BL 16044."
+    assert new_agreement_history_item.history_message == "Steve Tekell deleted the BL 16044."
 
 
 def test_agreement_history_draft_bli_change(loaded_db, app_ctx):

--- a/backend/ops_api/tests/ops/agreement/test_agreement_history.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement_history.py
@@ -10,8 +10,9 @@ from models import (
     OpsEventStatus,
     OpsEventType,
 )
-from models.agreement_history import add_history_events, get_project_display_name
+from models.agreement_history import add_history_events, create_agreement_update_history_event, get_project_display_name
 from ops_api.ops.services.agreement_messages import agreement_history_trigger
+from ops_api.ops.utils.users import get_sys_user
 
 test_user_id = 503
 test_user_name = "Amelia Popham"
@@ -471,6 +472,49 @@ def test_proc_shop_fee_changes(loaded_db, app_ctx):
     assert (
         proc_shop_change_request.history_message == "Steve Tekell changed the current fee rate for GCS from 0% to 6.0%."
     )
+
+
+def test_proc_shop_change_with_none_amount_budget_line(loaded_db, app_ctx):
+    """A procurement shop change must not crash when a budget line has a None amount."""
+    from models import ContractAgreement, ContractBudgetLineItem
+    from models.agreements import AgreementType
+    from models.budget_line_items import BudgetLineItemStatus
+
+    sys_user = get_sys_user(loaded_db)
+
+    agreement = ContractAgreement(
+        name="None Amount Fee Regression",
+        agreement_type=AgreementType.CONTRACT,
+        awarding_entity_id=3,  # NIH (seeded)
+    )
+    loaded_db.add(agreement)
+    loaded_db.flush()
+
+    bli = ContractBudgetLineItem(
+        agreement_id=agreement.id,
+        amount=None,  # the exact condition that previously raised TypeError
+        status=BudgetLineItemStatus.DRAFT,
+    )
+    loaded_db.add(bli)
+    loaded_db.flush()
+
+    # Fire the awarding_entity_id branch directly (proc shop 3 -> None).
+    history_item = create_agreement_update_history_event(
+        "awarding_entity_id",
+        3,
+        None,
+        sys_user,
+        timestamp,
+        agreement.id,
+        None,
+        loaded_db,
+        sys_user,
+    )
+
+    assert history_item is not None
+    assert history_item.history_title == "Change to Procurement Shop"
+    # None amount is treated as 0, so the fee total is $0.00 rather than crashing.
+    assert "fee total from $0.00 to $0.00" in history_item.history_message
 
 
 def test_agreement_history_create_bli(loaded_db, app_ctx):

--- a/frontend/cypress/e2e/procurementShopChangeRequest.cy.js
+++ b/frontend/cypress/e2e/procurementShopChangeRequest.cy.js
@@ -207,7 +207,7 @@ describe("Procurement Shop Change Request", () => {
                 ).should("have.text", "Budget Line Deleted");
                 cy.get('[data-cy="agreement-history-list"] > :nth-child(1) > [data-cy="log-item-message"]').should(
                     "have.text",
-                    `System Owner deleted the Draft BL ${bliId}.`
+                    `System Owner deleted the BL ${bliId}.`
                 );
                 cy.get(
                     '[data-cy="agreement-history-list"] > :nth-child(2) > .flex-justify > [data-cy="log-item-title"]'


### PR DESCRIPTION
## What changed

This PR supports client-requested data updates (converting existing Contract/IAA agreements into AA agreements, and removing budget lines) tracked in issue #5879. While running the `aas` and `remove_budget_lines` data-import scripts against real data, several bugs and data-loss issues surfaced. This PR fixes them and these changes were already used for the live data modifications.

Background: the `aas` importer converts an existing agreement into a new `AaAgreement` by repointing the old agreement's budget lines onto the new AA and then **deleting** the old agreement. Any table that still references the old agreement's id was either being cascade-deleted or left orphaned. This PR repoints all of those references to the new AA *before* the delete. It also fills a gap where the budget-line removal script never recorded agreement history.

**`backend/data_tools/src/load_aas/utils.py`** (agreement conversion)
- On re-import of an existing AA, preserve fields the CSV does not carry (`awarding_entity_id`, `product_service_code_id`, `project_officer_id`, `alternate_project_officer_id`) so the upsert no longer nulls them out.
- Before deleting the converted agreement, repoint its related records to the new AA so they survive and stay associated:
  - **CLINs** (`clin.agreement_id`) — otherwise cascade-deleted (`ondelete=CASCADE`), which also left repointed budget lines with dangling `clin_id`s.
  - **Procurement actions & trackers** (`agreement_id`) — the cascade delete previously violated the `procurement_tracker → procurement_action` FK and crashed the import.
  - **Agreement history** (`agreement_id` + `agreement_id_record`) — kept associated with the new AA instead of nulled/orphaned.
  - **Team members** (`agreement_team_members.agreement_id`) — otherwise removed with the old agreement.

**`backend/models/agreement_history.py`** (shared history logic — used by the live API too)
- Null-guard the procurement-shop fee-total computation (`(item.amount or 0)`) in both the agreement-update and change-request paths. A budget line with a `NULL` amount previously raised `TypeError: unsupported operand type(s) for *: 'NoneType' and 'decimal.Decimal'`.
- Remove the hardcoded word "Draft" from the BLI-deletion history message. The message assumed every deleted budget line was in DRAFT status, but any status can be deleted (and the code has no access to status here). Now reads `deleted the BL {id}`.

**`backend/data_tools/src/load_remove_budget_lines/utils.py`** (budget-line removal)
- After creating the `DELETE_BLI` OpsEvent, fire `agreement_history_trigger_func` so deletions produce a user-facing `AgreementHistory` record — matching newer loaders (`load_aas`, `load_grants`). Flushes first so the event's `id`/`created_on` are populated before the trigger reads them. The `DRY_RUN` env var now drives both the trigger's commit and the rollback/commit (single source of truth).

**Tests** — regression coverage added/updated in the three corresponding test files (field preservation on re-import, `None`-amount fee guard, BLI-delete history record, and the updated "deleted the BL" message assertion). I was pretty selective about adding new tests because some of these scenarios are highly unusual and infrequent. 

## Issue

https://github.com/HHS/OPRE-OPS/issues/5879

## How to test

Automated tests (from the repo root, using the project venv or pipenv):

```bash
# data_tools tests
cd backend/data_tools
pipenv run pytest tests/load_aas/test_load_aas.py
pipenv run pytest tests/load_remove_budget_lines/test_load_remove_budget_lines.py

# shared model / API history tests
cd ../ops_api
pipenv run pytest tests/ops/agreement/test_agreement_history.py
```

Manual / end-to-end (against a seeded DB):

```bash
cd backend
# AA conversion — should complete without a ForeignKeyViolation or TypeError.
# Spot-check that a converted agreement's CLINs, procurement actions/trackers,
# agreement_history rows, and team-member rows now carry the new AA's id.
python data_tools/src/load_data.py --env <env> --type aas --input-csv <aas.tsv>

# Budget-line removal — confirm an AgreementHistory row (BUDGET_LINE_ITEM_DELETED)
# is created per deleted BLI, with a message like "... deleted the BL <id>." (no "Draft").
python data_tools/src/load_data.py --env <env> --type remove_budget_lines --input-csv data_tools/test_csv/budget_line_items_to_delete.tsv
```

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — backend / data-tools changes only.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [x] Form validations updated

## Links

N/A