### PR TITLE
exclude System Admin from user picker dropdowns

### DIFF
--- a/backend/data_tools/src/common/utils.py
+++ b/backend/data_tools/src/common/utils.py
@@ -37,10 +37,8 @@ from models import (
     ServicesComponent,
     User,
 )
+from models.users import SYSTEM_ADMIN_EMAIL, SYSTEM_ADMIN_OIDC_ID
 from models.utils import generate_events_update
-
-SYSTEM_ADMIN_OIDC_ID = "00000000-0000-1111-a111-000000000026"
-SYSTEM_ADMIN_EMAIL = "system.admin@email.com"
 
 
 def get_config(environment_name: Optional[str] = None) -> DataToolsConfig:

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -9,6 +9,9 @@ from sqlalchemy.orm import Mapped, column_property, mapped_column, relationship
 
 from models import BaseModel
 
+SYSTEM_ADMIN_OIDC_ID = "00000000-0000-1111-a111-000000000026"
+SYSTEM_ADMIN_EMAIL = "system.admin@email.com"
+
 
 class UserRole(BaseModel):
     __tablename__ = "user_role"
@@ -168,6 +171,7 @@ class Role(BaseModel):
     @property
     def is_superuser(self) -> bool:
         return self.name == "SUPER_USER"
+
 
 class Group(BaseModel):
     """Main Group model."""

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -3076,6 +3076,12 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: exclude_system_admin
+          in: query
+          description: Exclude the System Admin ETL user from results
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: OK

--- a/backend/ops_api/ops/schemas/users.py
+++ b/backend/ops_api/ops/schemas/users.py
@@ -35,6 +35,7 @@ class QueryParameters(Schema):
     last_name: Optional[str] = fields.String()
     roles: Optional[list[str]] = custom_types.List(fields.String())
     exclude_read_only: Optional[bool] = fields.Boolean(load_default=False)
+    exclude_system_admin: Optional[bool] = fields.Boolean(load_default=False)
 
 
 class RoleSchema(Schema):

--- a/backend/ops_api/ops/services/users.py
+++ b/backend/ops_api/ops/services/users.py
@@ -9,6 +9,7 @@ from ops_api.ops.auth.utils import deactivate_all_user_sessions, get_all_active_
 from ops_api.ops.utils.users import is_user_admin
 
 READ_ONLY_ROLE = "READ_ONLY"
+SYSTEM_ADMIN_EMAIL = "system.admin@email.com"
 
 
 def resolve_roles(session: Session, role_names: list[str]) -> list[Role]:
@@ -93,16 +94,19 @@ def get_users(session: Session, **kwargs) -> list[User]:
 
     :param session: The database session.
     :param exclude_read_only: Whether to exclude read-only users.
+    :param exclude_system_admin: Whether to exclude the System Admin ETL user.
     :param **kwargs: The criteria to filter the users by.
     :return: The users that match the criteria.
 
     Business Rules:
     - Users with READ_ONLY role are excluded from the response
+    - The System Admin ETL user can optionally be excluded from the response
 
     """
     stmt = select(User)
 
     exclude_read_only = kwargs.pop("exclude_read_only", False)
+    exclude_system_admin = kwargs.pop("exclude_system_admin", False)
 
     for key, value in kwargs.items():
         if key == "roles":
@@ -112,6 +116,9 @@ def get_users(session: Session, **kwargs) -> list[User]:
 
     if exclude_read_only:
         stmt = stmt.where(~User.roles.any(Role.name == READ_ONLY_ROLE))
+
+    if exclude_system_admin:
+        stmt = stmt.where(User.email != SYSTEM_ADMIN_EMAIL)
 
     stmt = stmt.order_by(User.id)
 

--- a/backend/ops_api/ops/services/users.py
+++ b/backend/ops_api/ops/services/users.py
@@ -5,11 +5,11 @@ from sqlalchemy.orm import Session
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from models import Role, User, UserStatus
+from models.users import SYSTEM_ADMIN_EMAIL
 from ops_api.ops.auth.utils import deactivate_all_user_sessions, get_all_active_user_sessions
 from ops_api.ops.utils.users import is_user_admin
 
 READ_ONLY_ROLE = "READ_ONLY"
-SYSTEM_ADMIN_EMAIL = "system.admin@email.com"
 
 
 def resolve_roles(session: Session, role_names: list[str]) -> list[Role]:

--- a/backend/ops_api/ops/utils/users.py
+++ b/backend/ops_api/ops/utils/users.py
@@ -3,8 +3,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from models import Role, User
-
-SYSTEM_ADMIN_OIDC_ID = "00000000-0000-1111-a111-000000000026"
+from models.users import SYSTEM_ADMIN_OIDC_ID
 
 
 def is_user_admin(user: User, session: Session = None) -> bool:

--- a/backend/ops_api/tests/ops/users/test_users_get.py
+++ b/backend/ops_api/tests/ops/users/test_users_get.py
@@ -175,6 +175,16 @@ def test_get_all_users(auth_client, loaded_db, app_ctx):
     assert read_only_user.id not in user_ids, "READ_ONLY user should be filtered from response"
 
 
+def test_get_all_users_exclude_system_admin(auth_client, loaded_db, app_ctx):
+    response_filtered = auth_client.get(url_for("api.users-group", exclude_system_admin=True))
+    assert response_filtered.status_code == 200
+    user_ids = [user["id"] for user in response_filtered.json]
+    system_admin_user = loaded_db.get(User, 526)  # System Admin
+    assert system_admin_user is not None, "System Admin user should exist in database"
+    assert system_admin_user.email == "system.admin@email.com"
+    assert system_admin_user.id not in user_ids, "System Admin user should be filtered from response"
+
+
 def test_get_all_users_by_id(auth_client, loaded_db, app_ctx):
     response = auth_client.get(url_for("api.users-group", id=500))
     assert response.status_code == 200

--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -719,10 +719,13 @@ export const opsApi = createApi({
             providesTags: ["AgreementReasons"]
         }),
         getUsers: builder.query({
-            query: ({ excludeReadOnlyUsers } = {}) => {
+            query: ({ excludeReadOnlyUsers, excludeSystemAdmin } = {}) => {
                 const queryParams = [];
                 if (excludeReadOnlyUsers) {
                     queryParams.push("exclude_read_only=true");
+                }
+                if (excludeSystemAdmin) {
+                    queryParams.push("exclude_system_admin=true");
                 }
                 const queryString = queryParams.length > 0 ? `?${queryParams.join("&")}` : "";
                 return `/users/${queryString}`;

--- a/frontend/src/api/opsAPI.test.js
+++ b/frontend/src/api/opsAPI.test.js
@@ -1122,6 +1122,61 @@ describe("opsAPI - Wave 2 high-yield endpoint coverage", () => {
     });
 });
 
+describe("opsAPI - getUsers query parameter construction", () => {
+    afterEach(() => server.resetHandlers());
+
+    it("omits exclude params when no options are provided", async () => {
+        let capturedUrl = "";
+        server.use(
+            http.get("*/api/v1/users/", ({ request }) => {
+                capturedUrl = request.url;
+                return HttpResponse.json([]);
+            })
+        );
+
+        const storeRef = setupApiStore(opsApi);
+        await storeRef.store.dispatch(opsApi.endpoints.getUsers.initiate());
+
+        expect(capturedUrl).not.toContain("exclude_read_only=");
+        expect(capturedUrl).not.toContain("exclude_system_admin=");
+    });
+
+    it("includes exclude_system_admin=true when excludeSystemAdmin is set", async () => {
+        let capturedUrl = "";
+        server.use(
+            http.get("*/api/v1/users/", ({ request }) => {
+                capturedUrl = request.url;
+                return HttpResponse.json([]);
+            })
+        );
+
+        const storeRef = setupApiStore(opsApi);
+        await storeRef.store.dispatch(opsApi.endpoints.getUsers.initiate({ excludeSystemAdmin: true }));
+
+        expect(capturedUrl).toContain("exclude_system_admin=true");
+        expect(capturedUrl).not.toContain("exclude_read_only=");
+    });
+
+    it("combines exclude_read_only=true and exclude_system_admin=true when both are set", async () => {
+        let capturedUrl = "";
+        server.use(
+            http.get("*/api/v1/users/", ({ request }) => {
+                capturedUrl = request.url;
+                return HttpResponse.json([]);
+            })
+        );
+
+        const storeRef = setupApiStore(opsApi);
+        await storeRef.store.dispatch(
+            opsApi.endpoints.getUsers.initiate({ excludeReadOnlyUsers: true, excludeSystemAdmin: true })
+        );
+
+        expect(capturedUrl).toContain("exclude_read_only=true");
+        expect(capturedUrl).toContain("exclude_system_admin=true");
+        expect(capturedUrl).toContain("exclude_read_only=true&exclude_system_admin=true");
+    });
+});
+
 describe("opsAPI - getAllProjects queryFn pagination", () => {
     afterEach(() => server.resetHandlers());
 

--- a/frontend/src/components/Agreements/ProjectOfficerComboBox.jsx
+++ b/frontend/src/components/Agreements/ProjectOfficerComboBox.jsx
@@ -34,7 +34,7 @@ export const ProjectOfficerComboBox = ({
         data: users,
         error: errorUsers,
         isLoading: isLoadingUsers
-    } = useGetUsersQuery({ excludeReadOnlyUsers: true });
+    } = useGetUsersQuery({ excludeReadOnlyUsers: true, excludeSystemAdmin: true });
 
     if (isLoadingUsers) {
         return <div>Loading...</div>;

--- a/frontend/src/components/Agreements/TeamMemberComboBox.jsx
+++ b/frontend/src/components/Agreements/TeamMemberComboBox.jsx
@@ -41,7 +41,7 @@ export const TeamMemberComboBox = ({
         data: users,
         error: errorUsers,
         isLoading: isLoadingUsers
-    } = useGetUsersQuery({ excludeReadOnlyUsers: true });
+    } = useGetUsersQuery({ excludeReadOnlyUsers: true, excludeSystemAdmin: true });
     const [selectedTeamMember, setSelectedTeamMember] = useState({});
 
     if (isLoadingUsers) {

--- a/frontend/src/components/Users/UserEmailComboBox/UserEmailComboBox.jsx
+++ b/frontend/src/components/Users/UserEmailComboBox/UserEmailComboBox.jsx
@@ -11,7 +11,11 @@ import ComboBox from "../../UI/Form/ComboBox";
 function UserEmailComboBox({ selectedUsers, setSelectedUsers }) {
     const navigate = useNavigate();
     /** @type {{data?: import("../../../types/UserTypes").User[] | undefined, error?: Object, isLoading: boolean}} */
-    const { data: users, error: errorUsers, isLoading: isLoadingUsers } = useGetUsersQuery({});
+    const {
+        data: users,
+        error: errorUsers,
+        isLoading: isLoadingUsers
+    } = useGetUsersQuery({ excludeSystemAdmin: true });
 
     if (isLoadingUsers) {
         return <div>Loading...</div>;

--- a/frontend/src/pages/agreements/details/AgreementProcurementTracker.jsx
+++ b/frontend/src/pages/agreements/details/AgreementProcurementTracker.jsx
@@ -62,7 +62,7 @@ const AgreementProcurementTracker = ({ agreement }) => {
     });
 
     // Fetch all users for filtering
-    const { data: allUsers } = useGetUsersQuery({ excludeReadOnlyUsers: true });
+    const { data: allUsers } = useGetUsersQuery({ excludeReadOnlyUsers: true, excludeSystemAdmin: true });
 
     // Filter users by authorized_user_ids from the agreement (shared across all steps)
     const authorizedUsers = React.useMemo(() => {


### PR DESCRIPTION
## What changed

Excludes the seeded "System Admin" ETL/attribution user (email `system.admin@email.com`) from appearing as a selectable person in user-picker dropdowns across the app. This mirrors the existing `exclude_read_only` pattern already used to hide READ_ONLY-role users from these same pickers.

**Backend** (`backend/ops_api/ops/services/users.py`, `schemas/users.py`, `openapi.yml`)
- Added a new opt-in `exclude_system_admin` query param to `GET /users/`, filtering by `User.email != SYSTEM_ADMIN_EMAIL` when set. Defaults to `False`, so existing callers are unaffected.
- Added `test_get_all_users_exclude_system_admin` to `test_users_get.py`, mirroring the existing `exclude_read_only` test.

**Frontend** (`frontend/src/api/opsAPI.js` + 4 components)
- `getUsers` RTK Query endpoint now accepts an `excludeSystemAdmin` option, appending `exclude_system_admin=true` to the request when set.
- Wired `excludeSystemAdmin: true` into the COR/Alternate COR dropdown (`ProjectOfficerComboBox`), Team Members picker (`TeamMemberComboBox`), and Procurement Tracker step dropdowns (via `AgreementProcurementTracker`).
- Wired `excludeSystemAdmin: true` into the User Admin page's multi-select (`UserEmailComboBox`) — this one intentionally does *not* also pass `excludeReadOnlyUsers`, since User Admin needs to keep showing READ_ONLY-role users for role management.

## Issue

N/A — no associated ticket.

## How to test

**Automated:**
```bash
# Backend
cd backend/ops_api && pipenv run pytest tests/ops/users/test_users_get.py -v

# Frontend
cd frontend && bun run test --watch=false
```

**Manual:**
1. `docker compose up --build`
2. On an agreement create/edit page, open the COR, Alternate COR, and Team Members dropdowns — confirm "System Admin" does not appear.
3. On an agreement's Procurement Tracker tab, open any step's "who completed this" dropdown — confirm "System Admin" does not appear.
4. Go to `/user-admin` and open the user multi-select — confirm "System Admin" does not appear, but a READ_ONLY-role user (e.g. "Randy Read-Only") still does.
5. `GET /api/v1/users/?exclude_system_admin=true` should omit the System Admin user; `GET /api/v1/users/` (no param) should still include it.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — no visual changes; this only affects which users appear as options in existing dropdowns.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A