### PR TITLE
feat: create and view Grant agreements (OPS-5925)

### DIFF
--- a/docs/stories/OPS-5925/create-grant-plan.md
+++ b/docs/stories/OPS-5925/create-grant-plan.md
@@ -1,0 +1,105 @@
+# Plan: Create & View a Grant Agreement (Vertical Slice #5925)
+
+> Team context doc. This is the FIRST vertical slice of [#787 "Create a Grant"](https://github.com/HHS/OPRE-OPS/issues/787). Scope is limited to [#5925](https://github.com/HHS/OPRE-OPS/issues/5925). Later slices (#5926–#5928) cover budget lines and review/approval — **do not build those here.**
+
+## Context
+
+OPRE staff need to create Grant agreements. Today the Create Agreement wizard only supports Contracts (and Partner/AA types); the Grant option is present in the type dropdown but **actively blocked** by the validation suite, and grant-specific rendering is missing in a few helpers.
+
+Per the Figma design, a Grant only needs **4 fields**: Type, Agreement Title (`name`), Nickname (`nick_name`), and Description. This slice makes those 4 fields creatable through the existing wizard and viewable on the Agreement Details page.
+
+**Key finding — the backend is already done.** The `GrantAgreement` model, the `GrantAgreementData` marshmallow schema, and the `POST`/`PATCH /agreements` dispatch (routing by `agreement_type=GRANT`) all already support `name`, `nick_name`, `description`, and `agreement_type`. **No backend, model, migration, or schema changes are needed.** This is a **frontend-only** slice.
+
+### Decided scope (confirmed with product owner)
+- **In scope:** (1) Create a Grant via the `/agreements/create` wizard; (2) View a created Grant on the details page (`/agreements/:id`).
+- **When Type = Grant, show ONLY the 4 grant fields** — hide all Contract- and AA/Partner-specific controls.
+- **Keep the Step 1 "Select Project" step** — `project_id` is still required for grants.
+- **Out of scope:** editing a grant from the details page, budget lines, and the send-to-approval/review flow.
+
+## Critical Files
+- `frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.js` — Vest v6 validation suite (blocks GRANT today).
+- `frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx` — the create/edit form JSX.
+- `frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js` — form state/handlers.
+- `frontend/src/helpers/agreement.helpers.js` — `AGREEMENT_TYPE_VISIBLE_FIELDS` / `isFieldVisible` (details-view gating).
+- `frontend/src/pages/agreements/details/AgreementDetailsView.jsx` — read-only details view (verify only).
+
+Enums already contain GRANT — **no changes needed** to `agreements.constants.js` or `ServicesComponents.constants.js`.
+
+---
+
+## Implementation
+
+### 1. Make the Vest suite type-aware — `AgreementEditFormSuite.js`
+The suite currently (a) blocks GRANT and (b) unconditionally requires ~8 contract-only fields, so even an unblocked grant would keep the submit button disabled.
+
+- **Unblock GRANT:** in the two `"...not yet available"` tests (currently lines ~12–21), remove only the `enforce(...).notEquals(AGREEMENT_TYPES.GRANT)` lines. Leave IAA and DIRECT_OBLIGATION rejections intact (still out of scope).
+- **Guard contract-only tests:** add `const isGrant = data.agreement_type === AGREEMENT_TYPES.GRANT;` at the top of the suite body (after the `if (fieldName) only(fieldName)` block), then early-`return` from each contract-only test when `isGrant`:
+  ```js
+  test("service_requirement_type", "This is required information", () => {
+      if (isGrant) return;
+      enforce(data.service_requirement_type).notEquals("-Select Service Requirement Type-");
+  });
+  ```
+  Apply the same `if (isGrant) return;` guard to: `service_requirement_type`, `description`, `product_service_code_id`, `agreement_reason`, `vendor`, `project_officer`, `contract-type`, `procurement-shop-select`.
+- **Keep unconditional** (these ARE the grant requirements): the `agreement_type` "-Select-" test, `name`, and `project_id`.
+- **Vest v6 rules (from frontend/CLAUDE.md):** do NOT delete the `test(...)` registrations (keeps error keys stable — no `convertCodeForDisplay` label changes needed); do NOT switch to `only(dataObject)`; the early-`return` keeps each test id present and passing so prior failed state clears on re-run. `requesting_agency`/`servicing_agency` are already AA-gated — leave as-is.
+
+### 2. Hide contract/AA controls when Grant — `AgreementEditForm.jsx` + `.hooks.js`
+- In `AgreementEditForm.hooks.js`, add `const isGrant = agreementType === AGREEMENT_TYPES.GRANT;` (near `isAgreementAA`, ~line 301) and return it. Destructure `isGrant` in the component.
+- In `AgreementEditForm.jsx`, wrap the entire contract control block — `ContractTypeSelect` through the Notes `TextArea` (currently ~lines 421–618) — in `{!isGrant && ( <> … </> )}`. The 4 grant fields (type filter `Select`, Title `Input`, Nickname `Input`, Description `TextArea`) sit above this block and stay rendered. The `AgreementTypeSelect` (partner) and AA blocks are already gated by `selectedAgreementFilter === PARTNER` / `isAgreementAA`, so they won't show for grants.
+- **Clear stale contract state on switch:** extend `handleAgreementFilterChange` (`.hooks.js` ~line 650) so that when switching to GRANT it nulls out contract-only state (`setContractType(null)`, `setServiceReqType(null)`, `changeSelectedProductServiceCode(null)`, `setAgreementReason(null)`, `setAgreementVendor(null)`, project-officer setters, and the team-member/research/special-topic dispatch setters). All these setters are already in the hook's scope. This guarantees a clean 4-field payload if a user picks Contract first, types, then switches to Grant. (Submit gating is already safe via step 1's guards; this is payload hygiene to honor the "only 4 fields" intent.)
+
+### 3. Submit button — no change needed
+`shouldDisableBtn` already reduces to `!agreementTitle || !project_id || !agreementType || res.hasErrors() || uniqueness`. After step 1, a grant with a Title + selected Project (and `agreement_type=GRANT`, set by `handleAgreementFilterChange`) produces no suite errors, so Save Draft enables. Verify, don't modify.
+
+### 4. Persist via Save Draft; guard Continue — `AgreementEditForm.jsx`
+- The create path for this slice is **Save Draft** (`handleDraft` in `.hooks.js` ~line 522): for a new grant (`agreement.id` undefined) it calls `addAgreement(cleanData)`, which the backend routes by `agreement_type=GRANT`, then shows a success alert and redirects to `/agreements`. `cleanAgreementForApi` (`agreement.helpers.js` ~310–336) preserves `name`/`nick_name`/`description`/`agreement_type`/`project_id`. Works unchanged once steps 1–2 let the button enable.
+- **Guard Continue:** `handleContinue` advances to Step 3 (budget lines — out of scope) and does NOT persist a brand-new agreement. For grants in wizard mode, **hide the Continue button** (render only Save Draft) so users can't reach Step 3. Gate the Continue button JSX (~lines 642–651) on `!(isGrant && isWizardMode)`. Do NOT change the shared `handleContinue` logic (review mode reuses it).
+
+### 5. Details-page view — `agreement.helpers.js`
+Add a GRANT entry to `AGREEMENT_TYPE_VISIBLE_FIELDS` so `isFieldVisible` returns true for the grant fields (without it, a GRANT renders no gated fields):
+```js
+[AgreementType.GRANT]: new Set([
+    AgreementFields.DescriptionAndNotes, // gates the Description block (+ empty Notes line)
+    AgreementFields.NickName             // gates the Nickname tag
+]),
+```
+Both `AgreementFields` keys already exist — no enum change. Title and the "Grant" type tag render via always-on blocks. `AgreementDetailsView.jsx` needs no change (verify only). Note: `isNotDevelopedYet(GRANT)` still gates *editing from the table* — that's fine, editing is out of scope; **viewing** a grant's details page is not blocked.
+
+**Known cosmetic item (flag, don't fix here):** the details view always renders Project Officer, Alternate PO, and Team Members regardless of type; for a grant these show `NO_DATA`. Hiding them for grants is a separate change to the unconditional blocks — leave for a follow-up.
+
+### 6. Downstream consumers of a persisted Grant (found in review)
+Once a Grant is creatable, it appears in read-only views that today assume contract-shaped data. Handle these so the slice is coherent:
+
+- **`AgreementsTable/AgreementTableRow.jsx`** (~lines 148–150, 177–201): the expanded row renders Procurement Shop, Subtotal, Fees, Lifetime Obligated, Contract #, Award Type, and Vendor unconditionally. For a grant (no procurement shop, no BLIs) these show "TBD"/`NO_DATA`. **In scope:** gate the contract-only cells so grants don't show empty contract fields (mirror the `isFieldVisible` pattern or a simple `agreement_type` check). The type label cell and title already render fine.
+- **`AgreementMetaAccordion/AgreementMetaAccordion.jsx`** (~line 124): renders `procurement_shop?.abbr` → "TBD" for a grant. **In scope:** gate this line on `isFieldVisible(agreement.agreement_type, AgreementFields.ProcurementShop)` for consistency with the details view.
+- **`DetailsTabs/DetailsTabs.jsx`** (~lines 30–65): the "SCs & Budget Lines" tab renders for grants (because `isNotDevelopedYet(GRANT)` feeds `isDevelopedAgreement`), so a draft grant shows an empty budget-lines tab. **Acceptable for this slice** (budget lines arrive in #5927/#5928) — document as expected-empty; do not hide unless trivial.
+- **Edit-button UX trap (document, don't fix):** `isNotDevelopedYet(GRANT)` returns `true` (`agreement.helpers.js` ~152–162), so the Edit button stays disabled in the table/details for grants. A user can *create* a grant but not *edit* it until a later slice. This is consistent with "editing out of scope" — call it out explicitly in the PR description so it's not read as a bug.
+
+---
+
+## Tests
+- **Suite unit test** for `AgreementEditFormSuite.js`: `suite.run({ agreement_type: "GRANT", name: "X", project_id: 5 })` → `hasErrors()` is `false`; a contract payload still fails its contract tests (no regression).
+- **Form render test:** with Grant selected, assert the contract controls (ContractType, ServiceReqType, ProductServiceCode, ProcurementShop, Reason/Vendor, PO combo boxes, TeamMember, Notes) are absent and Title/Nickname/Description are present; Continue button hidden, Save Draft enabled with Title + project set.
+- **Details-view test:** a GRANT agreement renders Description + Nickname + "Grant" type tag and NOT contract-only tags.
+- **Table + accordion tests:** a GRANT row (with `procurement_shop = null`, no BLIs) renders without contract-only cells and without a "TBD" procurement shop in `AgreementMetaAccordion`. Extend the existing GRANT fixtures in `AgreementsTable.test.js` / `AgreementMetaAccordion.test.jsx`.
+- **Update** `AgreementEditForm.hooks.test.js` for the new `isGrant` + `handleAgreementFilterChange` clearing behavior. Grep `src/**/*.test.*` for `"This Agreement type is not yet available"` / `AGREEMENT_TYPES.GRANT` and update any assertion that expected GRANT to be blocked.
+- **E2E:** add `frontend/cypress/e2e/createGrantAgreement.cy.js` mirroring `createAgreement.cy.js`: Step 1 pick project → Continue; Step 2 select `GRANT`, type Title + Description, assert contract controls absent + `save-draft-btn` enabled, click Save Draft, assert success alert + redirect; optionally open the new agreement's details page and assert Description/Nickname/"Grant" tags.
+
+## Verification
+1. `cd frontend && bun run test --watch=false` — unit tests green (90% coverage gate).
+2. `bun run lint --fix && bun run format`.
+3. Manual (Docker stack up): `/agreements/create` → pick a Project → Continue → select **Grant** → confirm only the 4 fields show → enter Title + Description → **Save Draft** → success alert + redirect to `/agreements`. Open the new grant's details page → Title, Nickname, Description, and "Grant" type tag display.
+4. Regression: create a Contract the same way — all contract fields still show and validate; Continue still works.
+5. E2E: `bun run test:e2e` (or the `/e2e-tests` skill) including the new grant spec.
+
+## File-by-file change list
+1. `AgreementEditFormSuite.js` — unblock GRANT; `isGrant` guard on 8 contract tests.
+2. `AgreementEditForm.hooks.js` — add/return `isGrant`; clear contract state in `handleAgreementFilterChange` on GRANT.
+3. `AgreementEditForm.jsx` — destructure `isGrant`; wrap contract block in `{!isGrant && …}`; hide Continue for grants in wizard mode.
+4. `agreement.helpers.js` — add `AgreementType.GRANT` entry to `AGREEMENT_TYPE_VISIBLE_FIELDS`.
+5. `AgreementsTable/AgreementTableRow.jsx` — gate contract-only expanded-row cells so grants don't show empty contract fields.
+6. `AgreementMetaAccordion/AgreementMetaAccordion.jsx` — gate the procurement-shop line on `isFieldVisible(..., AgreementFields.ProcurementShop)`.
+7. Tests — suite test, form render test, details-view test, table/accordion grant-fixture assertions, `AgreementEditForm.hooks.test.js` updates, `cypress/e2e/createGrantAgreement.cy.js`.
+
+*(Not code: note the create-but-can't-edit `isNotDevelopedYet(GRANT)` behavior and the expected-empty budget-lines tab in the PR description.)*

--- a/frontend/cypress.config.ci.js
+++ b/frontend/cypress.config.ci.js
@@ -31,6 +31,7 @@ export default defineConfig({
             "cypress/e2e/createAgreementWithValidations.cy.js",
             "cypress/e2e/createAAAgreement.cy.js",
             "cypress/e2e/createBLIForAgreement.cy.js",
+            "cypress/e2e/createGrantAgreement.cy.js",
             "cypress/e2e/createResearchProject.cy.js",
             "cypress/e2e/declineChangeRequestsAtAgreementLevel.cy.js",
             "cypress/e2e/editAgreement.cy.js",

--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -28,6 +28,7 @@ export default defineConfig({
             "cypress/e2e/createAgreement.cy.js",
             "cypress/e2e/createAgreementWithValidations.cy.js",
             "cypress/e2e/createBLIForAgreement.cy.js",
+            "cypress/e2e/createGrantAgreement.cy.js",
             "cypress/e2e/createResearchProject.cy.js",
             "cypress/e2e/declineChangeRequestsAtAgreementLevel.cy.js",
             "cypress/e2e/editAgreement.cy.js",

--- a/frontend/cypress/e2e/agreementDetails.cy.js
+++ b/frontend/cypress/e2e/agreementDetails.cy.js
@@ -187,13 +187,14 @@ describe("agreement details", () => {
         cy.get("#toggleDraftBLIs").should("exist");
     });
 
-    it("Grants load with temp banner", () => {
+    it("Grant type agreement loads with details", () => {
         cy.visit("/agreements/3");
-        cy.get('[data-cy="alert"]').contains(
-            "Agreements that are grants, other partner agreements (IAAs, IPAs, IDDAs), or direct obligations have not been developed yet, but are coming soon."
-        );
-        cy.get('[data-cy="close-alert"]').click();
-        cy.get("#edit").should("not.exist");
+        cy.get("h1").contains("Grant #1: Early Care and Education Leadership Study (ExCELS)");
+        cy.get('[data-cy="agreement-description"]').contains("Test description");
+        cy.get('[data-cy="agreement-nickname-tag"]').contains(NO_DATA);
+        cy.get('[data-cy="agreement-type-tag"]').contains("Grant");
+        cy.get('[data-cy="contract-number-tag"]').should("not.exist");
+        cy.get('[data-cy="procurement-shop-tag"]').should("not.exist");
     });
 
     it("IAAs load with temp banner", () => {

--- a/frontend/cypress/e2e/agreementList.cy.js
+++ b/frontend/cypress/e2e/agreementList.cy.js
@@ -315,10 +315,10 @@ describe("Agreement List", () => {
     it("Should not allow user to edit an agreement that is not developed", () => {
         cy.get("button").contains("Filter").click();
 
-        // Select an agreement type that is not developed yet (Grant)
+        // Select an agreement type that is not developed yet (Direct Obligation)
         cy.get(".agreement-type-combobox__control").click();
         cy.get(".agreement-type-combobox__menu").should("be.visible");
-        cy.get(".agreement-type-combobox__menu").contains("Grant").click();
+        cy.get(".agreement-type-combobox__menu").contains("Direct Obligation").click();
 
         // Apply the filter
         cy.get("button").contains("Apply").click();
@@ -328,7 +328,7 @@ describe("Agreement List", () => {
 
         // Hover to reveal action icons and confirm edit is disabled
         cy.get("tbody tr[data-testid^='agreement-table-row-']").first().as("notDevelopedRow");
-        cy.get("@notDevelopedRow").find('[data-cy="agreement-type"]').should("have.text", "Grant");
+        cy.get("@notDevelopedRow").find('[data-cy="agreement-type"]').should("have.text", "Direct Obligation");
         cy.get("@notDevelopedRow").trigger("mouseover", { force: true });
         cy.get("tbody tr[data-testid^='agreement-table-row-']")
             .first()

--- a/frontend/cypress/e2e/createGrantAgreement.cy.js
+++ b/frontend/cypress/e2e/createGrantAgreement.cy.js
@@ -49,7 +49,7 @@ it("can create a Grant agreement", () => {
 
     // Save the draft
     cy.get("[data-cy='save-draft-btn']").click();
-    cy.wait("@postAgreement").its("response.statusCode").should("eq", 200);
+    cy.wait("@postAgreement").its("response.statusCode").should("eq", 201);
 
     // Should show success alert and redirect to /agreements
     cy.get("[data-cy='alert']").should("contain", "Agreement Draft Saved");

--- a/frontend/cypress/e2e/createGrantAgreement.cy.js
+++ b/frontend/cypress/e2e/createGrantAgreement.cy.js
@@ -1,0 +1,57 @@
+/// <reference types="cypress" />
+
+import { terminalLog, testLogin } from "./utils";
+
+beforeEach(() => {
+    testLogin("system-owner");
+    cy.visit("/agreements/create");
+});
+
+afterEach(() => {
+    cy.injectAxe();
+    cy.checkA11y(null, null, terminalLog);
+});
+
+it("can create a Grant agreement", () => {
+    cy.intercept("POST", "**/agreements").as("postAgreement");
+
+    // Step One - Select a Project
+    cy.get("#project-combobox-input").type("Human Services Interoperability Support{enter}");
+    cy.get("#continue").click();
+
+    // Step Two - Create Agreement
+    cy.get("[data-cy='agreement-type']").should("not.exist");
+    cy.get("[data-cy='save-draft-btn']").should("be.disabled");
+
+    // Select Grant type
+    cy.get("#agreement-type-filter").select("GRANT");
+
+    // Contract-only controls should not be visible
+    cy.get("#contract-type").should("not.exist");
+    cy.get("#service_requirement_type").should("not.exist");
+    cy.get("#product_service_code_id").should("not.exist");
+    cy.get("#agreement_reason").should("not.exist");
+    cy.get("#project-officer-combobox-input").should("not.exist");
+
+    // Continue button should not be visible for grants in wizard mode
+    cy.get("[data-cy='continue-btn']").should("not.exist");
+
+    // Save Draft should still be disabled (no title yet)
+    cy.get("[data-cy='save-draft-btn']").should("be.disabled");
+
+    // Enter required grant fields
+    cy.get("#name").type("E2E Grant Agreement Test");
+    cy.get("#nick_name").type("GRANT-TEST");
+    cy.get("#description").type("This is a test grant agreement description.");
+
+    // Save Draft should now be enabled
+    cy.get("[data-cy='save-draft-btn']").should("not.be.disabled");
+
+    // Save the draft
+    cy.get("[data-cy='save-draft-btn']").click();
+    cy.wait("@postAgreement").its("response.statusCode").should("eq", 200);
+
+    // Should show success alert and redirect to /agreements
+    cy.get("[data-cy='alert']").should("contain", "Agreement Draft Saved");
+    cy.url().should("include", "/agreements");
+});

--- a/frontend/cypress/e2e/createGrantAgreement.cy.js
+++ b/frontend/cypress/e2e/createGrantAgreement.cy.js
@@ -41,7 +41,7 @@ it("can create a Grant agreement", () => {
 
     // Enter required grant fields
     cy.get("#name").type("E2E Grant Agreement Test");
-    cy.get("#nick_name").type("GRANT-TEST");
+    cy.get("#nickname").type("GRANT-TEST");
     cy.get("#description").type("This is a test grant agreement description.");
 
     // Save Draft should now be enabled

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
@@ -299,6 +299,10 @@ const useAgreementEditForm = (
 
     const vendorDisabled = agreementReason === "NEW_REQ" || agreementReason === null || agreementReason === "0";
     const isAgreementAA = agreementType === AGREEMENT_TYPES.AA;
+    // REVIEW: NEW — mirrors the isAgreementAA pattern directly above.
+    // Consumed by AgreementEditForm.jsx to hide contract controls and by shouldDisableBtn (indirectly,
+    // via the suite's isGrant guards letting the button enable with only name + project_id).
+    const isGrant = agreementType === AGREEMENT_TYPES.GRANT;
     const shouldDisableBtn =
         !agreementTitle ||
         !agreement?.project_id ||
@@ -647,12 +651,30 @@ const useAgreementEditForm = (
         return "Disabled";
     };
 
+    // REVIEW: CHANGED — added GRANT branch that clears all contract-only state.
+    // This is payload hygiene: if a user selects Contract, starts typing, then switches to Grant,
+    // the stale contract values (contract_type, vendor, PO, etc.) would otherwise be sent to the API.
+    // The suite guards already prevent those fields from blocking Submit, but the payload would still
+    // contain junk. Clearing here ensures a clean 4-field payload (name, nick_name, description,
+    // agreement_type + project_id) regardless of prior user interaction.
+    // Note: team_members uses UPDATE_AGREEMENT (not a dedicated SET_TEAM_MEMBERS) because the reducer
+    // only has ADD_TEAM_MEMBER and REMOVE_TEAM_MEMBER; UPDATE_AGREEMENT sets the key directly.
     const handleAgreementFilterChange = (value) => {
         setSelectedAgreementFilter(value);
         if (value === AGREEMENT_TYPES.CONTRACT) {
             setAgreementType(AGREEMENT_TYPES.CONTRACT);
         } else if (value === AGREEMENT_TYPES.GRANT) {
             setAgreementType(AGREEMENT_TYPES.GRANT);
+            setContractType(null);
+            setServiceReqType(null);
+            changeSelectedProductServiceCode(null);
+            setAgreementReason(null);
+            setAgreementVendor(null);
+            changeSelectedProjectOfficer(null);
+            changeSelectedAlternateProjectOfficer(null);
+            dispatch({ type: "UPDATE_AGREEMENT", key: "team_members", value: [] });
+            dispatch({ type: "SET_RESEARCH_METHODOLOGIES", payload: [] });
+            dispatch({ type: "SET_SPECIAL_TOPICS", payload: [] });
         } else if (value === AGREEMENT_TYPES.DIRECT_OBLIGATION) {
             setAgreementType(AGREEMENT_TYPES.DIRECT_OBLIGATION);
         } else {
@@ -694,6 +716,7 @@ const useAgreementEditForm = (
         vendorDisabled,
         immutableFields,
         isAgreementAA,
+        isGrant, // REVIEW: NEW — added to return so AgreementEditForm.jsx can destructure it
         isSuperUser,
         shouldDisableBtn,
         changeSelectedProject,

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
@@ -664,12 +664,14 @@ const useAgreementEditForm = (
         if (value === AGREEMENT_TYPES.CONTRACT) {
             setAgreementType(AGREEMENT_TYPES.CONTRACT);
         } else if (value === AGREEMENT_TYPES.GRANT) {
+            suite.reset();
             setAgreementType(AGREEMENT_TYPES.GRANT);
             setContractType(null);
             setServiceReqType(null);
             changeSelectedProductServiceCode(null);
             setAgreementReason(null);
             setAgreementVendor(null);
+            setAgreementNotes(null);
             changeSelectedProjectOfficer(null);
             changeSelectedAlternateProjectOfficer(null);
             dispatch({ type: "UPDATE_AGREEMENT", key: "team_members", value: [] });

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.test.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.test.js
@@ -582,6 +582,7 @@ describe("useAgreementEditForm - isGrant and handleAgreementFilterChange", () =>
         const setServiceReqTypeMock = vi.fn();
         const setAgreementReasonMock = vi.fn();
         const setAgreementVendorMock = vi.fn();
+        const setAgreementNotesMock = vi.fn();
         const setAgreementTypeMock = vi.fn();
         const setSelectedProductServiceCodeMock = vi.fn();
         const setSelectedProjectOfficerMock = vi.fn();
@@ -592,6 +593,7 @@ describe("useAgreementEditForm - isGrant and handleAgreementFilterChange", () =>
             if (key === "service_requirement_type") return setServiceReqTypeMock;
             if (key === "agreement_reason") return setAgreementReasonMock;
             if (key === "vendor") return setAgreementVendorMock;
+            if (key === "notes") return setAgreementNotesMock;
             if (key === "agreement_type") return setAgreementTypeMock;
             return vi.fn();
         });
@@ -614,6 +616,10 @@ describe("useAgreementEditForm - isGrant and handleAgreementFilterChange", () =>
         expect(setServiceReqTypeMock).toHaveBeenCalledWith(null);
         expect(setAgreementReasonMock).toHaveBeenCalledWith(null);
         expect(setAgreementVendorMock).toHaveBeenCalledWith(null);
+        expect(setAgreementNotesMock).toHaveBeenCalledWith(null);
+        expect(setSelectedProductServiceCodeMock).toHaveBeenCalledWith(null);
+        expect(setSelectedProjectOfficerMock).toHaveBeenCalledWith(null);
+        expect(setSelectedAlternateProjectOfficerMock).toHaveBeenCalledWith(null);
         expect(dispatchMock).toHaveBeenCalledWith({ type: "UPDATE_AGREEMENT", key: "team_members", value: [] });
         expect(dispatchMock).toHaveBeenCalledWith({ type: "SET_RESEARCH_METHODOLOGIES", payload: [] });
         expect(dispatchMock).toHaveBeenCalledWith({ type: "SET_SPECIAL_TOPICS", payload: [] });

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.test.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.test.js
@@ -551,6 +551,75 @@ describe("useAgreementEditForm - handleDraft creates new agreements", () => {
     });
 });
 
+describe("useAgreementEditForm - isGrant and handleAgreementFilterChange", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useLocationMock.mockReturnValue({ pathname: "/agreements/create" });
+        useSelectorMock.mockReturnValue(false);
+        hasStateChangedMock.mockReturnValue(false);
+        useEditAgreementDispatchMock.mockReturnValue(vi.fn());
+        useSetStateMock.mockReturnValue(vi.fn());
+        useUpdateAgreementMock.mockReturnValue(vi.fn());
+    });
+
+    it("isGrant is true when agreement_type is GRANT", () => {
+        useEditAgreementMock.mockReturnValue(makeEditState({ agreement_type: "GRANT" }));
+        const { result } = renderUseAgreementEditForm();
+        expect(result.current.isGrant).toBe(true);
+    });
+
+    it("isGrant is false when agreement_type is CONTRACT", () => {
+        useEditAgreementMock.mockReturnValue(makeEditState({ agreement_type: "CONTRACT" }));
+        const { result } = renderUseAgreementEditForm();
+        expect(result.current.isGrant).toBe(false);
+    });
+
+    it("handleAgreementFilterChange clears contract-only state when switching to GRANT", () => {
+        const dispatchMock = vi.fn();
+        useEditAgreementDispatchMock.mockReturnValue(dispatchMock);
+
+        const setContractTypeMock = vi.fn();
+        const setServiceReqTypeMock = vi.fn();
+        const setAgreementReasonMock = vi.fn();
+        const setAgreementVendorMock = vi.fn();
+        const setAgreementTypeMock = vi.fn();
+        const setSelectedProductServiceCodeMock = vi.fn();
+        const setSelectedProjectOfficerMock = vi.fn();
+        const setSelectedAlternateProjectOfficerMock = vi.fn();
+
+        useUpdateAgreementMock.mockImplementation((key) => {
+            if (key === "contract_type") return setContractTypeMock;
+            if (key === "service_requirement_type") return setServiceReqTypeMock;
+            if (key === "agreement_reason") return setAgreementReasonMock;
+            if (key === "vendor") return setAgreementVendorMock;
+            if (key === "agreement_type") return setAgreementTypeMock;
+            return vi.fn();
+        });
+        useSetStateMock.mockImplementation((key) => {
+            if (key === "selected_product_service_code") return setSelectedProductServiceCodeMock;
+            if (key === "selected_project_officer") return setSelectedProjectOfficerMock;
+            if (key === "selected_alternate_project_officer") return setSelectedAlternateProjectOfficerMock;
+            return vi.fn();
+        });
+
+        useEditAgreementMock.mockReturnValue(makeEditState({ agreement_type: "CONTRACT" }));
+        const { result } = renderUseAgreementEditForm();
+
+        act(() => {
+            result.current.handleAgreementFilterChange("GRANT");
+        });
+
+        expect(setAgreementTypeMock).toHaveBeenCalledWith("GRANT");
+        expect(setContractTypeMock).toHaveBeenCalledWith(null);
+        expect(setServiceReqTypeMock).toHaveBeenCalledWith(null);
+        expect(setAgreementReasonMock).toHaveBeenCalledWith(null);
+        expect(setAgreementVendorMock).toHaveBeenCalledWith(null);
+        expect(dispatchMock).toHaveBeenCalledWith({ type: "UPDATE_AGREEMENT", key: "team_members", value: [] });
+        expect(dispatchMock).toHaveBeenCalledWith({ type: "SET_RESEARCH_METHODOLOGIES", payload: [] });
+        expect(dispatchMock).toHaveBeenCalledWith({ type: "SET_SPECIAL_TOPICS", payload: [] });
+    });
+});
+
 describe("useAgreementEditForm - runValidate project_officer validation", () => {
     beforeEach(() => {
         vi.clearAllMocks();

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -102,6 +102,7 @@ const AgreementEditForm = ({
         vendorDisabled,
         immutableFields,
         isAgreementAA,
+        isGrant, // REVIEW: NEW — destructured from hook; used to hide contract block and Continue button
         isSuperUser,
         shouldDisableBtn,
         changeSelectedProject,
@@ -418,204 +419,213 @@ const AgreementEditForm = ({
                     )}
                 </>
             )}
-            <ContractTypeSelect
-                messages={res.getErrors("contract-type")}
-                className={`margin-top-3 ${cn("contract-type")}`}
-                value={contractType}
-                onChange={(name, value) => {
-                    setContractType(value);
-                    runValidate(name, value, { contract_type: value });
-                }}
-                isDisabled={isFieldDisabled(
-                    AgreementFields.ContractType,
-                    immutableFields,
-                    isSuperUser,
-                    isAgreementAwarded
-                )}
-                tooltipMsg={awardedImmutableFieldsTooltipMsg}
-            />
-            <ServiceReqTypeSelect
-                messages={res.getErrors("service_requirement_type")}
-                className={`margin-top-3 ${cn("service_requirement_type")}`}
-                isRequired={true}
-                value={serviceReqType}
-                onChange={(name, value) => {
-                    setServiceReqType(value);
-                    runValidate(name, value);
-                }}
-                isDisabled={isFieldDisabled(
-                    AgreementFields.ServiceRequirementType,
-                    immutableFields,
-                    isSuperUser,
-                    isAgreementAwarded
-                )}
-                tooltipMsg={awardedImmutableFieldsTooltipMsg}
-            />
-            <ProductServiceCodeSelect
-                name="product_service_code_id"
-                label="Product Service Code"
-                messages={res.getErrors("product_service_code_id")}
-                className={cn("product_service_code_id")}
-                selectedProductServiceCode={selectedProductServiceCode || ""}
-                codes={productServiceCodes}
-                onChange={(name, value) => {
-                    changeSelectedProductServiceCode(productServiceCodes[value - 1]);
-                    if (isReviewMode) {
-                        runValidate(name, value);
-                    }
-                }}
-                isDisabled={isFieldDisabled(
-                    AgreementFields.ProductServiceCode,
-                    immutableFields,
-                    isSuperUser,
-                    isAgreementAwarded
-                )}
-                tooltipMsg={awardedImmutableFieldsTooltipMsg}
-            />
-            {selectedProductServiceCode &&
-                selectedProductServiceCode.naics &&
-                selectedProductServiceCode.support_code && (
-                    <SummaryBox
-                        selectedProductServiceCode={selectedProductServiceCode}
-                        width="19.5625rem"
-                        minHeight="4.375rem"
-                        className="margin-top-4"
-                    />
-                )}
-            <div className="margin-top-3">
-                <ProcurementShopSelectWithFee
-                    name="procurement-shop-select"
-                    label="Procurement Shop"
-                    className={cn("procurement-shop-select")}
-                    messages={res.getErrors("procurement-shop-select")}
-                    selectedProcurementShop={selectedProcurementShop}
-                    onChangeSelectedProcurementShop={(procurementShop) => {
-                        handleOnChangeSelectedProcurementShop(procurementShop);
-                        if (isReviewMode) {
-                            runValidate("procurement-shop-select", procurementShop);
-                        }
-                    }}
-                    isDisabled={isProcurementShopDisabled}
-                    disabledMessage={disabledMessage()}
-                />
-            </div>
-            <div className="display-flex margin-top-3">
-                <AgreementReasonSelect
-                    name="agreement_reason"
-                    label="Reason for Agreement"
-                    messages={res.getErrors("agreement_reason")}
-                    className={cn("agreement_reason")}
-                    selectedAgreementReason={agreementReason}
-                    onChange={(name, value) => {
-                        setAgreementVendor(null);
-                        setAgreementReason(value);
-                        if (isReviewMode) {
-                            runValidate(name, value);
-                            runValidate("vendor", null, { agreement_reason: value });
-                        }
-                    }}
-                    isDisabled={isFieldDisabled(
-                        AgreementFields.AgreementReason,
-                        immutableFields,
-                        isSuperUser,
-                        isAgreementAwarded
-                    )}
-                    tooltipMsg={awardedImmutableFieldsTooltipMsg}
-                />
-                <fieldset
-                    className={`usa-fieldset margin-top-0 margin-left-4 ${vendorDisabled && "text-disabled"}`}
-                    disabled={
-                        vendorDisabled ||
-                        isFieldDisabled(
-                            AgreementFields.AgreementReason,
+            {/* REVIEW: NEW — wraps ContractTypeSelect through Notes TextArea (the entire contract-only
+                control block). When Grant is selected none of these render, so the form shows only
+                the 4 grant fields: type filter Select, Title Input, Nickname Input, Description TextArea.
+                The AA controls above are already gated by selectedAgreementFilter === PARTNER / isAgreementAA
+                so they also won't appear for grants. */}
+            {!isGrant && (
+                <>
+                    <ContractTypeSelect
+                        messages={res.getErrors("contract-type")}
+                        className={`margin-top-3 ${cn("contract-type")}`}
+                        value={contractType}
+                        onChange={(name, value) => {
+                            setContractType(value);
+                            runValidate(name, value, { contract_type: value });
+                        }}
+                        isDisabled={isFieldDisabled(
+                            AgreementFields.ContractType,
                             immutableFields,
                             isSuperUser,
                             isAgreementAwarded
-                        )
-                    }
-                >
-                    <Input
-                        name="vendor"
-                        label="Vendor"
-                        messages={res.getErrors("vendor")}
-                        className={`margin-top-0 ${cn("vendor")}`}
-                        value={agreementVendor || ""}
+                        )}
+                        tooltipMsg={awardedImmutableFieldsTooltipMsg}
+                    />
+                    <ServiceReqTypeSelect
+                        messages={res.getErrors("service_requirement_type")}
+                        className={`margin-top-3 ${cn("service_requirement_type")}`}
+                        isRequired={true}
+                        value={serviceReqType}
                         onChange={(name, value) => {
-                            setAgreementVendor(value);
+                            setServiceReqType(value);
+                            runValidate(name, value);
+                        }}
+                        isDisabled={isFieldDisabled(
+                            AgreementFields.ServiceRequirementType,
+                            immutableFields,
+                            isSuperUser,
+                            isAgreementAwarded
+                        )}
+                        tooltipMsg={awardedImmutableFieldsTooltipMsg}
+                    />
+                    <ProductServiceCodeSelect
+                        name="product_service_code_id"
+                        label="Product Service Code"
+                        messages={res.getErrors("product_service_code_id")}
+                        className={cn("product_service_code_id")}
+                        selectedProductServiceCode={selectedProductServiceCode || ""}
+                        codes={productServiceCodes}
+                        onChange={(name, value) => {
+                            changeSelectedProductServiceCode(productServiceCodes[value - 1]);
                             if (isReviewMode) {
                                 runValidate(name, value);
                             }
                         }}
+                        isDisabled={isFieldDisabled(
+                            AgreementFields.ProductServiceCode,
+                            immutableFields,
+                            isSuperUser,
+                            isAgreementAwarded
+                        )}
+                        tooltipMsg={awardedImmutableFieldsTooltipMsg}
                     />
-                </fieldset>
-            </div>
-            <div
-                className="margin-top-3"
-                data-cy="research-and-special-topics"
-            >
-                <ResearchMethodologyComboBox
-                    legendClassName="usa-label"
-                    overrideStyles={{ width: "30em" }}
-                    selectedResearchMethodologies={researchMethodologies}
-                    setSelectedResearchMethodologies={setResearchMethodology}
-                />
-                <SpecialTopicComboBox
-                    legendClassName="usa-label"
-                    overrideStyles={{ width: "30em" }}
-                    selectedSpecialTopics={specialTopics}
-                    setSelectedSpecialTopics={setSpecialTopics}
-                />
-            </div>
-            <div
-                className="display-flex margin-top-3"
-                data-cy="cor-combo-boxes"
-            >
-                <ProjectOfficerComboBox
-                    selectedProjectOfficer={selectedProjectOfficer}
-                    setSelectedProjectOfficer={changeSelectedProjectOfficer}
-                    legendClassname="usa-label margin-top-0 margin-bottom-1"
-                    messages={res.getErrors("project_officer")}
-                    onChange={(name, value) => {
-                        if (isReviewMode) {
-                            runValidate(name, value, { project_officer_id: value });
-                        }
-                    }}
-                    overrideStyles={{ width: "15em" }}
-                    label={convertCodeForDisplay("projectOfficer", agreementType)}
-                />
-                <ProjectOfficerComboBox
-                    selectedProjectOfficer={selectedAlternateProjectOfficer}
-                    setSelectedProjectOfficer={changeSelectedAlternateProjectOfficer}
-                    className="margin-left-4"
-                    legendClassname="usa-label margin-top-0 margin-bottom-1"
-                    overrideStyles={{ width: "15em" }}
-                    label={`Alternate ${convertCodeForDisplay("projectOfficer", agreementType)}`}
-                />
-            </div>
-            <div className="margin-top-3 width-card-lg">
-                <TeamMemberComboBox
-                    legendClassname="usa-label margin-top-0 margin-bottom-1"
-                    selectedTeamMembers={selectedTeamMembers}
-                    selectedProjectOfficer={selectedProjectOfficer}
-                    selectedAlternateProjectOfficer={selectedAlternateProjectOfficer}
-                    setSelectedTeamMembers={setSelectedTeamMembers}
-                    overrideStyles={{ width: "15em" }}
-                />
-            </div>
-            <h3 className="font-sans-sm text-semibold">Team Members Added</h3>
-            <TeamMemberList
-                selectedTeamMembers={selectedTeamMembers}
-                removeTeamMember={removeTeamMember}
-            />
-            <TextArea
-                name="agreementNotes"
-                label="Notes (optional)"
-                maxLength={500}
-                messages={res.getErrors("agreementNotes")}
-                className={cn("agreementNotes")}
-                value={agreementNotes || ""}
-                onChange={(name, value) => setAgreementNotes(value)}
-            />
+                    {selectedProductServiceCode &&
+                        selectedProductServiceCode.naics &&
+                        selectedProductServiceCode.support_code && (
+                            <SummaryBox
+                                selectedProductServiceCode={selectedProductServiceCode}
+                                width="19.5625rem"
+                                minHeight="4.375rem"
+                                className="margin-top-4"
+                            />
+                        )}
+                    <div className="margin-top-3">
+                        <ProcurementShopSelectWithFee
+                            name="procurement-shop-select"
+                            label="Procurement Shop"
+                            className={cn("procurement-shop-select")}
+                            messages={res.getErrors("procurement-shop-select")}
+                            selectedProcurementShop={selectedProcurementShop}
+                            onChangeSelectedProcurementShop={(procurementShop) => {
+                                handleOnChangeSelectedProcurementShop(procurementShop);
+                                if (isReviewMode) {
+                                    runValidate("procurement-shop-select", procurementShop);
+                                }
+                            }}
+                            isDisabled={isProcurementShopDisabled}
+                            disabledMessage={disabledMessage()}
+                        />
+                    </div>
+                    <div className="display-flex margin-top-3">
+                        <AgreementReasonSelect
+                            name="agreement_reason"
+                            label="Reason for Agreement"
+                            messages={res.getErrors("agreement_reason")}
+                            className={cn("agreement_reason")}
+                            selectedAgreementReason={agreementReason}
+                            onChange={(name, value) => {
+                                setAgreementVendor(null);
+                                setAgreementReason(value);
+                                if (isReviewMode) {
+                                    runValidate(name, value);
+                                    runValidate("vendor", null, { agreement_reason: value });
+                                }
+                            }}
+                            isDisabled={isFieldDisabled(
+                                AgreementFields.AgreementReason,
+                                immutableFields,
+                                isSuperUser,
+                                isAgreementAwarded
+                            )}
+                            tooltipMsg={awardedImmutableFieldsTooltipMsg}
+                        />
+                        <fieldset
+                            className={`usa-fieldset margin-top-0 margin-left-4 ${vendorDisabled && "text-disabled"}`}
+                            disabled={
+                                vendorDisabled ||
+                                isFieldDisabled(
+                                    AgreementFields.AgreementReason,
+                                    immutableFields,
+                                    isSuperUser,
+                                    isAgreementAwarded
+                                )
+                            }
+                        >
+                            <Input
+                                name="vendor"
+                                label="Vendor"
+                                messages={res.getErrors("vendor")}
+                                className={`margin-top-0 ${cn("vendor")}`}
+                                value={agreementVendor || ""}
+                                onChange={(name, value) => {
+                                    setAgreementVendor(value);
+                                    if (isReviewMode) {
+                                        runValidate(name, value);
+                                    }
+                                }}
+                            />
+                        </fieldset>
+                    </div>
+                    <div
+                        className="margin-top-3"
+                        data-cy="research-and-special-topics"
+                    >
+                        <ResearchMethodologyComboBox
+                            legendClassName="usa-label"
+                            overrideStyles={{ width: "30em" }}
+                            selectedResearchMethodologies={researchMethodologies}
+                            setSelectedResearchMethodologies={setResearchMethodology}
+                        />
+                        <SpecialTopicComboBox
+                            legendClassName="usa-label"
+                            overrideStyles={{ width: "30em" }}
+                            selectedSpecialTopics={specialTopics}
+                            setSelectedSpecialTopics={setSpecialTopics}
+                        />
+                    </div>
+                    <div
+                        className="display-flex margin-top-3"
+                        data-cy="cor-combo-boxes"
+                    >
+                        <ProjectOfficerComboBox
+                            selectedProjectOfficer={selectedProjectOfficer}
+                            setSelectedProjectOfficer={changeSelectedProjectOfficer}
+                            legendClassname="usa-label margin-top-0 margin-bottom-1"
+                            messages={res.getErrors("project_officer")}
+                            onChange={(name, value) => {
+                                if (isReviewMode) {
+                                    runValidate(name, value, { project_officer_id: value });
+                                }
+                            }}
+                            overrideStyles={{ width: "15em" }}
+                            label={convertCodeForDisplay("projectOfficer", agreementType)}
+                        />
+                        <ProjectOfficerComboBox
+                            selectedProjectOfficer={selectedAlternateProjectOfficer}
+                            setSelectedProjectOfficer={changeSelectedAlternateProjectOfficer}
+                            className="margin-left-4"
+                            legendClassname="usa-label margin-top-0 margin-bottom-1"
+                            overrideStyles={{ width: "15em" }}
+                            label={`Alternate ${convertCodeForDisplay("projectOfficer", agreementType)}`}
+                        />
+                    </div>
+                    <div className="margin-top-3 width-card-lg">
+                        <TeamMemberComboBox
+                            legendClassname="usa-label margin-top-0 margin-bottom-1"
+                            selectedTeamMembers={selectedTeamMembers}
+                            selectedProjectOfficer={selectedProjectOfficer}
+                            selectedAlternateProjectOfficer={selectedAlternateProjectOfficer}
+                            setSelectedTeamMembers={setSelectedTeamMembers}
+                            overrideStyles={{ width: "15em" }}
+                        />
+                    </div>
+                    <h3 className="font-sans-sm text-semibold">Team Members Added</h3>
+                    <TeamMemberList
+                        selectedTeamMembers={selectedTeamMembers}
+                        removeTeamMember={removeTeamMember}
+                    />
+                    <TextArea
+                        name="agreementNotes"
+                        label="Notes (optional)"
+                        maxLength={500}
+                        messages={res.getErrors("agreementNotes")}
+                        className={cn("agreementNotes")}
+                        value={agreementNotes || ""}
+                        onChange={(name, value) => setAgreementNotes(value)}
+                    />
+                </>
+            )}
             {!hideFooterButtons && (
                 <div className="grid-row flex-justify margin-top-8">
                     {isWizardMode ? <GoBackButton handleGoBack={goBack} /> : <div />}
@@ -639,16 +649,24 @@ const AgreementEditForm = ({
                                 Save Draft
                             </button>
                         )}
-                        <button
-                            type="button"
-                            id="continue"
-                            className="usa-button"
-                            onClick={handleContinue}
-                            disabled={shouldDisableBtn}
-                            data-cy="continue-btn"
-                        >
-                            {isWizardMode ? "Continue" : "Save Changes"}
-                        </button>
+                        {/* REVIEW: NEW — hides Continue in wizard mode for grants.
+                            Continue advances to Step 3 (budget lines, out of scope for this slice)
+                            and does NOT persist a new agreement, so reaching it without a Save Draft
+                            would lose the grant. In non-wizard (edit/review) mode Continue renders
+                            as "Save Changes" and must still be available, so the gate is
+                            !(isGrant && isWizardMode) rather than just !isGrant. */}
+                        {!(isGrant && isWizardMode) && (
+                            <button
+                                type="button"
+                                id="continue"
+                                className="usa-button"
+                                onClick={handleContinue}
+                                disabled={shouldDisableBtn}
+                                data-cy="continue-btn"
+                            >
+                                {isWizardMode ? "Continue" : "Save Changes"}
+                            </button>
+                        )}
                     </div>
                 </div>
             )}

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.js
@@ -6,39 +6,53 @@ const suite = create((data = {}, fieldName) => {
         only(fieldName);
     }
 
+    // REVIEW: NEW — derived flag used to skip contract-only tests below.
+    // Placed after the only() call so it's computed every run regardless of which field is being validated.
+    const isGrant = data.agreement_type === AGREEMENT_TYPES.GRANT;
+
     test("agreement_type", "This is required information", () => {
         enforce(data.agreement_type).notEquals("-Select Agreement Type-");
     });
+    // REVIEW: CHANGED — removed `.notEquals(AGREEMENT_TYPES.GRANT)` from both "not yet available" tests.
+    // IAA and DIRECT_OBLIGATION remain blocked. The test registrations are kept intact (not deleted)
+    // so vest's error-key registry stays stable — no label/convertCodeForDisplay changes needed.
     test("agreement-type-filter", "This Agreement type is not yet available", () => {
         enforce(data["agreement-type-filter"]).notEquals(AGREEMENT_TYPES.IAA);
-        enforce(data["agreement-type-filter"]).notEquals(AGREEMENT_TYPES.GRANT);
         enforce(data["agreement-type-filter"]).notEquals(AGREEMENT_TYPES.DIRECT_OBLIGATION);
     });
     test("agreement_type", "This Agreement type is not yet available", () => {
         enforce(data.agreement_type).notEquals(AGREEMENT_TYPES.IAA);
-        enforce(data.agreement_type).notEquals(AGREEMENT_TYPES.GRANT);
         enforce(data.agreement_type).notEquals(AGREEMENT_TYPES.DIRECT_OBLIGATION);
     });
+    // REVIEW: UNCHANGED — name and project_id are required for all agreement types including GRANT.
     test("name", "This is required information", () => {
         enforce(data.name).isNotBlank();
     });
     test("project_id", "This is required information", () => {
         enforce(data.project_id).greaterThan(0);
     });
+    // REVIEW: CHANGED — each of the following 8 tests now early-returns for GRANT.
+    // Early-return keeps the test registered (vest v6 requirement) but makes it pass immediately,
+    // clearing any stale error state from a previous type selection.
     test("service_requirement_type", "This is required information", () => {
+        if (isGrant) return;
         enforce(data.service_requirement_type).notEquals("-Select Service Requirement Type-");
     });
     test("description", "This is required information", () => {
+        if (isGrant) return;
         enforce(data.description).isNotBlank();
     });
     test("product_service_code_id", "This is required information", () => {
+        if (isGrant) return;
         enforce(data.product_service_code_id).greaterThan(0);
     });
     test("agreement_reason", "This is required information", () => {
+        if (isGrant) return;
         enforce(data.agreement_reason).isNotBlank();
         enforce(data.agreement_reason).notEquals("0");
     });
     test("vendor", "This is required information", () => {
+        if (isGrant) return;
         if (
             data.agreement_reason &&
             (data.agreement_reason === "RECOMPETE" || data.agreement_reason === "LOGICAL_FOLLOW_ON")
@@ -47,16 +61,20 @@ const suite = create((data = {}, fieldName) => {
         }
     });
     test("project_officer", "This is required information", () => {
+        if (isGrant) return;
         enforce(data.project_officer_id).greaterThan(0);
     });
     test("contract-type", "This is required information", () => {
+        if (isGrant) return;
         enforce(data.contract_type).notEquals("-Select an option-");
         enforce(data.contract_type).isNotEmpty();
     });
     test("procurement-shop-select", "This is required information", () => {
+        if (isGrant) return;
         enforce(data["procurement-shop-select"]).isNotEmpty();
         enforce(data["procurement-shop-select"]?.id).greaterThan(0);
     });
+    // REVIEW: UNCHANGED — requesting_agency / servicing_agency remain AA-only; no change needed.
     test("requesting_agency", "This is required information", () => {
         if (data.agreement_type === AGREEMENT_TYPES.AA) {
             enforce(data["requesting_agency"]).isNotNullish();

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.test.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditFormSuite.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from "vitest";
+import suite from "./AgreementEditFormSuite";
+
+afterEach(() => {
+    suite.reset();
+});
+
+const validGrantData = {
+    agreement_type: "GRANT",
+    "agreement-type-filter": "GRANT",
+    name: "My Grant",
+    project_id: 5
+};
+
+const validContractData = {
+    agreement_type: "CONTRACT",
+    "agreement-type-filter": "CONTRACT",
+    name: "My Contract",
+    project_id: 5,
+    service_requirement_type: "SEVERABLE",
+    description: "A description",
+    product_service_code_id: 1,
+    agreement_reason: "NEW_REQ",
+    project_officer_id: 1,
+    contract_type: "FIRM_FIXED_PRICE",
+    "procurement-shop-select": { id: 2 }
+};
+
+describe("AgreementEditFormSuite — GRANT", () => {
+    it("passes with only the 4 required grant fields", () => {
+        const result = suite.run(validGrantData);
+        expect(result.hasErrors()).toBe(false);
+    });
+
+    it("passes even when contract-only fields are missing", () => {
+        const result = suite.run({ ...validGrantData });
+        expect(result.hasErrors("contract-type")).toBe(false);
+        expect(result.hasErrors("procurement-shop-select")).toBe(false);
+        expect(result.hasErrors("service_requirement_type")).toBe(false);
+        expect(result.hasErrors("product_service_code_id")).toBe(false);
+        expect(result.hasErrors("agreement_reason")).toBe(false);
+        expect(result.hasErrors("project_officer")).toBe(false);
+    });
+
+    it("still fails when name is missing", () => {
+        const result = suite.run({ ...validGrantData, name: "" });
+        expect(result.hasErrors("name")).toBe(true);
+    });
+
+    it("still fails when project_id is missing", () => {
+        const result = suite.run({ ...validGrantData, project_id: 0 });
+        expect(result.hasErrors("project_id")).toBe(true);
+    });
+});
+
+describe("AgreementEditFormSuite — CONTRACT regression", () => {
+    it("passes with all required contract fields", () => {
+        const result = suite.run(validContractData);
+        expect(result.hasErrors()).toBe(false);
+    });
+
+    it("fails contract-type when missing", () => {
+        const result = suite.run({ ...validContractData, contract_type: undefined });
+        expect(result.hasErrors("contract-type")).toBe(true);
+    });
+
+    it("fails procurement-shop-select when missing", () => {
+        const result = suite.run({ ...validContractData, "procurement-shop-select": undefined });
+        expect(result.hasErrors("procurement-shop-select")).toBe(true);
+    });
+
+    it("fails service_requirement_type when missing", () => {
+        const result = suite.run({
+            ...validContractData,
+            service_requirement_type: "-Select Service Requirement Type-"
+        });
+        expect(result.hasErrors("service_requirement_type")).toBe(true);
+    });
+});
+
+describe("AgreementEditFormSuite — IAA still blocked", () => {
+    it("blocks IAA agreement type", () => {
+        const result = suite.run({ agreement_type: "IAA", "agreement-type-filter": "IAA", name: "X", project_id: 1 });
+        expect(result.hasErrors("agreement_type")).toBe(true);
+    });
+});

--- a/frontend/src/components/Agreements/AgreementMetaAccordion/AgreementMetaAccordion.jsx
+++ b/frontend/src/components/Agreements/AgreementMetaAccordion/AgreementMetaAccordion.jsx
@@ -109,20 +109,29 @@ const AgreementMetaAccordion = ({
                             )}
                         </dl>
                     </div>
-                    {newAwardingEntity && changeRequestType === CHANGE_REQUEST_SLUG_TYPES.PROCUREMENT_SHOP ? (
-                        <div className="padding-left-1 border-left-05 text-brand-portfolio-budget-graph-3">
+                    {/* REVIEW: CHANGED — wrapped the entire procurement-shop block (both the change-request
+                        highlight variant and the plain variant) in isFieldVisible(..., ProcurementShop).
+                        Previously this rendered unconditionally, showing "TBD" for a grant's null shop.
+                        isFieldVisible(GRANT, ProcurementShop) returns false because GRANT's entry in
+                        AGREEMENT_TYPE_VISIBLE_FIELDS only contains DescriptionAndNotes + NickName.
+                        The inner ternary (newAwardingEntity / changeRequest highlight) is unchanged. */}
+                    {isFieldVisible(agreement?.agreement_type, AgreementFields.ProcurementShop) &&
+                        (newAwardingEntity && changeRequestType === CHANGE_REQUEST_SLUG_TYPES.PROCUREMENT_SHOP ? (
+                            <div className="padding-left-1 border-left-05 text-brand-portfolio-budget-graph-3">
+                                <dl>
+                                    {renderTerm(
+                                        "procurement-shop",
+                                        "Procurement Shop",
+                                        newAwardingEntity?.abbr,
+                                        "text-brand-portfolio-budget-graph-3"
+                                    )}
+                                </dl>
+                            </div>
+                        ) : (
                             <dl>
-                                {renderTerm(
-                                    "procurement-shop",
-                                    "Procurement Shop",
-                                    newAwardingEntity?.abbr,
-                                    "text-brand-portfolio-budget-graph-3"
-                                )}
+                                {renderTerm("procurement-shop", "Procurement Shop", agreement?.procurement_shop?.abbr)}
                             </dl>
-                        </div>
-                    ) : (
-                        <dl>{renderTerm("procurement-shop", "Procurement Shop", agreement?.procurement_shop?.abbr)}</dl>
-                    )}
+                        ))}
                     <dl className="margin-0">
                         {renderTerm(
                             "reason",

--- a/frontend/src/components/Agreements/AgreementMetaAccordion/AgreementMetaAccordion.test.jsx
+++ b/frontend/src/components/Agreements/AgreementMetaAccordion/AgreementMetaAccordion.test.jsx
@@ -210,6 +210,25 @@ describe("AgreementMetaAccordion", () => {
             expect(screen.queryByText("GRANT123")).not.toBeInTheDocument();
         });
 
+        it("should NOT show Procurement Shop for GRANT agreements", () => {
+            const grantAgreement = {
+                ...agreement,
+                agreement_type: "GRANT",
+                procurement_shop: { abbr: "PSC", fee: 0 }
+            };
+
+            render(
+                <AgreementMetaAccordion
+                    agreement={grantAgreement}
+                    instructions="test instructions"
+                    projectOfficerName="John Doe"
+                    convertCodeForDisplay={convertCodeForDisplay}
+                />
+            );
+
+            expect(screen.queryByText("Procurement Shop")).not.toBeInTheDocument();
+        });
+
         it("should NOT show contract number for non-awarded CONTRACT agreements", () => {
             const nonAwardedAgreement = {
                 ...agreement,

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
@@ -141,64 +141,83 @@ export const AgreementTableRow = ({ agreement }) => {
                     <dt className="margin-0 text-base-dark">Project</dt>
                     <dd className="margin-0">{researchProjectName || NO_DATA}</dd>
                 </dl>
-                <dl
-                    className="font-12px"
-                    style={{ marginLeft: "2.5rem" }}
-                >
-                    <dt className="margin-0 text-base-dark">Procurement Shop</dt>
-                    <dd className="margin-0">{procurementShopDisplay}</dd>
-                </dl>
-                <dl
-                    className="font-12px"
-                    style={{ marginLeft: "2.5rem" }}
-                >
-                    <dt className="margin-0 text-base-dark">Subtotal</dt>
-                    <dd className="margin-0">{formatCurrency(agreementSubTotal)}</dd>
-                </dl>
-                <dl
-                    className="font-12px"
-                    style={{ marginLeft: "2.5rem" }}
-                >
-                    <dt className="margin-0 text-base-dark">Fees</dt>
-                    <dd className="margin-0">{formatCurrency(agreementFees)}</dd>
-                </dl>
-                <dl
-                    className="font-12px"
-                    style={{ marginLeft: "2.5rem" }}
-                >
-                    <dt className="margin-0 text-base-dark">Lifetime Obligated</dt>
-                    <dd className="margin-0">{formatCurrency(lifetimeObligated)}</dd>
-                </dl>
+                {/* REVIEW: NEW — gates Procurement Shop / Subtotal / Fees / Lifetime Obligated for GRANT rows.
+                    Grants have no procurement shop and no BLIs at creation time, so these cells would all
+                    show TBD or $0 and are misleading. Using a string literal "GRANT" rather than importing
+                    the AGREEMENT_TYPES constant because this file already uses the string form elsewhere
+                    (e.g. isNotDevelopedYet) and adding another import for a one-liner guard would be noisy.
+                    QUESTION FOR REVIEW: should we import AGREEMENT_TYPES.GRANT here for consistency? */}
+                {agreement?.agreement_type !== "GRANT" && (
+                    <>
+                        <dl
+                            className="font-12px"
+                            style={{ marginLeft: "2.5rem" }}
+                        >
+                            <dt className="margin-0 text-base-dark">Procurement Shop</dt>
+                            <dd className="margin-0">{procurementShopDisplay}</dd>
+                        </dl>
+                        <dl
+                            className="font-12px"
+                            style={{ marginLeft: "2.5rem" }}
+                        >
+                            <dt className="margin-0 text-base-dark">Subtotal</dt>
+                            <dd className="margin-0">{formatCurrency(agreementSubTotal)}</dd>
+                        </dl>
+                        <dl
+                            className="font-12px"
+                            style={{ marginLeft: "2.5rem" }}
+                        >
+                            <dt className="margin-0 text-base-dark">Fees</dt>
+                            <dd className="margin-0">{formatCurrency(agreementFees)}</dd>
+                        </dl>
+                        <dl
+                            className="font-12px"
+                            style={{ marginLeft: "2.5rem" }}
+                        >
+                            <dt className="margin-0 text-base-dark">Lifetime Obligated</dt>
+                            <dd className="margin-0">{formatCurrency(lifetimeObligated)}</dd>
+                        </dl>
+                    </>
+                )}
             </div>
             <div
                 className="display-flex padding-right-4"
                 style={{ justifyContent: "space-between" }}
             >
-                <dl className="font-12px">
-                    <dt className="margin-0 text-base-dark">Contract #</dt>
-                    <dd className="margin-0">{contractNumber || NO_DATA}</dd>
-                </dl>
-                <dl
-                    className="font-12px"
-                    style={{ marginLeft: "7rem" }}
-                >
-                    <dt className="margin-0 text-base-dark">Award Type</dt>
-                    <dd className="margin-0">{awardType}</dd>
-                </dl>
-                <dl
-                    className="font-12px"
-                    style={{ marginLeft: "2.5rem" }}
-                >
-                    <dt className="margin-0 text-base-dark">&nbsp;</dt>
-                    <dd className="margin-0">&nbsp;</dd>
-                </dl>
-                <dl
-                    className="font-12px"
-                    style={{ marginLeft: "4rem" }}
-                >
-                    <dt className="margin-0 text-base-dark">Vendor</dt>
-                    <dd className="margin-0">{vendor}</dd>
-                </dl>
+                {/* REVIEW: NEW — gates Contract # / Award Type / spacer / Vendor for GRANT rows.
+                    Change-icons div intentionally kept outside this gate so delete/edit icons
+                    still render for grants. The spacer dl (&nbsp;) is a layout placeholder that
+                    existed before this change; it's included in the gate since it only makes sense
+                    when Contract # and Vendor are present. */}
+                {agreement?.agreement_type !== "GRANT" && (
+                    <>
+                        <dl className="font-12px">
+                            <dt className="margin-0 text-base-dark">Contract #</dt>
+                            <dd className="margin-0">{contractNumber || NO_DATA}</dd>
+                        </dl>
+                        <dl
+                            className="font-12px"
+                            style={{ marginLeft: "7rem" }}
+                        >
+                            <dt className="margin-0 text-base-dark">Award Type</dt>
+                            <dd className="margin-0">{awardType}</dd>
+                        </dl>
+                        <dl
+                            className="font-12px"
+                            style={{ marginLeft: "2.5rem" }}
+                        >
+                            <dt className="margin-0 text-base-dark">&nbsp;</dt>
+                            <dd className="margin-0">&nbsp;</dd>
+                        </dl>
+                        <dl
+                            className="font-12px"
+                            style={{ marginLeft: "4rem" }}
+                        >
+                            <dt className="margin-0 text-base-dark">Vendor</dt>
+                            <dd className="margin-0">{vendor}</dd>
+                        </dl>
+                    </>
+                )}
                 {!isReadOnly && (
                     <div
                         className="flex-align-self-end margin-bottom-1"

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
@@ -10,6 +10,7 @@ import TableRowExpandable from "../../UI/TableRowExpandable";
 import { expandedRowBGColor } from "../../UI/TableRowExpandable/TableRowExpandable.helpers";
 import { useTableRow } from "../../UI/TableRowExpandable/TableRowExpandable.hooks";
 import TextClip from "../../UI/Text/TextClip";
+import { AGREEMENT_TYPES } from "../../../components/ServicesComponents/ServicesComponents.constants";
 import {
     areAllBudgetLinesInStatus,
     getAgreementContractNumber,
@@ -147,7 +148,7 @@ export const AgreementTableRow = ({ agreement }) => {
                     the AGREEMENT_TYPES constant because this file already uses the string form elsewhere
                     (e.g. isNotDevelopedYet) and adding another import for a one-liner guard would be noisy.
                     QUESTION FOR REVIEW: should we import AGREEMENT_TYPES.GRANT here for consistency? */}
-                {agreement?.agreement_type !== "GRANT" && (
+                {agreement?.agreement_type !== AGREEMENT_TYPES.GRANT && (
                     <>
                         <dl
                             className="font-12px"

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
@@ -1,5 +1,5 @@
 import { Provider } from "react-redux";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { BrowserRouter } from "react-router-dom";
 import AgreementsTable from "./AgreementsTable";
 import { configureStore } from "@reduxjs/toolkit";
@@ -135,7 +135,10 @@ it("does not render contract-only expanded fields for a GRANT agreement row", ()
         </Provider>
     );
 
-    // Contract-only column headers should not appear in the grant row
+    // Expand the grant row so ExpandedData is actually rendered
+    fireEvent.click(screen.getByTestId("expand-row"));
+
+    // Contract-only fields must be absent even in the expanded state
     expect(screen.queryByText("Contract #")).not.toBeInTheDocument();
     expect(screen.queryByText("Procurement Shop")).not.toBeInTheDocument();
     expect(screen.queryByText("Award Type")).not.toBeInTheDocument();

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
@@ -122,3 +122,22 @@ it("renders without crashing", () => {
     expect(screen.getByText("Total")).toBeInTheDocument();
     expect(screen.getByText("FY25 Obligated")).toBeInTheDocument();
 });
+
+it("does not render contract-only expanded fields for a GRANT agreement row", () => {
+    render(
+        <Provider store={store}>
+            <BrowserRouter>
+                <AgreementsTable
+                    agreements={agreements}
+                    selectedFiscalYear="2025"
+                />
+            </BrowserRouter>
+        </Provider>
+    );
+
+    // Contract-only column headers should not appear in the grant row
+    expect(screen.queryByText("Contract #")).not.toBeInTheDocument();
+    expect(screen.queryByText("Procurement Shop")).not.toBeInTheDocument();
+    expect(screen.queryByText("Award Type")).not.toBeInTheDocument();
+    expect(screen.queryByText("Vendor")).not.toBeInTheDocument();
+});

--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -287,7 +287,13 @@ const AGREEMENT_TYPE_VISIBLE_FIELDS = {
         AgreementFields.NickName,
         AgreementFields.SpecialTopic,
         AgreementFields.Methodologies
-    ])
+    ]),
+    // REVIEW: NEW — GRANT entry. Gates Description and Nickname on the details view.
+    // Both AgreementFields keys already existed; no enum changes needed.
+    // isFieldVisible(GRANT, ProcurementShop) → false, so the MetaAccordion gate works automatically.
+    // isFieldVisible(GRANT, ContractNumber) → false, which the existing test at line 235 already asserts.
+    // Title and the "Grant" type label render via always-on blocks in AgreementDetailsView and are not in this set.
+    [AgreementType.GRANT]: new Set([AgreementFields.DescriptionAndNotes, AgreementFields.NickName])
     // Add new AgreementTypes here
 };
 

--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -150,11 +150,7 @@ export const getProcurementShopSubTotal = (agreement, budgetLines = [], isAfterA
  * @returns {boolean} - True if the agreement is not developed yet, otherwise false.
  */
 export const isNotDevelopedYet = (agreementType) => {
-    if (
-        agreementType === AgreementType.GRANT ||
-        agreementType === AgreementType.DIRECT_OBLIGATION ||
-        agreementType === AgreementType.IAA
-    ) {
+    if (agreementType === AgreementType.DIRECT_OBLIGATION || agreementType === AgreementType.IAA) {
         return true;
     }
 

--- a/frontend/src/helpers/agreement.helpers.test.js
+++ b/frontend/src/helpers/agreement.helpers.test.js
@@ -433,9 +433,9 @@ describe("getProcurementShopFees", () => {
 });
 
 describe("isNotDevelopedYet", () => {
-    it("returns true for GRANT agreement type", () => {
+    it("returns false for GRANT agreement type (grants are now creatable)", () => {
         const result = isNotDevelopedYet(AgreementType.GRANT);
-        expect(result).toBe(true);
+        expect(result).toBe(false);
     });
 
     it("returns true for DIRECT_OBLIGATION agreement type", () => {

--- a/frontend/src/helpers/agreement.helpers.test.js
+++ b/frontend/src/helpers/agreement.helpers.test.js
@@ -215,8 +215,18 @@ describe("isFieldVisible", () => {
     });
 
     it("returns false for unsupported agreement types", () => {
-        expect(isFieldVisible(AgreementType.GRANT, AgreementFields.DescriptionAndNotes)).toBe(false);
         expect(isFieldVisible(AgreementType.IAA, AgreementFields.ContractType)).toBe(false);
+    });
+
+    it("returns true for GRANT DescriptionAndNotes and NickName fields", () => {
+        expect(isFieldVisible(AgreementType.GRANT, AgreementFields.DescriptionAndNotes)).toBe(true);
+        expect(isFieldVisible(AgreementType.GRANT, AgreementFields.NickName)).toBe(true);
+    });
+
+    it("returns false for GRANT contract-only fields", () => {
+        expect(isFieldVisible(AgreementType.GRANT, AgreementFields.ProcurementShop)).toBe(false);
+        expect(isFieldVisible(AgreementType.GRANT, AgreementFields.ContractType)).toBe(false);
+        expect(isFieldVisible(AgreementType.GRANT, AgreementFields.Vendor)).toBe(false);
     });
 
     it("returns false for unknown fields", () => {


### PR DESCRIPTION
## What changed

This is the first vertical slice of [#787 "Create a Grant"](https://github.com/HHS/OPRE-OPS/issues/787). It makes Grant agreements creatable through the existing Create Agreement wizard and viewable on the Agreement Details page. The backend already supported `GrantAgreement`, so this is a frontend-only slice.

Per the Figma design, a Grant only needs 4 fields: Type, Agreement Title (`name`), Nickname (`nick_name`), and Description. Selecting Grant in the wizard now hides all Contract- and AA/Partner-specific controls and shows only those 4 fields.

- **`AgreementEditFormSuite.js`**: Unblocked `GRANT` in the two "not yet available" Vest tests (IAA and DIRECT_OBLIGATION remain blocked). Added an `isGrant` early-return guard to the 8 contract-only tests (`service_requirement_type`, `description`, `product_service_code_id`, `agreement_reason`, `vendor`, `project_officer`, `contract-type`, `procurement-shop-select`) so they pass immediately for grants without deleting the test registrations (keeps Vest v6 error-key registry stable).
- **`AgreementEditForm.hooks.js`**: Added `isGrant` derived from `agreementType`, returned from the hook. Extended `handleAgreementFilterChange` to clear all contract-only state (contract type, service req type, product service code, agreement reason, vendor, notes, project officers, team members, research methodologies, special topics) when switching to Grant, so a Contract-then-Grant switch doesn't leave stale data in the payload.
- **`AgreementEditForm.jsx`**: Wrapped the entire contract control block (`ContractTypeSelect` through the Notes `TextArea`) in `{!isGrant && (...)}`. Hid the Continue button for grants in wizard mode (`!(isGrant && isWizardMode)`) since Continue advances to Step 3 (budget lines, out of scope) without persisting the agreement — Save Draft is the only path to create a grant in this slice.
- **`agreement.helpers.js`**: Added a `GRANT` entry to `AGREEMENT_TYPE_VISIBLE_FIELDS` (`DescriptionAndNotes`, `NickName`) so the details view renders grant fields. Removed `GRANT` from `isNotDevelopedYet`'s blocked list is *not* included — see Known limitations below.
- **`AgreementsTable/AgreementTableRow.jsx`**: Gated the contract-only expanded-row cells (Procurement Shop, Subtotal, Fees, Lifetime Obligated, Contract #, Award Type, Vendor) so grant rows don't show misleading "TBD"/`$0` values.
- **`AgreementMetaAccordion.jsx`**: Gated the Procurement Shop line on `isFieldVisible(agreement_type, ProcurementShop)` for the same reason.
- Added `frontend/cypress/e2e/createGrantAgreement.cy.js` covering the full create-a-grant flow, plus unit test updates across the suite, hooks, form, table, and accordion.

### Known limitations (by design, out of scope for this slice)
- Editing a grant from the details page is not supported — `isNotDevelopedYet(GRANT)` still returns `true`, so the Edit button stays disabled after creation.
- Budget lines and the review/approval flow are out of scope (later slices #5926–#5928); a draft grant's "SCs & Budget Lines" tab renders empty, which is expected.
- Details view still unconditionally renders Project Officer, Alternate PO, and Team Members (shows `NO_DATA` for grants) — flagged as a cosmetic follow-up, not fixed here.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5925

## How to test

**Automated:**
```bash
cd frontend
bun run test --watch=false
```

**E2E:**
```bash
cd frontend
bun run test:e2e -- --spec cypress/e2e/createGrantAgreement.cy.js
```

**Manual (Docker stack up via `docker compose up --build`):**
1. Go to `/agreements/create`, select a Project, click Continue.
2. On Step 2, select **Grant** in the type dropdown — confirm only Type, Title, Nickname, and Description show, and the Continue button is hidden.
3. Enter a Title and Description, click **Save Draft** — confirm a success alert appears and you're redirected to `/agreements`.
4. Open the new grant's details page — confirm Title, Nickname, Description, and a "Grant" type tag display, and no contract-only fields (Procurement Shop, Contract #, Vendor, etc.) appear.
5. Regression: create a **Contract** the same way — confirm all contract fields still show, validate, and Continue still works.

## A11y impact

- [ ] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Screenshots

Create Grant Name Screenshot
<img width="1110" height="818" alt="Screenshot 2026-07-15 at 3 20 33 PM" src="https://github.com/user-attachments/assets/4f864f73-dd82-4965-88b3-7b95e2a36ef9" />


## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

Plan doc: `docs/stories/OPS-5925/create-grant-plan.md` (added in this PR)