### PR TITLE
link docs/TESTING.md from CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Each major directory has its own `CLAUDE.md` with detailed commands, architectur
 - **`backend/ops_api/CLAUDE.md`**: Backend Flask API — commands, testing, architecture, authorization patterns
 - **`backend/data_tools/CLAUDE.md`**: ETL and data import — load_data CLI, test fixtures, environment configs
 - **`frontend/CLAUDE.md`**: React frontend — commands, testing, RTK Query, component patterns
+- **`docs/TESTING.md`**: Testing philosophy and the test-type decision matrix — consult before adding any new test, at any layer
 
 ## Data Model
 

--- a/backend/data_tools/CLAUDE.md
+++ b/backend/data_tools/CLAUDE.md
@@ -78,6 +78,8 @@ Coverage is not enabled by default so that running individual tests stays fast. 
 
 **Important:** Tests mirror the source structure. Tests for `src/load_projects/utils.py` live under `tests/load_projects/`. Many tests use the `loaded_db` fixture, which brings up Postgres via pytest-docker and applies history triggers.
 
+See [docs/TESTING.md](../../docs/TESTING.md#etl-testing-pattern) for the ETL testing pattern (parse → validate → create models → verify).
+
 ### Code Quality
 
 ```bash

--- a/backend/ops_api/CLAUDE.md
+++ b/backend/ops_api/CLAUDE.md
@@ -20,6 +20,8 @@ Coverage is not enabled by default so that running individual tests stays fast. 
 
 Test files mirror source structure: `ops/resources/agreements.py` → `tests/ops/resources/test_agreements.py`.
 
+Before adding a test, see [docs/TESTING.md](../../docs/TESTING.md#decision-matrix-which-test-type-should-i-use) for the unit vs. integration vs. BDD decision matrix, [When NOT to Write Tests](../../docs/TESTING.md#when-not-to-write-tests), and [BDD Testing Guidelines](../../docs/TESTING.md#bdd-testing-guidelines) for multi-step business-process scenarios.
+
 For the full CI check suite across both packages (ops_api + data_tools, including lint, format, and Docker pre-flight for data_tools), use the `/backend-tests` skill — it is NOT auto-invoked, so invoke it explicitly (e.g., `/backend-tests all`).
 
 ### Code Quality

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -40,6 +40,8 @@ bun run test:ui                  # Run tests with UI
 
 **Important**: 90% code coverage is required. Tests are co-located with components (`.test.jsx` files).
 
+Before adding a test, see [docs/TESTING.md](../docs/TESTING.md#decision-matrix-which-test-type-should-i-use) for the unit vs. integration vs. component vs. E2E decision matrix and [When NOT to Write Tests](../docs/TESTING.md#when-not-to-write-tests).
+
 ### E2E Tests
 
 E2E tests use Cypress and require the Docker stack to be running. Use the `/e2e-tests` skill for running, monitoring, and fixing E2E tests.


### PR DESCRIPTION
## What changed

Adds a short, on-demand pointer sentence in each of the four `CLAUDE.md` files to the most relevant section of `docs/TESTING.md`, so Claude Code sessions consult the project's testing strategy at the right moment instead of guessing or reinventing conventions.

- **`CLAUDE.md`**: adds `docs/TESTING.md` to the Subdirectory Guides list, describing it as the testing philosophy and test-type decision matrix.
- **`backend/ops_api/CLAUDE.md`**: links the decision matrix, "When NOT to Write Tests," and BDD Testing Guidelines sections — closes a gap where this file had no BDD guidance despite the backend using pytest-bdd.
- **`frontend/CLAUDE.md`**: links the decision matrix (unit vs. integration vs. component vs. E2E) and "When NOT to Write Tests."
- **`backend/data_tools/CLAUDE.md`**: links the ETL Testing Pattern section.

Deliberately used plain markdown links with anchors rather than `@docs/TESTING.md` import syntax — `@`-imports load the full file into every session's context regardless of task, and this doc is 1249 lines. Plain links match this repo's existing convention (e.g. `.storybook/README.md`, `.claude/actions/README.md`) and let Claude open just the relevant section on demand.

Idea and impetus for this change credited to @josbell — thanks for raising it!

## Issue

N/A — no ticket for this change.

## How to test

This is a documentation-only change (no code, no runtime behavior).

1. Open each edited file and click through the new links to confirm they resolve to the correct anchor in `docs/TESTING.md`:
   - `CLAUDE.md` → `docs/TESTING.md`
   - `backend/ops_api/CLAUDE.md` → `../../docs/TESTING.md#decision-matrix-which-test-type-should-i-use`, `#when-not-to-write-tests`, `#bdd-testing-guidelines`
   - `frontend/CLAUDE.md` → `../docs/TESTING.md#decision-matrix-which-test-type-should-i-use`, `#when-not-to-write-tests`
   - `backend/data_tools/CLAUDE.md` → `../../docs/TESTING.md#etl-testing-pattern`
2. Optionally, start a Claude Code session in `backend/ops_api/` or `frontend/` and ask it to add a test — confirm it now references `docs/TESTING.md` guidance.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] No UI component changes in this PR

## Screenshots

N/A — no UI changes.

## Definition of Done Checklist

Not applicable — this PR only adds cross-reference links between existing markdown files; no code, tests, or coverage are affected.

## Links

- [docs/TESTING.md](../blob/main/docs/TESTING.md)