### PR TITLE
fix: fold PLANNED_MOD BLIs into PLANNED in procurement overview

### DIFF
--- a/backend/ops_api/ops/services/agreements.py
+++ b/backend/ops_api/ops/services/agreements.py
@@ -939,10 +939,14 @@ def _compute_procurement_overview(all_results: list[Agreement], fiscal_year: int
     """
     tracked_statuses = [
         BudgetLineItemStatus.PLANNED,
-        BudgetLineItemStatus.PLANNED_MOD,
         BudgetLineItemStatus.IN_EXECUTION,
         BudgetLineItemStatus.OBLIGATED,
     ]
+
+    # PLANNED_MOD BLIs are modifications to already-PLANNED lines, so they're grouped under PLANNED here.
+    status_bucket = {
+        BudgetLineItemStatus.PLANNED_MOD: BudgetLineItemStatus.PLANNED,
+    }
 
     amount_by_status: dict[BudgetLineItemStatus, Decimal] = {s: Decimal("0") for s in tracked_statuses}
     agreements_by_status: dict[BudgetLineItemStatus, set[int]] = {s: set() for s in tracked_statuses}
@@ -951,9 +955,10 @@ def _compute_procurement_overview(all_results: list[Agreement], fiscal_year: int
         for bli in agreement.budget_line_items:
             if fiscal_year is not None and bli.fiscal_year != fiscal_year:
                 continue
-            if bli.status in amount_by_status:
-                amount_by_status[bli.status] += (bli.amount or Decimal("0")) + bli.fees
-                agreements_by_status[bli.status].add(agreement.id)
+            bucket = status_bucket.get(bli.status, bli.status)
+            if bucket in amount_by_status:
+                amount_by_status[bucket] += (bli.amount or Decimal("0")) + bli.fees
+                agreements_by_status[bucket].add(agreement.id)
 
     total_amount = sum(amount_by_status.values(), Decimal("0"))
     tracked_agreement_ids = set().union(*agreements_by_status.values())

--- a/backend/ops_api/tests/ops/services/test_agreements.py
+++ b/backend/ops_api/tests/ops/services/test_agreements.py
@@ -1614,7 +1614,7 @@ class TestComputeProcurementOverview:
         result = _compute_procurement_overview([], fiscal_year=2025)
         assert result["total_amount"] == 0.0
         assert result["total_agreements"] == 0
-        assert len(result["status_data"]) == 4  # PLANNED, PLANNED_MOD, IN_EXECUTION, OBLIGATED
+        assert len(result["status_data"]) == 3  # PLANNED, IN_EXECUTION, OBLIGATED
 
     def test_single_planned_bli(self):
         from decimal import Decimal
@@ -1683,6 +1683,20 @@ class TestComputeProcurementOverview:
         for status in result["status_data"]:
             assert status["amount_percent"] == 0.0
             assert status["agreements_percent"] == 0.0
+
+    def test_planned_mod_grouped_under_planned(self):
+        from decimal import Decimal
+
+        bli_planned = _make_mock_bli(BudgetLineItemStatus.PLANNED, 2025, Decimal("100000"), Decimal("0"))
+        bli_planned_mod = _make_mock_bli(BudgetLineItemStatus.PLANNED_MOD, 2025, Decimal("50000"), Decimal("0"))
+        ag = _make_mock_procurement_agreement(blis=[bli_planned, bli_planned_mod])
+
+        result = _compute_procurement_overview([ag], fiscal_year=2025)
+
+        assert {s["status"] for s in result["status_data"]} == {"PLANNED", "IN_EXECUTION", "OBLIGATED"}
+        planned = next(s for s in result["status_data"] if s["status"] == "PLANNED")
+        assert planned["amount"] == 150000.0
+        assert planned["agreements"] == 1
 
 
 class TestComputeProcurementStepSummary:


### PR DESCRIPTION
## What changed

The Procurement Overview dashboard card (`ProcurementOverviewCard.jsx`) was rendering an extra "Planned Mod" legend entry alongside Planned, Executing, and Obligated. The component itself just renders whatever `status_data` the backend returns, so the fix is on the backend.

**`backend/ops_api/ops/services/agreements.py`**: `_compute_procurement_overview` treated `BudgetLineItemStatus.PLANNED_MOD` as its own tracked status (contradicting its own docstring, which says it should only report PLANNED/IN_EXECUTION/OBLIGATED). `PLANNED_MOD` BLIs are modifications to already-`PLANNED` lines, so their amount/agreement counts are now folded into the `PLANNED` bucket instead of appearing as a fourth status — consistent with how `PLANNED_MOD` is already treated elsewhere in the app (e.g. `ProcurementDetailsTableRow.jsx` counts `PLANNED_MOD` as part of "Planned").

**`backend/ops_api/tests/ops/services/test_agreements.py`**: Updated `test_empty_list` to expect 3 tracked statuses instead of 4, and added `test_planned_mod_grouped_under_planned` to verify `PLANNED_MOD` amounts/agreement counts are merged into the `PLANNED` bucket.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5902

## How to test

1. Run the updated unit tests:
   ```
   cd backend/ops_api
   pipenv run pytest tests/ops/services/test_agreements.py -k TestComputeProcurementOverview -v
   ```
   All 8 tests should pass, including the new `test_planned_mod_grouped_under_planned`.
2. Manually verify in the UI: seed or use existing data with at least one `PLANNED_MOD` budget line item, load the Procurement Dashboard, and confirm the overview card legend shows only three entries — Planned, Executing, Obligated — with the `PLANNED_MOD` amount rolled into the Planned total.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] No UI component changes in this PR

## Screenshots

Fixed front end:
<img width="1050" height="385" alt="Screenshot 2026-07-22 at 3 30 47 PM" src="https://github.com/user-attachments/assets/74014ba6-c058-4699-9852-18119cb10939" />


## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A