### PR TITLE
fix(procurement-dashboard): display readable status labels in overview card

### DIFF
--- a/frontend/src/pages/procurementDashboard/summary/ProcurementOverviewCard.jsx
+++ b/frontend/src/pages/procurementDashboard/summary/ProcurementOverviewCard.jsx
@@ -3,7 +3,7 @@ import { formatCurrency } from "../../../helpers/currencyFormat.helpers";
 import LegendItem from "../../../components/UI/Cards/LineGraphWithLegendCard/LegendItem";
 import HorizontalStackedBar from "../../../components/UI/DataViz/HorizontalStackedBar/HorizontalStackedBar";
 import RoundedBox from "../../../components/UI/RoundedBox";
-import { computeDisplayPercents } from "../../../helpers/utils";
+import { computeDisplayPercents, convertCodeForDisplay } from "../../../helpers/utils";
 
 const STATUS_COLORS = {
     PLANNED: "var(--data-viz-bl-by-status-2)",
@@ -20,7 +20,7 @@ const buildStatusData = (procurementOverview) => {
 
     const statusItems = status_data.map((item, index) => ({
         id: index + 1,
-        label: item.label,
+        label: convertCodeForDisplay("budgetLineStatus", item.status),
         color: STATUS_COLORS[item.status] || "var(--data-viz-bl-by-status-2)",
         amount: item.amount,
         abbreviation: item.label,
@@ -140,7 +140,7 @@ const ProcurementOverviewCard = ({ procurementOverview, fiscalYear, isLoading, e
                                 <LegendItem
                                     activeId={activeId}
                                     id={item.id}
-                                    label={item.label === "In Execution" ? "Executing" : item.label}
+                                    label={item.label}
                                     value={item.amount}
                                     color={item.color}
                                     percent={item.amountDisplayPercent}


### PR DESCRIPTION
## What changed

Fixes the Procurement Dashboard summary page rendering raw enum strings (e.g. `IN_EXECUTION`) instead of human-readable labels (e.g. `Executing`) in the Procurement Overview card's stacked bar legend.

**`frontend/src/pages/procurementDashboard/summary/ProcurementOverviewCard.jsx`**
- Added `convertCodeForDisplay` to the import from `utils`
- In `buildStatusData`, replaced `item.label` (the raw enum value from the API) with `convertCodeForDisplay("budgetLineStatus", item.status)`, which uses the existing frontend mapping to produce readable display names
- Removed a vestigial `item.label === "In Execution"` ternary in the render that never fired (the label was `"IN_EXECUTION"`, not `"In Execution"`)

The backend's `item.label` field has always been set to `status.value` (the raw enum string) since the function was introduced in commit `ab6573420` — it was never human-readable. The frontend mapping in `convertCodeForDisplay` already has the correct display names and is used consistently everywhere else statuses are shown.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5902

## How to test

1. Start the app (`docker compose up --build`)
2. Navigate to the Procurement Dashboard summary page
3. Verify the stacked bar legend shows `Planned`, `Executing`, and `Obligated` instead of `PLANNED`, `IN_EXECUTION`, and `OBLIGATED`

To run the relevant unit tests:
```bash
cd frontend
bun run test --watch=false
```

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] No UI component changes in this PR

## Screenshots

Fixing the label fixed both problems
<img width="1002" height="477" alt="Screenshot 2026-07-08 at 10 29 43 AM" src="https://github.com/user-attachments/assets/04c20099-95cf-4c1d-9e5c-09c8ef1c408d" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

## Links

N/A