### PR TITLE
fix: bypass navigation blocker when saving agreement draft

### DIFF
--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
@@ -529,7 +529,14 @@ const useAgreementEditForm = (
         }
 
         try {
-            const result = await saveAgreement();
+            // Bypass the navigation blocker: saving a draft is an intentional, saved exit,
+            // so the "You have unsaved changes" modal must not appear. Note that
+            // setHasAgreementChanged(false) only resets the parent's copy — the blocker's
+            // hasChanged is bound to the local useHasStateChanged(agreement) value, which
+            // stays true here. Navigation is deferred to the success alert's redirectUrl so a
+            // re-render propagates isCancelling before useBlocker re-evaluates.
+            setIsCancelling(true);
+            const result = await saveAgreement("/agreements");
             if (result === false && !agreement.id) {
                 const data = {
                     ...agreement,
@@ -545,12 +552,16 @@ const useAgreementEditForm = (
                 setAlert({
                     type: "success",
                     heading: "Agreement Draft Saved",
-                    message: `The agreement ${agreement.name} has been successfully created.`
+                    message: `The agreement ${agreement.name} has been successfully created.`,
+                    redirectUrl: "/agreements"
                 });
                 scrollToTop();
+            } else if (result === false) {
+                // Existing agreement with no changes to save: saveAgreement set no alert and
+                // hasChanged is false, so the blocker is inactive — navigate directly.
+                navigate("/agreements");
             }
             setHasAgreementChanged(false);
-            navigate("/agreements");
             // eslint-disable-next-line no-unused-vars
         } catch (error) {
             if (!agreement.id) {

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.test.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.test.js
@@ -16,6 +16,7 @@ const useSelectorMock = vi.fn();
 const useLocationMock = vi.fn();
 const hasStateChangedMock = vi.fn();
 const scrollToCenterMock = vi.fn();
+const setIsCancellingMock = vi.fn();
 
 vi.mock("react-router-dom", async (importOriginal) => {
     const actual = await importOriginal();
@@ -59,7 +60,7 @@ vi.mock("../../../hooks/useNavigationBlocker.hooks", () => ({
         showBlockerModal: false,
         setShowBlockerModal: vi.fn(),
         blockerModalProps: {},
-        setIsCancelling: vi.fn()
+        setIsCancelling: setIsCancellingMock
     })
 }));
 
@@ -449,13 +450,18 @@ describe("useAgreementEditForm - handleDraft creates new agreements", () => {
         });
 
         expect(addAgreementMock).toHaveBeenCalled();
+        // Bypasses the navigation blocker and defers navigation to the success alert's
+        // redirectUrl instead of calling navigate() directly, so the "unsaved changes"
+        // modal does not appear (issue #5910).
+        expect(setIsCancellingMock).toHaveBeenCalledWith(true);
         expect(setAlertMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 type: "success",
-                heading: "Agreement Draft Saved"
+                heading: "Agreement Draft Saved",
+                redirectUrl: "/agreements"
             })
         );
-        expect(navigateMock).toHaveBeenCalledWith("/agreements");
+        expect(navigateMock).not.toHaveBeenCalledWith("/agreements");
     });
 
     it("does NOT call addAgreement when agreement has an id (existing agreement)", async () => {
@@ -475,7 +481,17 @@ describe("useAgreementEditForm - handleDraft creates new agreements", () => {
         });
 
         expect(addAgreementMock).not.toHaveBeenCalled();
-        expect(navigateMock).toHaveBeenCalledWith("/agreements");
+        // Existing draft with changes: saveAgreement("/agreements") updates it and carries the
+        // redirectUrl on its own success alert, so navigate() is not called directly.
+        expect(setIsCancellingMock).toHaveBeenCalledWith(true);
+        expect(setAlertMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: "success",
+                heading: "Agreement Updated",
+                redirectUrl: "/agreements"
+            })
+        );
+        expect(navigateMock).not.toHaveBeenCalledWith("/agreements");
     });
 
     it("shows error alert when addAgreement fails", async () => {


### PR DESCRIPTION
## What changed

Fixes the "Unsaved Changes" modal incorrectly appearing when a user clicks **Save Draft** in the Create Agreement wizard.

`handleDraft` (in `AgreementEditForm.hooks.js`) previously called `navigate("/agreements")` synchronously after saving. The `useNavigationBlocker` hook blocks any pathname change while `hasChanged && !isCancelling`, so this tripped the blocker and rendered the "You have unsaved changes" modal — with the success alert visible behind its transparent backdrop.

Two reasons it fired:
1. `setHasAgreementChanged(false)` only reset the parent's copy. The blocker's `hasChanged` is bound to the local `useHasStateChanged(agreement)` value, which stays `true` because the agreement still differs from its mount snapshot.
2. `handleDraft` never set the `isCancelling` bypass flag (unlike `handleCancel`, which does).

The fix makes `handleDraft` mirror the proven `handleCancel` pattern:
- Calls `setIsCancelling(true)` to bypass the blocker.
- Defers navigation via the success alert's `redirectUrl: "/agreements"` instead of a synchronous `navigate()`, so a re-render propagates `isCancelling=true` before `useBlocker` re-evaluates (its predicate is captured at render).
- New draft: adds `redirectUrl` to the "Agreement Draft Saved" alert.
- Existing draft: calls `saveAgreement("/agreements")` so its own success alert carries the redirect.
- Keeps a direct `navigate()` only for the no-op case (existing agreement, no changes) where the blocker is already inactive.
- Error path unchanged.

Only step 2 (Agreement) of the wizard was affected: step 1 (Select Project) has no Save Draft button, and step 3 (Budget Lines) uses a "Create Agreement" button whose blocker is already disabled past step 0 and navigates via `redirectUrl`.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5910

## How to test

1. Log into staging (or run locally).
2. Select **Create** from the main nav, then **Agreement**.
3. Fill out enough to enable **Save Draft** and click it on the Agreement step.
4. Confirm only the success alert appears ("Agreement Draft Saved") and you are redirected to the Agreements list — the "Unsaved Changes" modal should **not** appear.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated
