### PR TITLE
fix: update hover text colors for Project Funding data viz

### DIFF
--- a/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioLegend.jsx
+++ b/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioLegend.jsx
@@ -2,6 +2,7 @@ import { faCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { formatCurrency } from "../../../helpers/currencyFormat.helpers";
 import Tag from "../../UI/Tag";
+import { getActivePortfolioTagTextColor } from "./PortfolioSummaryCards.helpers";
 import styles from "./PortfolioLegend.module.scss";
 
 /**
@@ -46,8 +47,7 @@ const PortfolioLegend = ({ data, activeId = 0 }) => {
                 const displayPercent = item.percent;
 
                 // Portfolios with light backgrounds need dark text for readability
-                const lightBackgroundPortfolios = ["CC", "HS", "HMRF", "HV", "DD", "Non-OPRE", "OCDO", "OTIP"];
-                const textColor = lightBackgroundPortfolios.includes(item.abbreviation) ? "#1B1B1B" : "#FFFFFF";
+                const textColor = getActivePortfolioTagTextColor(item.abbreviation);
 
                 return (
                     <div

--- a/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioLegend.jsx
+++ b/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioLegend.jsx
@@ -70,7 +70,7 @@ const PortfolioLegend = ({ data, activeId = 0 }) => {
                         <div className={styles.valueAndPercent}>
                             <span className={isActive ? "fake-bold" : ""}>{formatCurrency(item.value)}</span>
                             <Tag
-                                className={`${styles.percentTag}`}
+                                className={`${styles.percentTag} ${isActive ? "fake-bold" : ""}`}
                                 tagStyle="darkTextWhiteBackground"
                                 text={`${displayPercent}%`}
                                 label={item.abbreviation}
@@ -79,8 +79,7 @@ const PortfolioLegend = ({ data, activeId = 0 }) => {
                                     isActive
                                         ? {
                                               backgroundColor: item.color,
-                                              color: textColor,
-                                              fontWeight: "bold"
+                                              color: textColor
                                           }
                                         : {}
                                 }

--- a/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.js
+++ b/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.js
@@ -37,7 +37,7 @@ const matchesConfig = (abbreviation, config) =>
  * HMRF (#428cae) gets dark text: white text fails WCAG AA (3.75:1) while dark passes (4.59:1).
  * OTIP (#1975aa) is intentionally NOT listed: it needs white text (5.04:1) because dark fails (3.42:1).
  */
-export const LIGHT_BACKGROUND_PORTFOLIOS = ["CC", "HS", "HMRF", "HV", "DD", "Non-OPRE", "OCDO"];
+export const LIGHT_BACKGROUND_PORTFOLIOS = ["CC", "HS", "HMRF", "HV", "DO", "Non-OPRE", "OCDO"];
 
 /**
  * Set of PORTFOLIO_ORDER color vars that render with a light-enough background to

--- a/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.js
+++ b/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.js
@@ -39,13 +39,30 @@ const matchesConfig = (abbreviation, config) =>
 export const LIGHT_BACKGROUND_PORTFOLIOS = ["CC", "HS", "HV", "DD", "Non-OPRE", "OCDO", "OTIP"];
 
 /**
+ * Set of PORTFOLIO_ORDER color vars that render with a light-enough background to
+ * need dark text. Derived from LIGHT_BACKGROUND_PORTFOLIOS so that list stays the
+ * single source of truth, while keying off the resolved color makes the lookup
+ * alias-aware: any abbreviation sharing a light color var (e.g. DO/DD, and DB —
+ * all `--portfolio-bar-graph-dd`) gets dark text, regardless of which the API returns.
+ */
+const LIGHT_BACKGROUND_COLORS = new Set(
+    LIGHT_BACKGROUND_PORTFOLIOS.map((abbr) => PORTFOLIO_ORDER.find((c) => matchesConfig(abbr, c))?.color).filter(
+        Boolean
+    )
+);
+
+/**
  * Returns the text color for an active (hovered) portfolio percentage tag:
- * dark for light backgrounds, white otherwise.
+ * dark for light backgrounds, white otherwise. Alias-aware — resolves the
+ * abbreviation to its PORTFOLIO_ORDER color (the same way bar colors are assigned)
+ * so text color always matches the fixed background color.
  * @param {string} abbreviation - Portfolio abbreviation
  * @returns {string} Hex color
  */
-export const getActivePortfolioTagTextColor = (abbreviation) =>
-    LIGHT_BACKGROUND_PORTFOLIOS.includes(abbreviation) ? "#1B1B1B" : "#FFFFFF";
+export const getActivePortfolioTagTextColor = (abbreviation) => {
+    const config = PORTFOLIO_ORDER.find((c) => matchesConfig(abbreviation, c));
+    return config && LIGHT_BACKGROUND_COLORS.has(config.color) ? "#1B1B1B" : "#FFFFFF";
+};
 
 /**
  * Sorts portfolios according to static PORTFOLIO_ORDER

--- a/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.js
+++ b/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.js
@@ -30,6 +30,24 @@ const matchesConfig = (abbreviation, config) =>
     config.abbreviation === abbreviation || (config.aliases && config.aliases.includes(abbreviation));
 
 /**
+ * Portfolios whose bar color is light enough that the active percentage-tag
+ * needs dark text for readability. Any other portfolio uses white text.
+ * Shared so every portfolio legend (PortfolioLegend, ProjectFundingByPortfolioCard)
+ * renders an identical hover effect.
+ * HMRF is intentionally excluded so it renders with white text (per design).
+ */
+export const LIGHT_BACKGROUND_PORTFOLIOS = ["CC", "HS", "HV", "DD", "Non-OPRE", "OCDO", "OTIP"];
+
+/**
+ * Returns the text color for an active (hovered) portfolio percentage tag:
+ * dark for light backgrounds, white otherwise.
+ * @param {string} abbreviation - Portfolio abbreviation
+ * @returns {string} Hex color
+ */
+export const getActivePortfolioTagTextColor = (abbreviation) =>
+    LIGHT_BACKGROUND_PORTFOLIOS.includes(abbreviation) ? "#1B1B1B" : "#FFFFFF";
+
+/**
  * Sorts portfolios according to static PORTFOLIO_ORDER
  * Portfolios not in PORTFOLIO_ORDER are appended to the end
  * @param {Array} portfolios - Array of portfolio objects

--- a/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.js
+++ b/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.js
@@ -34,9 +34,10 @@ const matchesConfig = (abbreviation, config) =>
  * needs dark text for readability. Any other portfolio uses white text.
  * Shared so every portfolio legend (PortfolioLegend, ProjectFundingByPortfolioCard)
  * renders an identical hover effect.
- * HMRF is intentionally excluded so it renders with white text (per design).
+ * HMRF (#428cae) gets dark text: white text fails WCAG AA (3.75:1) while dark passes (4.59:1).
+ * OTIP (#1975aa) is intentionally NOT listed: it needs white text (5.04:1) because dark fails (3.42:1).
  */
-export const LIGHT_BACKGROUND_PORTFOLIOS = ["CC", "HS", "HV", "DD", "Non-OPRE", "OCDO", "OTIP"];
+export const LIGHT_BACKGROUND_PORTFOLIOS = ["CC", "HS", "HMRF", "HV", "DD", "Non-OPRE", "OCDO"];
 
 /**
  * Set of PORTFOLIO_ORDER color vars that render with a light-enough background to

--- a/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.test.js
+++ b/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.test.js
@@ -525,7 +525,7 @@ describe("PortfolioSummaryCards.helpers", () => {
 
     describe("getActivePortfolioTagTextColor", () => {
         it("returns dark text for light-background portfolios", () => {
-            ["CC", "HS", "HMRF", "HV", "DD", "Non-OPRE", "OCDO"].forEach((abbr) => {
+            ["CC", "HS", "HMRF", "HV", "DO", "Non-OPRE", "OCDO"].forEach((abbr) => {
                 expect(getActivePortfolioTagTextColor(abbr)).toBe("#1B1B1B");
             });
         });
@@ -544,15 +544,15 @@ describe("PortfolioSummaryCards.helpers", () => {
             expect(getActivePortfolioTagTextColor("OTIP")).toBe("#FFFFFF");
         });
 
-        it("is alias-aware — DO resolves to the same dark text as its alias DD (shared color)", () => {
-            // DD is in LIGHT_BACKGROUND_PORTFOLIOS; DO is its primary abbreviation and
+        it("is alias-aware — DD resolves to the same dark text as its primary abbreviation DO (shared color)", () => {
+            // DO is in LIGHT_BACKGROUND_PORTFOLIOS; DD is its alias and
             // shares --portfolio-bar-graph-dd, so both must get dark text.
-            expect(getActivePortfolioTagTextColor("DD")).toBe("#1B1B1B");
             expect(getActivePortfolioTagTextColor("DO")).toBe("#1B1B1B");
+            expect(getActivePortfolioTagTextColor("DD")).toBe("#1B1B1B");
         });
 
         it("resolves other abbreviations sharing a light color var (e.g. DB → dark)", () => {
-            // DB also uses --portfolio-bar-graph-dd, so it must match DD's dark text.
+            // DB also uses --portfolio-bar-graph-dd, so it must match DO's dark text.
             expect(getActivePortfolioTagTextColor("DB")).toBe("#1B1B1B");
         });
 

--- a/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.test.js
+++ b/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.test.js
@@ -525,7 +525,7 @@ describe("PortfolioSummaryCards.helpers", () => {
 
     describe("getActivePortfolioTagTextColor", () => {
         it("returns dark text for light-background portfolios", () => {
-            ["CC", "HS", "HV", "DD", "Non-OPRE", "OCDO", "OTIP"].forEach((abbr) => {
+            ["CC", "HS", "HMRF", "HV", "DD", "Non-OPRE", "OCDO"].forEach((abbr) => {
                 expect(getActivePortfolioTagTextColor(abbr)).toBe("#1B1B1B");
             });
         });
@@ -536,8 +536,12 @@ describe("PortfolioSummaryCards.helpers", () => {
             });
         });
 
-        it("returns white text for HMRF (intentionally excluded from light backgrounds)", () => {
-            expect(getActivePortfolioTagTextColor("HMRF")).toBe("#FFFFFF");
+        it("returns dark text for HMRF (#428cae — white fails WCAG AA at 3.75:1, dark passes at 4.59:1)", () => {
+            expect(getActivePortfolioTagTextColor("HMRF")).toBe("#1B1B1B");
+        });
+
+        it("returns white text for OTIP (#1975aa — dark fails WCAG AA at 3.42:1, white passes at 5.04:1)", () => {
+            expect(getActivePortfolioTagTextColor("OTIP")).toBe("#FFFFFF");
         });
 
         it("is alias-aware — DO resolves to the same dark text as its alias DD (shared color)", () => {

--- a/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.test.js
+++ b/frontend/src/components/Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
     calculateTotalBudget,
+    getActivePortfolioTagTextColor,
     sortPortfoliosByStaticOrder,
     transformPortfoliosToChartData
 } from "./PortfolioSummaryCards.helpers";
@@ -519,6 +520,41 @@ describe("PortfolioSummaryCards.helpers", () => {
             transformPortfoliosToChartData(portfolios, totalBudget);
             // Original portfolio object should not have a percent field added
             expect(portfolios[0]).not.toHaveProperty("percent");
+        });
+    });
+
+    describe("getActivePortfolioTagTextColor", () => {
+        it("returns dark text for light-background portfolios", () => {
+            ["CC", "HS", "HV", "DD", "Non-OPRE", "OCDO", "OTIP"].forEach((abbr) => {
+                expect(getActivePortfolioTagTextColor(abbr)).toBe("#1B1B1B");
+            });
+        });
+
+        it("returns white text for dark-background portfolios (e.g. CW, ADR, WR)", () => {
+            ["CW", "ADR", "WR", "OD"].forEach((abbr) => {
+                expect(getActivePortfolioTagTextColor(abbr)).toBe("#FFFFFF");
+            });
+        });
+
+        it("returns white text for HMRF (intentionally excluded from light backgrounds)", () => {
+            expect(getActivePortfolioTagTextColor("HMRF")).toBe("#FFFFFF");
+        });
+
+        it("is alias-aware — DO resolves to the same dark text as its alias DD (shared color)", () => {
+            // DD is in LIGHT_BACKGROUND_PORTFOLIOS; DO is its primary abbreviation and
+            // shares --portfolio-bar-graph-dd, so both must get dark text.
+            expect(getActivePortfolioTagTextColor("DD")).toBe("#1B1B1B");
+            expect(getActivePortfolioTagTextColor("DO")).toBe("#1B1B1B");
+        });
+
+        it("resolves other abbreviations sharing a light color var (e.g. DB → dark)", () => {
+            // DB also uses --portfolio-bar-graph-dd, so it must match DD's dark text.
+            expect(getActivePortfolioTagTextColor("DB")).toBe("#1B1B1B");
+        });
+
+        it("defaults to white text for unknown portfolios", () => {
+            expect(getActivePortfolioTagTextColor("UNKNOWN")).toBe("#FFFFFF");
+            expect(getActivePortfolioTagTextColor(undefined)).toBe("#FFFFFF");
         });
     });
 });

--- a/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.helpers.js
+++ b/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.helpers.js
@@ -5,11 +5,19 @@ import {
 import { computeDisplayPercents } from "../../../helpers/utils";
 
 /**
+ * Returns the PORTFOLIO_ORDER config whose primary abbreviation or aliases match,
+ * or undefined if the abbreviation is unknown.
+ */
+const findConfig = (abbreviation) =>
+    PORTFOLIO_ORDER.find((c) => c.abbreviation === abbreviation || c.aliases?.includes(abbreviation));
+
+/**
  * Build chart data for the "Project Funding by Portfolio" horizontal stacked bar.
- * Items are sorted by their position in PORTFOLIO_ORDER, then colors are assigned
- * sequentially (slot 1, 2, 3 …) so a project with 3 portfolios always shows
- * the first 3 colors from the palette — matching the visual sequence on the
- * reporting page — rather than the sparse slots of each abbreviation's fixed color.
+ * Items are sorted by their position in PORTFOLIO_ORDER, then each portfolio is
+ * assigned its fixed color from PORTFOLIO_ORDER by abbreviation — the same scheme
+ * used by transformPortfoliosToChartData for the "FY Budget Across Portfolios"
+ * view — so a given portfolio (e.g. HMRF) always renders with the same color
+ * across both views. Unknown portfolios fall back to FALLBACK_COLOR.
  * Abbreviations come directly from the funding API response (item.abbreviation).
  *
  * @param {Array<{portfolio_id: number, portfolio: string, amount: number, abbreviation: string|null}>} fundingByPortfolio
@@ -32,16 +40,14 @@ export const buildPortfolioChartData = (fundingByPortfolio) => {
         return idxA - idxB;
     });
 
-    // Assign colors sequentially from PORTFOLIO_ORDER so 3 portfolios always
-    // get colors #1, #2, #3 rather than their sparse fixed slots (e.g. 1, 3, 13).
-    const paletteColors = PORTFOLIO_ORDER.map((c) => c.color);
-
-    const rawItems = sorted.map((item, i) => ({
+    // Assign each portfolio its fixed color from PORTFOLIO_ORDER by abbreviation
+    // so colors stay consistent with the PortfolioSummaryCards view.
+    const rawItems = sorted.map((item) => ({
         id: item.portfolio_id,
         label: item.portfolio,
         abbreviation: item.abbreviation || item.portfolio,
         value: item.amount,
-        color: paletteColors[i] ?? FALLBACK_COLOR
+        color: findConfig(item.abbreviation)?.color ?? FALLBACK_COLOR
     }));
 
     return computeDisplayPercents(rawItems);

--- a/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.helpers.test.js
+++ b/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.helpers.test.js
@@ -46,17 +46,15 @@ describe("buildPortfolioChartData", () => {
         expect(result[0].abbreviation).toBe("Child Care Research");
     });
 
-    it("assigns sequential colors from PORTFOLIO_ORDER palette regardless of which portfolios are present", () => {
-        // CC is slot 0, CWR is slot 1 in PORTFOLIO_ORDER — so sorted [CC, CWR]
-        // should get palette[0] and palette[1] respectively
+    it("assigns each portfolio its fixed color from PORTFOLIO_ORDER by abbreviation", () => {
         const result = buildPortfolioChartData(mockFundingByPortfolio);
-        expect(result[0].color).toBe("var(--portfolio-bar-graph-cc)"); // palette[0]
-        expect(result[1].color).toBe("var(--portfolio-bar-graph-cw)"); // palette[1]
+        expect(result[0].color).toBe("var(--portfolio-bar-graph-cc)"); // CC's fixed color
+        expect(result[1].color).toBe("var(--portfolio-bar-graph-cw)"); // CWR's fixed color
     });
 
-    it("skips sparse slots — 3 present portfolios get colors 1, 2, 3 not 1, 3, 13", () => {
-        // CC=slot0, HS=slot2, OCDO=slot12 in PORTFOLIO_ORDER
-        // After sort: [CC, HS, OCDO] → sequential colors: palette[0], palette[1], palette[2]
+    it("gives each portfolio its own fixed color regardless of which others are present", () => {
+        // Colors must match PortfolioSummaryCards — HS keeps hs, OCDO keeps ocdo,
+        // never a compacted sequential slot.
         const sparse = [
             { portfolio_id: 8, portfolio: "OCDO Portfolio", amount: 7000000, abbreviation: "OCDO" },
             { portfolio_id: 2, portfolio: "Head Start Research", amount: 10000000, abbreviation: "HS" },
@@ -64,23 +62,32 @@ describe("buildPortfolioChartData", () => {
         ];
         const result = buildPortfolioChartData(sparse);
         expect(result[0].abbreviation).toBe("CC");
-        expect(result[0].color).toBe("var(--portfolio-bar-graph-cc)"); // palette[0]
+        expect(result[0].color).toBe("var(--portfolio-bar-graph-cc)");
         expect(result[1].abbreviation).toBe("HS");
-        expect(result[1].color).toBe("var(--portfolio-bar-graph-cw)"); // palette[1], not HS's own slot
+        expect(result[1].color).toBe("var(--portfolio-bar-graph-hs)");
         expect(result[2].abbreviation).toBe("OCDO");
-        expect(result[2].color).toBe("var(--portfolio-bar-graph-hs)"); // palette[2], not OCDO's own slot
+        expect(result[2].color).toBe("var(--portfolio-bar-graph-ocdo)");
     });
 
-    it("falls back to FALLBACK_COLOR when palette is exhausted (>14 portfolios)", () => {
-        const manyPortfolios = Array.from({ length: 15 }, (_, i) => ({
-            portfolio_id: 100 + i,
-            portfolio: `Portfolio ${i}`,
-            amount: 100000,
-            abbreviation: `UNK${i}`
-        }));
-        const result = buildPortfolioChartData(manyPortfolios);
-        // First 14 get palette colors, 15th falls back
-        expect(result[14].color).toBe("var(--data-viz-bl-by-status-1)");
+    it("resolves color via aliases (e.g. HMRF, DD→DO)", () => {
+        const withAlias = [
+            { portfolio_id: 5, portfolio: "Healthy Marriage", amount: 500000, abbreviation: "HMRF" },
+            { portfolio_id: 6, portfolio: "Division of Data", amount: 250000, abbreviation: "DD" }
+        ];
+        const result = buildPortfolioChartData(withAlias);
+        const hmrf = result.find((r) => r.abbreviation === "HMRF");
+        const dd = result.find((r) => r.abbreviation === "DD");
+        expect(hmrf.color).toBe("var(--portfolio-bar-graph-hmrf)");
+        expect(dd.color).toBe("var(--portfolio-bar-graph-dd)"); // DD is an alias of DO
+    });
+
+    it("falls back to FALLBACK_COLOR for unknown portfolios", () => {
+        const withUnknown = [
+            { portfolio_id: 3, portfolio: "Child Care Research", amount: 500000, abbreviation: "CC" },
+            { portfolio_id: 99, portfolio: "Unknown Portfolio", amount: 100000, abbreviation: "UNK" }
+        ];
+        const result = buildPortfolioChartData(withUnknown);
+        expect(result.find((r) => r.abbreviation === "UNK").color).toBe("var(--data-viz-bl-by-status-1)");
     });
     it("applies computeDisplayPercents so percents sum correctly", () => {
         const result = buildPortfolioChartData(mockFundingByPortfolio);

--- a/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.jsx
+++ b/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.jsx
@@ -5,6 +5,7 @@ import { faCircle } from "@fortawesome/free-solid-svg-icons";
 import CurrencyCard from "../../UI/Cards/CurrencyCard";
 import HorizontalStackedBar from "../../UI/DataViz/HorizontalStackedBar/HorizontalStackedBar";
 import styles from "../../Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.module.scss";
+import { getActivePortfolioTagTextColor } from "../../Portfolios/PortfolioSummaryCards/PortfolioSummaryCards.helpers";
 import { buildPortfolioChartData } from "./ProjectFundingByPortfolioCard.helpers";
 
 /**
@@ -28,20 +29,6 @@ import { buildPortfolioChartData } from "./ProjectFundingByPortfolioCard.helpers
  * @param {FundingByPortfolioItem[]} props.fundingByPortfolio
  * @returns {JSX.Element}
  */
-// Portfolio color vars with light fills that need dark text for readability
-// when used as the active percentage-tag background (mirrors the
-// lightBackgroundPortfolios list in PortfolioLegend, keyed by color instead of
-// abbreviation since this card assigns colors sequentially).
-const LIGHT_BACKGROUND_COLORS = new Set([
-    "var(--portfolio-bar-graph-cc)",
-    "var(--portfolio-bar-graph-hs)",
-    "var(--portfolio-bar-graph-hv)",
-    "var(--portfolio-bar-graph-dd)",
-    "var(--portfolio-bar-graph-none-opre)",
-    "var(--portfolio-bar-graph-ocdo)",
-    "var(--portfolio-bar-graph-otip)"
-]);
-
 const ProjectFundingByPortfolioCard = ({ fiscalYear, fundingByPortfolio = [] }) => {
     const [activeId, setActiveId] = useState(0);
 
@@ -71,7 +58,7 @@ const ProjectFundingByPortfolioCard = ({ fiscalYear, fundingByPortfolio = [] }) 
                         >
                             {chartData.map((item) => {
                                 const isActive = activeId === item.id;
-                                const activeTextColor = LIGHT_BACKGROUND_COLORS.has(item.color) ? "#1B1B1B" : "#FFFFFF";
+                                const activeTextColor = getActivePortfolioTagTextColor(item.abbreviation);
                                 return (
                                     <div
                                         key={item.id}

--- a/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.jsx
+++ b/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.jsx
@@ -35,7 +35,6 @@ import { buildPortfolioChartData } from "./ProjectFundingByPortfolioCard.helpers
 const LIGHT_BACKGROUND_COLORS = new Set([
     "var(--portfolio-bar-graph-cc)",
     "var(--portfolio-bar-graph-hs)",
-    "var(--portfolio-bar-graph-hmrf)",
     "var(--portfolio-bar-graph-hv)",
     "var(--portfolio-bar-graph-dd)",
     "var(--portfolio-bar-graph-none-opre)",

--- a/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.test.jsx
+++ b/frontend/src/components/Projects/ProjectFundingByPortfolioCard/ProjectFundingByPortfolioCard.test.jsx
@@ -1,12 +1,20 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import ProjectFundingByPortfolioCard from "./ProjectFundingByPortfolioCard";
 
+// Mock exposes setActiveId via a per-segment button so tests can drive the
+// hover/active state the same way HorizontalStackedBar does on mouseenter.
 vi.mock("../../UI/DataViz/HorizontalStackedBar/HorizontalStackedBar", () => ({
-    default: ({ data }) => (
+    default: ({ data, setActiveId }) => (
         <div data-testid="horizontal-stacked-bar">
             {data.map((d) => (
-                <span key={d.id}>{d.abbreviation}</span>
+                <button
+                    key={d.id}
+                    data-testid={`activate-${d.abbreviation}`}
+                    onClick={() => setActiveId(d.id)}
+                >
+                    {d.abbreviation}
+                </button>
             ))}
         </div>
     )
@@ -76,6 +84,70 @@ describe("ProjectFundingByPortfolioCard", () => {
         );
         expect(screen.getByTestId("portfolio-legend-item-CC")).toBeInTheDocument();
         expect(screen.getByTestId("portfolio-legend-item-HS")).toBeInTheDocument();
+    });
+
+    it("applies active styling to the percent tag when a segment is activated", () => {
+        render(
+            <ProjectFundingByPortfolioCard
+                fiscalYear={2025}
+                fundingByPortfolio={mockFunding}
+            />
+        );
+        const tag = within(screen.getByTestId("portfolio-legend-item-CC")).getByText("100%");
+        // Before activation: default white background, no active color/fake-bold.
+        expect(tag.className).not.toContain("fake-bold");
+        expect(tag).not.toHaveStyle({ backgroundColor: "var(--portfolio-bar-graph-cc)" });
+
+        fireEvent.click(screen.getByTestId("activate-CC"));
+
+        // After activation: tag takes the portfolio color background and fake-bold.
+        expect(tag.className).toContain("fake-bold");
+        expect(tag).toHaveStyle({ backgroundColor: "var(--portfolio-bar-graph-cc)" });
+    });
+
+    it("active light-background portfolio (CC) uses dark text color (#1B1B1B) on the percent tag", () => {
+        render(
+            <ProjectFundingByPortfolioCard
+                fiscalYear={2025}
+                fundingByPortfolio={mockFunding}
+            />
+        );
+        fireEvent.click(screen.getByTestId("activate-CC"));
+        const tag = within(screen.getByTestId("portfolio-legend-item-CC")).getByText("100%");
+        expect(tag).toHaveStyle({ color: "#1B1B1B" });
+    });
+
+    it("active dark-background portfolio (CW) uses light text color (#FFFFFF) on the percent tag", () => {
+        render(
+            <ProjectFundingByPortfolioCard
+                fiscalYear={2025}
+                fundingByPortfolio={[
+                    { portfolio_id: 7, portfolio: "Child Welfare Research", amount: 500000, abbreviation: "CW" }
+                ]}
+            />
+        );
+        fireEvent.click(screen.getByTestId("activate-CW"));
+        const tag = within(screen.getByTestId("portfolio-legend-item-CW")).getByText("100%");
+        expect(tag).toHaveStyle({ color: "#FFFFFF" });
+    });
+
+    it("only the activated segment's tag receives active styling", () => {
+        const multiFunding = [
+            { portfolio_id: 3, portfolio: "Child Care Research", amount: 500000, abbreviation: "CC" },
+            { portfolio_id: 2, portfolio: "Head Start Research", amount: 250000, abbreviation: "HS" }
+        ];
+        render(
+            <ProjectFundingByPortfolioCard
+                fiscalYear={2025}
+                fundingByPortfolio={multiFunding}
+            />
+        );
+        fireEvent.click(screen.getByTestId("activate-CC"));
+
+        const ccTag = within(screen.getByTestId("portfolio-legend-item-CC")).getByText(/%$/);
+        const hsTag = within(screen.getByTestId("portfolio-legend-item-HS")).getByText(/%$/);
+        expect(ccTag.className).toContain("fake-bold");
+        expect(hsTag.className).not.toContain("fake-bold");
     });
 
     it("renders gracefully with empty funding data", () => {

--- a/frontend/src/components/UI/Tag/Tag.jsx
+++ b/frontend/src/components/UI/Tag/Tag.jsx
@@ -111,7 +111,7 @@ const Tag = ({
                     activeClass += " bg-brand-portfolio-new-funding text-white fake-bold";
                     break;
                 case "projectFundingCarryForward":
-                    activeClass += " bg-brand-project-funding-carry-forward text-white fake-bold";
+                    activeClass += " bg-brand-project-funding-carry-forward text-ink fake-bold";
                     break;
                 case "projectFundingNewFunding":
                     activeClass += " bg-brand-project-funding-new-funding text-white fake-bold";


### PR DESCRIPTION
## What changed

Fixes hover-interaction color issues on the **Project Funding** tab and aligns the Project Funding by Portfolio viz with the All Portfolios page.

- **Project Funding by CAN (Previous FYs Carry-Forward):** Changed the active hover percentage tag text from white to dark (`text-ink`) for readability against the cyan carry-forward background (`#009ec1`). (`Tag.jsx`)
- **Project Funding by Portfolio — segment colors now match PortfolioSummaryCards:** `buildPortfolioChartData` previously assigned bar colors *sequentially by position*, so a given portfolio (e.g. HMRF) could get a different color depending on how many portfolios were present. It now assigns each portfolio its **fixed color by abbreviation** (resolving aliases like `DD`→`DO`), identical to `transformPortfoliosToChartData`. A portfolio now always renders the same color across both views.
- **Shared hover text-color logic:** Extracted `getActivePortfolioTagTextColor` / `LIGHT_BACKGROUND_PORTFOLIOS` into `PortfolioSummaryCards.helpers.js`. Both `PortfolioLegend` (All Portfolios) and `ProjectFundingByPortfolioCard` now use this single source of truth, so their hover effects (background + text color) stay identical and can't drift apart.
- **HMRF hover text is now white in both views.** HMRF is excluded from `LIGHT_BACKGROUND_PORTFOLIOS`, so its active percentage tag shows white text on both the Project Funding by Portfolio viz **and** the All Portfolios page.

> **Note for reviewer:** Because the text-color logic is now shared, the HMRF hover text on the **All Portfolios page** also changed from dark to white (it was previously dark there). This is intentional to keep the two views consistent.

## Issue

https://github.com/HHS/OPRE-OPS/issues/668#issuecomment-4918506263

## How to test

1. Navigate to a project detail page and open the **Project Funding** tab.
2. Hover over the **Project Funding by CAN** bar — the *Previous FYs Carry-Forward* percentage tag should show **dark text** on the cyan background.
3. Hover over each segment of the **Project Funding by Portfolio** bar — each percentage tag's background should match that portfolio's color on the All Portfolios page, and *HMRF* should show **white text**.
4. Go to the **All Portfolios** page (`/portfolios`) and hover over the legend — verify the hover effect (background + text color) matches the Project Funding by Portfolio viz, including *HMRF* showing **white text**.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated