### PR TITLE
fix: highlight percentage tags on data viz hover (OPS-668)

### DIFF
--- a/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.jsx
+++ b/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.jsx
@@ -28,6 +28,21 @@ import { buildPortfolioChartData } from "./ProjectFundingByPortfolioCard.helpers
  * @param {FundingByPortfolioItem[]} props.fundingByPortfolio
  * @returns {JSX.Element}
  */
+// Portfolio color vars with light fills that need dark text for readability
+// when used as the active percentage-tag background (mirrors the
+// lightBackgroundPortfolios list in PortfolioLegend, keyed by color instead of
+// abbreviation since this card assigns colors sequentially).
+const LIGHT_BACKGROUND_COLORS = new Set([
+    "var(--portfolio-bar-graph-cc)",
+    "var(--portfolio-bar-graph-hs)",
+    "var(--portfolio-bar-graph-hmrf)",
+    "var(--portfolio-bar-graph-hv)",
+    "var(--portfolio-bar-graph-dd)",
+    "var(--portfolio-bar-graph-none-opre)",
+    "var(--portfolio-bar-graph-ocdo)",
+    "var(--portfolio-bar-graph-otip)"
+]);
+
 const ProjectFundingByPortfolioCard = ({ fiscalYear, fundingByPortfolio = [] }) => {
     const [activeId, setActiveId] = useState(0);
 
@@ -57,6 +72,7 @@ const ProjectFundingByPortfolioCard = ({ fiscalYear, fundingByPortfolio = [] }) 
                         >
                             {chartData.map((item) => {
                                 const isActive = activeId === item.id;
+                                const activeTextColor = LIGHT_BACKGROUND_COLORS.has(item.color) ? "#1B1B1B" : "#FFFFFF";
                                 return (
                                     <div
                                         key={item.id}
@@ -80,7 +96,10 @@ const ProjectFundingByPortfolioCard = ({ fiscalYear, fundingByPortfolio = [] }) 
                                             style={{
                                                 padding: "0.25rem 0.5rem",
                                                 borderRadius: "0.25rem",
-                                                fontSize: "12px"
+                                                fontSize: "12px",
+                                                ...(isActive
+                                                    ? { backgroundColor: item.color, color: activeTextColor }
+                                                    : {})
                                             }}
                                         >
                                             {item.percent}%

--- a/frontend/src/pages/projects/detail/ProjectSpending.jsx
+++ b/frontend/src/pages/projects/detail/ProjectSpending.jsx
@@ -130,11 +130,21 @@ const ProjectSpending = () => {
             DIRECT_OBLIGATION: "direct_obligation"
         };
 
+        // Match each agreement type to its active Tag style so the legend
+        // percentage tag is highlighted with the segment color on hover
+        const tagStyleActiveMap = {
+            CONTRACT: "whiteOnContractBlue",
+            PARTNER: "darkOnPartnerGreen",
+            GRANT: "darkOnGrantOrange",
+            DIRECT_OBLIGATION: "whiteOnDirectObligationPink"
+        };
+
         const rawItems = AGREEMENT_TYPE_ORDER.map((config, idx) => ({
             id: idx + 1,
             label: config.label,
             value: Number(typeBreakdown[keyMap[config.type]] ?? 0),
-            color: config.color
+            color: config.color,
+            tagStyleActive: tagStyleActiveMap[config.type]
         }));
 
         return computeDisplayPercents(rawItems);


### PR DESCRIPTION
## What changed

Fixes the missing hover highlight on two project-detail data visualizations so the percentage value gets the same background color as the hovered chart segment — matching the behavior of the "Budget Across Portfolios" viz that serves as the reference standard.

**`frontend/src/pages/projects/detail/ProjectSpending.jsx`**
- The "Project Spending By Agreement Type" donut legend now assigns each agreement type its matching `tagStyleActive` (`whiteOnContractBlue`, `darkOnPartnerGreen`, `darkOnGrantOrange`, `whiteOnDirectObligationPink`). These active styles already exist in the `Tag` component, so on hover the percentage tag is filled with the segment color. Previously the legend text bolded but the percentage tag stayed white because agreement-type labels didn't match `Tag`'s hardcoded label cases and no `tagStyleActive` was passed.

**`frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.jsx`**
- The "FY Project Funding by Portfolio" legend percentage now takes the segment's `backgroundColor` (with legible light/dark text) when active, mirroring `PortfolioLegend`. Previously the percentage span was hardcoded to `bg-white` and only bolded on hover. Since this card assigns palette colors sequentially rather than by abbreviation, the light/dark text decision keys off a `LIGHT_BACKGROUND_COLORS` set derived from the same light-background portfolio list used by `PortfolioLegend`.

## Issue

https://github.com/HHS/OPRE-OPS/issues/668

## How to test

1. Run the frontend unit tests:
   ```bash
   cd frontend
   bun run test --watch=false ProjectFundingByPortfolioCard
   bun run test --watch=false DonutGraphWithLegendCard LegendItem Tag
   ```
2. Start the app (`podman compose up --build`) and open a Project Details page.
3. On the **Project Spending** tab, hover over the "Project Spending By Agreement Type" donut segments — the corresponding legend percentage tag should be highlighted with the segment's color (text remains legible).
4. On the **Project Funding** tab, hover over the "FY Project Funding by Portfolio" bar segments — the corresponding legend percentage should get a rounded rectangle filled with the segment color, matching the Budget Across Portfolios viz on the portfolios list page.

## A11y impact

- [ ] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated