### PR TITLE
fix: fixed header font sizes in reportingcountcard

### DIFF
--- a/frontend/src/components/Reporting/ReportingCountCard/ReportingCountCard.jsx
+++ b/frontend/src/components/Reporting/ReportingCountCard/ReportingCountCard.jsx
@@ -30,7 +30,7 @@ const AGREEMENT_TYPE_COLORS = {
 
 const CountColumn = ({ title, total, types, labelMap, getTagProps }) => (
     <div className={styles.column}>
-        <h3 className={styles.columnHeader}>{title}</h3>
+        <h3 className="margin-0 margin-bottom-1 font-12px text-base-dark text-normal">{title}</h3>
         <p className={styles.total}>{total}</p>
         <div className={styles.tagList}>
             {types.map(({ type, count }) => (

--- a/frontend/src/components/Reporting/ReportingCountCard/ReportingCountCard.module.scss
+++ b/frontend/src/components/Reporting/ReportingCountCard/ReportingCountCard.module.scss
@@ -10,13 +10,6 @@
     align-items: flex-start;
 }
 
-.columnHeader {
-    font-size: 0.875rem;
-    font-weight: 400;
-    margin: 0 0 0.5rem 0;
-    color: #565c65;
-}
-
 .total {
     font-size: 2rem;
     font-weight: 700;


### PR DESCRIPTION
## What changed

Corrected the font size of the headers in the ReportingCountCard.

## Issue

#4162 [feedback](https://github.com/HHS/OPRE-OPS/issues/4162#issuecomment-4879711940)

## How to test

- Go to a Portfolio Spending page and/or the Reporting Page
- Confirm that header font sizes within the cards match

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [x] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [ ] N/A — change is page-specific or non-visual

## Screenshots

<img width="777" height="355" alt="image" src="https://github.com/user-attachments/assets/53977da1-80ac-4ee3-b563-1cb443cc210e" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [-] Form validations updated
