### PR TITLE
fix: reset validation suites on mount/unmount to prevent sticky Obligate By error

### DIFF
--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
@@ -109,6 +109,19 @@ const useCreateBLIsAndSCs = (
     const activeUser = useSelector((state) => state.auth.activeUser);
     const isSuperUser = activeUser?.is_superuser ?? false;
 
+    // Reset validation suites on mount and unmount so stale results from a
+    // previous agreement or user session never paint errors on a fresh form. (issue #5894)
+    React.useEffect(() => {
+        suite.reset();
+        budgetFormSuite.reset();
+        datePickerSuite.reset();
+        return () => {
+            suite.reset();
+            budgetFormSuite.reset();
+            datePickerSuite.reset();
+        };
+    }, []);
+
     React.useEffect(() => {
         if (currentStep != 0) {
             setBlockerDisabledForCreateAgreement(true);

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
@@ -109,12 +109,22 @@ const useCreateBLIsAndSCs = (
     const activeUser = useSelector((state) => state.auth.activeUser);
     const isSuperUser = activeUser?.is_superuser ?? false;
 
+    // Snapshot the page-suite result in state. The suites are module-level singletons
+    // read during render (here and in BudgetLinesForm), so a stale result from a prior
+    // session/agreement can be painted before the reset effect below fires. Storing the
+    // result in state lets the effect call setState after reset(), which schedules a
+    // re-render with clean validation instead of relying on an incidental re-render. (issue #5894)
+    const [pageSuiteResult, setPageSuiteResult] = React.useState(() => suite.get());
+
     // Reset validation suites on mount and unmount so stale results from a
     // previous agreement or user session never paint errors on a fresh form. (issue #5894)
     React.useEffect(() => {
         suite.reset();
         budgetFormSuite.reset();
         datePickerSuite.reset();
+        // Force a re-render with the freshly-cleared state so the render-time reads
+        // (this hook's `res` and BudgetLinesForm's datePickerSuite.get()) repaint clean.
+        setPageSuiteResult(suite.get());
         return () => {
             suite.reset();
             budgetFormSuite.reset();
@@ -155,11 +165,14 @@ const useCreateBLIsAndSCs = (
     }, [tempBudgetLines, servicesComponents]);
 
     // Validation
+    // Review mode re-runs the suite every render against the current budget lines.
+    // Non-review mode reads the state-backed snapshot so a mount-time reset() repaints
+    // clean instead of surfacing a stale singleton result. (issue #5894)
     const res = isReviewMode
         ? suite.run({
               budgetLines: tempBudgetLines
           })
-        : suite.get();
+        : pageSuiteResult;
     const pageErrors = res.getErrors();
     // Filter page errors to only include "Budget line item" errors and consolidate into single message
     const budgetLineErrors = Object.entries(pageErrors).filter((error) => error[0].includes("Budget line item"));

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import useCreateBLIsAndSCs from "./CreateBLIsAndSCs.hooks";
 
@@ -202,6 +202,37 @@ describe("useCreateBLIsAndSCs", () => {
         expect(pageSuite.default.reset).toHaveBeenCalledTimes(2);
         expect(budgetSuite.default.reset).toHaveBeenCalledTimes(2);
         expect(dateSuite.default.reset).toHaveBeenCalledTimes(2);
+    });
+
+    it("clears a stale page-suite result left by a prior session on mount (issue #5894)", async () => {
+        const pageSuite = (await import("./suite")).default;
+
+        // Model the module-level singleton as actually stateful: a prior session left it
+        // "dirty", so get() surfaces Budget line item errors until reset() is called.
+        // This makes the assertion depend on the reset + state repaint working, not merely
+        // on reset() having been invoked (the previous test's weakness).
+        let dirty = true;
+        const staleResult = {
+            getErrors: () => ({ "Budget line item (stale-1)": ["This is required information"] }),
+            hasErrors: () => true,
+            isValid: () => false
+        };
+        const cleanResult = {
+            getErrors: () => ({}),
+            hasErrors: () => false,
+            isValid: () => true
+        };
+        pageSuite.get.mockImplementation(() => (dirty ? staleResult : cleanResult));
+        pageSuite.reset.mockImplementation(() => {
+            dirty = false;
+        });
+
+        const { result } = renderSubject();
+
+        // After the mount effect resets the suite and repaints from clean state,
+        // the stale page errors must be gone without any user interaction.
+        await waitFor(() => expect(result.current.budgetLinePageErrorsExist).toBe(false));
+        expect(result.current.pageErrors).toEqual([]);
     });
 
     it("adds a budget line and raises success toast", () => {

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
@@ -182,6 +182,28 @@ describe("useCreateBLIsAndSCs", () => {
         expect(result.current.isAgreementNotYetDeveloped).toBe(true);
     });
 
+    it("resets validation suites on mount and unmount so stale errors do not leak (issue #5894)", async () => {
+        const [pageSuite, budgetSuite, dateSuite] = await Promise.all([
+            import("./suite"),
+            import("../BudgetLinesForm/suite"),
+            import("../BudgetLinesForm/datePickerSuite")
+        ]);
+
+        const { unmount } = renderSubject();
+
+        // reset runs on mount to clear any result left by a prior mount/session
+        expect(pageSuite.default.reset).toHaveBeenCalledTimes(1);
+        expect(budgetSuite.default.reset).toHaveBeenCalledTimes(1);
+        expect(dateSuite.default.reset).toHaveBeenCalledTimes(1);
+
+        unmount();
+
+        // and again on unmount, leaving suites clean for the next consumer
+        expect(pageSuite.default.reset).toHaveBeenCalledTimes(2);
+        expect(budgetSuite.default.reset).toHaveBeenCalledTimes(2);
+        expect(dateSuite.default.reset).toHaveBeenCalledTimes(2);
+    });
+
     it("adds a budget line and raises success toast", () => {
         const { result } = renderSubject();
 


### PR DESCRIPTION
## What changed

Fixes a bug where the **Obligate By** date validation error would "stick" across budget-line forms — appearing by default for a different user or on a different agreement without any interaction.

**Root cause:** The budget-line form uses three Vest validation suites (`datePickerSuite`, `budgetFormSuite`, and the page-level `suite`) declared as **module-level singletons**. Vest retains a suite's last result until `.reset()` is called. Because OPS is a SPA, logging out and back in as a different user never reloads the JS modules, so a failing "Obligate By" result from one user survived into the next session and was painted onto the DatePicker on mount (`BudgetLinesForm.jsx` reads `datePickerSuite.get()` during render).

**Fix** — `CreateBLIsAndSCs.hooks.js` (the sole mount point for `BudgetLinesForm`, covering the create/edit/review-edit/details flows):

- Added a mount + unmount `useEffect` that resets all three suites, so a freshly mounted form always starts with clean validation state. Follows the existing in-repo idiom at `AgreementEditForm.hooks.js`.

- **CreateBLIsAndSCs.hooks.test.js** — added a regression test asserting each suite is reset once on mount and once on unmount.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5894

## How to test

Automated:
```bash
cd frontend
bun run test --watch=false src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
bun run test --watch=false src/components/BudgetLineItems/
```

Manual (mirrors the issue's repro steps):
1. Log in as one user (e.g. a Division Director), edit an agreement, and create/edit a budget line with an **Obligate By** date in the past to trigger the validation error.
2. Log out.
3. Log in as a different user (e.g. a Budget Team user) and navigate to edit an agreement.
4. Confirm the **Obligate By** date picker shows **no** validation error by default, without editing anything.

## A11y impact

- [x] No accessibility-impacting changes in this PR

_Logic-only change; no UI markup or component behavior changes._

## Storybook

- [x] N/A — change is page-specific or non-visual

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated