### PR TITLE
fix(award-approval): rename award info section and scroll CLIN selector into view on selection

### DIFF
--- a/frontend/src/components/BudgetLineItems/CLINSelector/CLINSelector.jsx
+++ b/frontend/src/components/BudgetLineItems/CLINSelector/CLINSelector.jsx
@@ -22,7 +22,7 @@ const CLINSelector = ({ onAddCLIN, budgetLineId, currentClinNumber }) => {
 
     const handleAddCLIN = () => {
         if (selectedCLIN) {
-            onAddCLIN(parseInt(selectedCLIN)); // Pass CLIN number (1-10)
+            onAddCLIN(parseInt(selectedCLIN));
         }
     };
 

--- a/frontend/src/pages/agreements/award-approval/RequestAwardApproval.jsx
+++ b/frontend/src/pages/agreements/award-approval/RequestAwardApproval.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import App from "../../../App";
 import PageHeader from "../../../components/UI/PageHeader";
@@ -57,6 +57,13 @@ export const RequestAwardApproval = () => {
     const { setAlert } = useAlert();
 
     const [selectedBudgetLineId, setSelectedBudgetLineId] = useState(null);
+    const clinSelectorRef = useRef(null);
+
+    useEffect(() => {
+        if (selectedBudgetLineId && clinSelectorRef.current) {
+            clinSelectorRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+        }
+    }, [selectedBudgetLineId]);
 
     const handleAddCLIN = (clinNumber) => {
         if (!selectedBudgetLineId) return;
@@ -218,12 +225,14 @@ export const RequestAwardApproval = () => {
                     </div>
                 )}
                 {selectedBudgetLineId && (
-                    <CLINSelector
-                        key={selectedBudgetLineId}
-                        budgetLineId={selectedBudgetLineId}
-                        onAddCLIN={handleAddCLIN}
-                        currentClinNumber={clinAssignments[selectedBudgetLineId]}
-                    />
+                    <div ref={clinSelectorRef}>
+                        <CLINSelector
+                            key={selectedBudgetLineId}
+                            budgetLineId={selectedBudgetLineId}
+                            onAddCLIN={handleAddCLIN}
+                            currentClinNumber={clinAssignments[selectedBudgetLineId]}
+                        />
+                    </div>
                 )}
                 {groupedBudgetLinesByServicesComponent &&
                     groupedBudgetLinesByServicesComponent.length > 0 &&
@@ -335,9 +344,9 @@ export const RequestAwardApproval = () => {
                 </fieldset>
             </Accordion>
 
-            {/* Award Information */}
+            {/* Current Award Information */}
             <Accordion
-                heading="Award Information"
+                heading="Current Award Information"
                 level={3}
                 isClosed={false}
                 dataCy="award-information-accordion"


### PR DESCRIPTION
## What changed

Two small fixes to the Award Approval page:

- Renamed the \"Award Information\" accordion to \"Current Award Information\"
- When a user clicks the CLIN link on a BLI row, the CLIN selector now scrolls into view (centered) so it's immediately visible without manual scrolling

## Issue

#1640

## How to test

1. Complete procurement tracker up to step 6 and request award approval
2. Verify the accordion heading reads **\"Current Award Information\"**
3. Scroll down to a BLI table, hover a budget line row, and click the **CLIN** link
4. Confirm the CLIN selector scrolls into view centered on screen
5. Select a CLIN and click **Add CLIN**, then click the CLIN link on another row — confirm scroll fires each time

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated