### PR TITLE
refactor: move filter option fetches to page level to cut redundant requests

### DIFF
--- a/frontend/src/pages/budgetLines/list/BLIFilterButton.jsx
+++ b/frontend/src/pages/budgetLines/list/BLIFilterButton.jsx
@@ -9,8 +9,6 @@ import AgreementTypeComboBox from "../../../components/Agreements/AgreementTypeC
 import AgreementNameComboBox from "../../../components/Agreements/AgreementNameComboBox/AgreementNameComboBox";
 import CANActivePeriodComboBox from "../../../components/CANs/CANActivePeriodComboBox/CANActivePeriodComboBox";
 import BLIStatusComboBox from "../../../components/BudgetLineItems/BLIStatusComboBox";
-import { useSearchParams } from "react-router-dom";
-import { useGetBudgetLineItemsFilterOptionsQuery } from "../../../api/opsAPI";
 import { getCurrentFiscalYear } from "../../../helpers/utils";
 import { FILTER_MODAL_FULL_WIDTH } from "../../../constants";
 
@@ -21,9 +19,10 @@ import { FILTER_MODAL_FULL_WIDTH } from "../../../constants";
  * @param {Function} props.setFilters - A function to call to set the filters.
  * @param {string|number} props.selectedFiscalYear - The current fiscal year shortcut value from the dropdown.
  * @param {boolean} props.useApproachB - Whether to use Approach B (UX requested) with "All FYs" option.
+ * @param {import("../../../types/BudgetLineTypes").Filters} [props.filterOptions] - Prefetched filter options from the page.
  * @returns {React.ReactElement} - The procurement shop select element.
  */
-export const BLIFilterButton = ({ filters, setFilters, selectedFiscalYear, useApproachB }) => {
+export const BLIFilterButton = ({ filters, setFilters, selectedFiscalYear, useApproachB, filterOptions }) => {
     const [fiscalYears, setFiscalYears] = React.useState([]);
     const [portfolios, setPortfolios] = React.useState([]);
     const [bliStatus, setBLIStatus] = React.useState([]);
@@ -32,15 +31,6 @@ export const BLIFilterButton = ({ filters, setFilters, selectedFiscalYear, useAp
     const [agreementTypes, setAgreementTypes] = React.useState([]);
     const [agreementTitles, setAgreementTitles] = React.useState([]);
     const [canActivePeriods, setCanActivePeriods] = React.useState([]);
-    const [searchParams] = useSearchParams();
-
-    const myBudgetLineItemsUrl = searchParams.get("filter") === "my-budget-lines";
-
-    /** @type {{data?: import("../../../types/BudgetLineTypes").Filters | undefined, isSuccess: boolean}} */
-    const { data: filterOptions } = useGetBudgetLineItemsFilterOptionsQuery(
-        { onlyMy: myBudgetLineItemsUrl, enableObe: false },
-        { refetchOnMountOrArgChange: true }
-    );
 
     // Fiscal year options for modal (no "All" option - empty selection means "All")
     const fiscalYearOptions = React.useMemo(() => {
@@ -182,6 +172,7 @@ export const BLIFilterButton = ({ filters, setFilters, selectedFiscalYear, useAp
                 setSelectedPortfolios={setPortfolios}
                 legendClassname={legendStyles}
                 overrideStyles={FILTER_MODAL_FULL_WIDTH}
+                usePrefetchedOptions={true}
             />
         </fieldset>,
         <fieldset

--- a/frontend/src/pages/budgetLines/list/BLIFilterButton.test.jsx
+++ b/frontend/src/pages/budgetLines/list/BLIFilterButton.test.jsx
@@ -1,12 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { vi, describe, it, expect, beforeEach } from "vitest";
-import { useGetBudgetLineItemsFilterOptionsQuery } from "../../../api/opsAPI";
 import BLIFilterButton from "./BLIFilterButton";
-
-vi.mock("../../../api/opsAPI");
-vi.mock("react-router-dom", () => ({
-    useSearchParams: () => [new URLSearchParams()]
-}));
 
 // Mock child components
 vi.mock("../../../components/UI/FilterButton/FilterButton", () => ({
@@ -129,9 +123,6 @@ describe("BLIFilterButton", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
-        useGetBudgetLineItemsFilterOptionsQuery.mockReturnValue({
-            data: mockFilterOptions
-        });
     });
 
     it("renders filter button component", () => {
@@ -140,6 +131,7 @@ describe("BLIFilterButton", () => {
                 filters={defaultFilters}
                 setFilters={mockSetFilters}
                 selectedFiscalYear={2024}
+                filterOptions={mockFilterOptions}
             />
         );
 
@@ -167,6 +159,7 @@ describe("BLIFilterButton", () => {
                     filters={filtersWithNullish}
                     setFilters={mockSetFilters}
                     selectedFiscalYear={2024}
+                    filterOptions={mockFilterOptions}
                 />
             );
         }).not.toThrow();
@@ -191,6 +184,7 @@ describe("BLIFilterButton", () => {
                     filters={allNullFilters}
                     setFilters={mockSetFilters}
                     selectedFiscalYear={2024}
+                    filterOptions={mockFilterOptions}
                 />
             );
         }).not.toThrow();
@@ -204,6 +198,7 @@ describe("BLIFilterButton", () => {
                 filters={defaultFilters}
                 setFilters={mockSetFilters}
                 selectedFiscalYear={2024}
+                filterOptions={mockFilterOptions}
             />
         );
 
@@ -221,6 +216,7 @@ describe("BLIFilterButton", () => {
                 filters={defaultFilters}
                 setFilters={mockSetFilters}
                 selectedFiscalYear={2024}
+                filterOptions={mockFilterOptions}
             />
         );
 
@@ -243,6 +239,7 @@ describe("BLIFilterButton", () => {
                 filters={defaultFilters}
                 setFilters={mockSetFilters}
                 selectedFiscalYear={2024}
+                filterOptions={mockFilterOptions}
             />
         );
 
@@ -266,6 +263,7 @@ describe("BLIFilterButton", () => {
                 setFilters={mockSetFilters}
                 selectedFiscalYear={2024}
                 useApproachB={false}
+                filterOptions={mockFilterOptions}
             />
         );
 
@@ -294,6 +292,7 @@ describe("BLIFilterButton", () => {
                 setFilters={mockSetFilters}
                 selectedFiscalYear={2024}
                 useApproachB={true}
+                filterOptions={mockFilterOptions}
             />
         );
 
@@ -315,34 +314,25 @@ describe("BLIFilterButton", () => {
     });
 
     it("handles missing filter options data", () => {
-        useGetBudgetLineItemsFilterOptionsQuery.mockReturnValue({
-            data: undefined
-        });
-
         expect(() => {
             render(
                 <BLIFilterButton
                     filters={defaultFilters}
                     setFilters={mockSetFilters}
                     selectedFiscalYear={2024}
+                    filterOptions={undefined}
                 />
             );
         }).not.toThrow();
     });
 
     it("includes selectedFiscalYear in options when not in filterOptions", () => {
-        useGetBudgetLineItemsFilterOptionsQuery.mockReturnValue({
-            data: {
-                ...mockFilterOptions,
-                fiscal_years: [2023, 2025] // 2024 is not in the list
-            }
-        });
-
         render(
             <BLIFilterButton
                 filters={defaultFilters}
                 setFilters={mockSetFilters}
                 selectedFiscalYear={2024}
+                filterOptions={{ ...mockFilterOptions, fiscal_years: [2023, 2025] }}
             />
         );
 

--- a/frontend/src/pages/budgetLines/list/BudgetLineItemList.jsx
+++ b/frontend/src/pages/budgetLines/list/BudgetLineItemList.jsx
@@ -3,6 +3,7 @@ import { PacmanLoader } from "react-spinners";
 import App from "../../../App";
 import {
     useGetBudgetLineItemsQuery,
+    useGetBudgetLineItemsFilterOptionsQuery,
     useLazyGetBudgetLineItemsQuery,
     useLazyGetPortfolioByIdQuery,
     useLazyGetServicesComponentByIdQuery
@@ -31,6 +32,12 @@ const BudgetLineItemList = () => {
     const [currentPage, setCurrentPage] = useState(1);
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions();
     const { myBudgetLineItemsUrl, filters, setFilters, useApproachB, fyHelpers } = useBudgetLinesList();
+
+    /** @type {{data?: import("../../../types/BudgetLineTypes").Filters | undefined}} */
+    const { data: bliFilterOptions } = useGetBudgetLineItemsFilterOptionsQuery({
+        onlyMy: myBudgetLineItemsUrl,
+        enableObe: false
+    });
 
     // ============================================
     // TEMPORARY: A/B Testing Fiscal Year Filter
@@ -202,6 +209,7 @@ const BudgetLineItemList = () => {
                                     setFilters={setFilters}
                                     selectedFiscalYear={fiscalYearDropdownValue}
                                     useApproachB={useApproachB}
+                                    filterOptions={bliFilterOptions}
                                 />
                             </div>
                         </div>

--- a/frontend/src/pages/budgetLines/list/BudgetLineItemList.test.jsx
+++ b/frontend/src/pages/budgetLines/list/BudgetLineItemList.test.jsx
@@ -4,6 +4,7 @@ import configureStore from "redux-mock-store";
 import { vi, describe, it, expect, beforeEach } from "vitest";
 import {
     useGetBudgetLineItemsQuery,
+    useGetBudgetLineItemsFilterOptionsQuery,
     useLazyGetBudgetLineItemsQuery,
     useLazyGetPortfolioByIdQuery,
     useLazyGetServicesComponentByIdQuery
@@ -143,6 +144,7 @@ describe("BudgetLineItemList", () => {
         useLazyGetBudgetLineItemsQuery.mockReturnValue([vi.fn(), { isLoading: false }]);
         useLazyGetPortfolioByIdQuery.mockReturnValue([vi.fn(), { isLoading: false }]);
         useLazyGetServicesComponentByIdQuery.mockReturnValue([vi.fn(), { isLoading: false }]);
+        useGetBudgetLineItemsFilterOptionsQuery.mockReturnValue({ data: undefined });
 
         // Default mock for useBudgetLinesList hook
         vi.spyOn(hooks, "useBudgetLinesList").mockReturnValue({

--- a/frontend/src/pages/portfolios/list/PortfolioFilterButton/PortfolioFilterButton.jsx
+++ b/frontend/src/pages/portfolios/list/PortfolioFilterButton/PortfolioFilterButton.jsx
@@ -93,6 +93,7 @@ export const PortfolioFilterButton = ({ filters, setFilters, allPortfolios, fyBu
                 setSelectedPortfolios={setPortfolios}
                 legendClassname={legendStyles}
                 overrideStyles={FILTER_MODAL_FULL_WIDTH}
+                usePrefetchedOptions={true}
             />
         </fieldset>,
         <fieldset

--- a/frontend/src/pages/reporting/ReportingFilterButton.jsx
+++ b/frontend/src/pages/reporting/ReportingFilterButton.jsx
@@ -3,7 +3,7 @@ import FilterButton from "../../components/UI/FilterButton/FilterButton";
 import PortfoliosComboBox from "../../components/Portfolios/PortfoliosComboBox";
 import { FILTER_MODAL_FULL_WIDTH } from "../../constants";
 
-const ReportingFilterButton = ({ filters, setFilters }) => {
+const ReportingFilterButton = ({ filters, setFilters, portfolioOptions = [] }) => {
     const [portfolios, setPortfolios] = React.useState([]);
 
     React.useEffect(() => {
@@ -31,11 +31,13 @@ const ReportingFilterButton = ({ filters, setFilters }) => {
             className={fieldStyles}
         >
             <PortfoliosComboBox
+                portfolioOptions={portfolioOptions}
                 selectedPortfolios={portfolios}
                 setSelectedPortfolios={setPortfolios}
                 legendClassname={legendStyles}
                 defaultString="All Portfolios"
                 overrideStyles={FILTER_MODAL_FULL_WIDTH}
+                usePrefetchedOptions={true}
             />
         </fieldset>
     ];

--- a/frontend/src/pages/reporting/ReportingFilterButton.test.jsx
+++ b/frontend/src/pages/reporting/ReportingFilterButton.test.jsx
@@ -3,8 +3,13 @@ import { describe, it, expect, vi } from "vitest";
 import ReportingFilterButton from "./ReportingFilterButton";
 
 vi.mock("../../components/Portfolios/PortfoliosComboBox", () => ({
-    default: ({ selectedPortfolios, defaultString }) => (
-        <div data-testid="portfolios-combobox">{selectedPortfolios.length > 0 ? "Selected" : defaultString}</div>
+    default: ({ selectedPortfolios, defaultString, usePrefetchedOptions }) => (
+        <div
+            data-testid="portfolios-combobox"
+            data-prefetched={usePrefetchedOptions}
+        >
+            {selectedPortfolios.length > 0 ? "Selected" : defaultString}
+        </div>
     )
 }));
 

--- a/frontend/src/pages/reporting/ReportingPage.hooks.js
+++ b/frontend/src/pages/reporting/ReportingPage.hooks.js
@@ -110,6 +110,7 @@ export const useReportingPageData = () => {
         setSelectedFiscalYear,
         filters,
         setFilters,
+        allPortfolios,
         totalFunding,
         totalSpending,
         portfoliosWithFunding,

--- a/frontend/src/pages/reporting/ReportingPage.jsx
+++ b/frontend/src/pages/reporting/ReportingPage.jsx
@@ -20,6 +20,7 @@ const ReportingPage = () => {
         setSelectedFiscalYear,
         filters,
         setFilters,
+        allPortfolios,
         totalFunding,
         totalSpending,
         portfoliosWithFunding,
@@ -52,6 +53,7 @@ const ReportingPage = () => {
                 <ReportingFilterButton
                     filters={filters}
                     setFilters={setFilters}
+                    portfolioOptions={allPortfolios ?? []}
                 />
             </div>
             <p className="margin-top-0 margin-bottom-4">


### PR DESCRIPTION
## What changed

Audited the Budget Lines, Reporting, and Portfolio List filter flows and moved redundant filter-option fetches to the page level, matching the pattern already established by the Agreements filter.

**`BLIFilterButton` / `BudgetLineItemList`**
- Moved `useGetBudgetLineItemsFilterOptionsQuery` out of `BLIFilterButton` and into `BudgetLineItemList` (the page). The page now passes the result down as a `filterOptions` prop. This prevents the query from re-firing every time the filter modal mounts.
- Added `usePrefetchedOptions={true}` to `PortfoliosComboBox` inside `BLIFilterButton` so it skips its own internal `useGetPortfoliosQuery` and uses the already-available portfolio array from `filterOptions`.
- Removed the now-unused `useSearchParams` import and `myBudgetLineItemsUrl` derivation from `BLIFilterButton` (those were only needed to parameterize the relocated query).

**`ReportingFilterButton` / `ReportingPage`**
- `useReportingPageData` already called `useGetPortfoliosQuery` to power the page content, but that result was never passed to `ReportingFilterButton`, causing `PortfoliosComboBox` to fire a second identical request when the filter opened.
- Added `allPortfolios` to the hook's return value, threaded it through `ReportingPage`, and passed it as `portfolioOptions` to `ReportingFilterButton`.
- Added `usePrefetchedOptions={true}` to `PortfoliosComboBox` in `ReportingFilterButton` to suppress the redundant internal fetch.

**`PortfolioFilterButton`**
- `allPortfolios` was already correctly passed as a prop and forwarded to `PortfoliosComboBox` as `portfolioOptions`, but `usePrefetchedOptions={true}` was missing, so the combo box still fired its own query. One-line fix.

**Tests**
- Updated `BLIFilterButton.test.jsx` to pass `filterOptions` as a prop instead of mocking the RTK Query hook (tests now match the component's new API).
- Updated `BudgetLineItemList.test.jsx` to mock the newly added `useGetBudgetLineItemsFilterOptionsQuery` call.
- Updated `ReportingFilterButton.test.jsx` mock to forward the `usePrefetchedOptions` prop.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5419

## How to test

**Unit tests:**
```bash
cd frontend
bun run test --watch=false
```
All 327 test files should pass.

**Manual verification — Budget Lines:**
1. Open the browser DevTools Network tab and filter for `budget-line-items/filters`.
2. Navigate to `/budget-line-items`.
3. Confirm the filter-options request fires **once** on page load (not again when opening the filter modal).
4. Open the filter modal, set a portfolio filter, and apply — confirm filtering works correctly and filter tags appear.

**Manual verification — Reporting:**
1. Filter Network tab for `portfolios`.
2. Navigate to `/reports`.
3. Confirm only **one** portfolios request fires (not a second one when opening the filter modal).
4. Open the filter, select a portfolio, apply — confirm the page updates to show that portfolio's data.

**Manual verification — Portfolio List:**
1. Navigate to `/portfolios`.
2. Open the filter modal — confirm the portfolio dropdown is populated without a new network request.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — no visual changes; this is a data-fetching refactor only.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A