### PR TITLE
feat: context-aware breadcrumbs (issue #3789 Deliverable A)

### DIFF
--- a/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
@@ -25,6 +25,8 @@ import { TABLE_HEADINGS_LIST } from "./AgreementsTable.constants";
 import { AWARD_TYPE_LABELS } from "../../../pages/agreements/agreements.constants";
 import { useHandleDeleteAgreement, useHandleEditAgreement, useNavigateAgreementReview } from "./AgreementsTable.hooks";
 import { useIsUserReadOnly } from "../../../hooks/user.hooks";
+import { useSetBreadcrumbTrail } from "../../../hooks/useBreadcrumbTrail.hooks";
+import { LIST_CRUMBS } from "../../../helpers/breadcrumb.helpers";
 
 /**
  * Renders a row in the agreements table.
@@ -70,6 +72,9 @@ export const AgreementTableRow = ({ agreement }) => {
     const [searchParams] = useSearchParams();
     const forApprovalUrl = searchParams.get("filter") === "for-approval";
 
+    const setBreadcrumbTrail = useSetBreadcrumbTrail();
+    const agreementPath = `/agreements/${agreement?.id}`;
+
     function getLockedMessage() {
         const lockedMessages = {
             notTeamMember: "Only team members on this agreement can edit, delete, or send to approval",
@@ -109,7 +114,10 @@ export const AgreementTableRow = ({ agreement }) => {
             <td data-cy="agreement-name">
                 <Link
                     className="text-ink text-no-underline"
-                    to={`/agreements/${agreement?.id}`}
+                    to={agreementPath}
+                    onClick={() =>
+                        setBreadcrumbTrail({ targetPath: agreementPath, ancestors: [LIST_CRUMBS.agreements] })
+                    }
                     aria-label={`View agreement details for ${agreementName || "agreement"}`}
                 >
                     <TextClip

--- a/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.jsx
+++ b/frontend/src/components/BudgetLineItems/AllBudgetLinesTable/AllBLIRow.jsx
@@ -16,6 +16,8 @@ import tableStyles from "../../UI/Table/table.module.css";
 import TableTag from "../../UI/TableTag";
 import TextClip from "../../UI/Text/TextClip";
 import { useGetPortfolioByIdQuery } from "../../../api/opsAPI";
+import { useSetBreadcrumbTrail } from "../../../hooks/useBreadcrumbTrail.hooks";
+import { LIST_CRUMBS } from "../../../helpers/breadcrumb.helpers";
 
 /**
  * BLIRow component that represents a single row in the Budget Lines table.
@@ -42,6 +44,9 @@ const AllBLIRow = ({ budgetLine }) => {
         budgetLine?.agreement?.name?.trim() ||
         (budgetLine?.agreement?.id ? `Agreement ${budgetLine.agreement.id}` : "Agreement details");
 
+    const setBreadcrumbTrail = useSetBreadcrumbTrail();
+    const agreementPath = budgetLine?.agreement?.id ? `/agreements/${budgetLine.agreement.id}` : "";
+
     const TableRowData = (
         <>
             <td data-cy="bli-id">{budgetLine.id}</td>
@@ -49,7 +54,13 @@ const AllBLIRow = ({ budgetLine }) => {
                 <div className={tableStyles.textClipContainer}>
                     {budgetLine?.agreement?.id ? (
                         <Link
-                            to={`/agreements/${budgetLine.agreement.id}`}
+                            to={agreementPath}
+                            onClick={() =>
+                                setBreadcrumbTrail({
+                                    targetPath: agreementPath,
+                                    ancestors: [LIST_CRUMBS.budgetLines]
+                                })
+                            }
                             className="text-ink text-no-underline"
                             aria-label={agreementLinkLabel}
                         >

--- a/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTable.jsx
+++ b/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTable.jsx
@@ -19,6 +19,7 @@ import { SORT_TYPES, useSortData } from "../../../hooks/use-sortable-data.hooks"
  * @property {number} totalFunding
  * @property {number} fiscalYear
  * @property {'portfolio' | 'can'} [tableType]
+ * @property {import("../../../sessionUISlice").BreadcrumbAncestor[]} [ancestry] - Breadcrumb ancestry passed to each row's agreement link (composed by the embedding page).
  */
 
 /**
@@ -26,7 +27,7 @@ import { SORT_TYPES, useSortData } from "../../../hooks/use-sortable-data.hooks"
  * @param {CANBudgetLineTableProps} props
  * @returns  {JSX.Element} - The component JSX.
  */
-const CANBudgetLineTable = ({ budgetLines, totalFunding, fiscalYear, tableType = "can" }) => {
+const CANBudgetLineTable = ({ budgetLines, totalFunding, fiscalYear, tableType = "can", ancestry = [] }) => {
     const { sortCondition, sortDescending, setSortConditions } = useSetSortConditions();
     const [currentPage, setCurrentPage] = React.useState(1);
     let visibleBudgetLines = budgetLines.filter((budgetLine) => !budgetLine.is_obe);
@@ -73,6 +74,7 @@ const CANBudgetLineTable = ({ budgetLines, totalFunding, fiscalYear, tableType =
                         creatorId={budgetLine.created_by}
                         creationDate={budgetLine.created_on}
                         description={budgetLine?.line_description ?? ""}
+                        ancestry={ancestry}
                     />
                 ))}
             </Table>

--- a/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.jsx
+++ b/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.jsx
@@ -12,6 +12,7 @@ import tableStyles from "../../UI/Table/table.module.css";
 import TableTag from "../../UI/TableTag";
 import TextClip from "../../UI/Text/TextClip";
 import { getProcurementShopLabel } from "../../../helpers/budgetLines.helpers";
+import { useSetBreadcrumbTrail } from "../../../hooks/useBreadcrumbTrail.hooks";
 
 /**
  * @typedef {import("../../../types/BudgetLineTypes").BudgetLine} BudgetLine
@@ -32,6 +33,7 @@ import { getProcurementShopLabel } from "../../../helpers/budgetLines.helpers";
  * @property {number} creatorId
  * @property {string} creationDate
  * @property {string} description
+ * @property {import("../../../sessionUISlice").BreadcrumbAncestor[]} [ancestry] - Breadcrumb ancestry to record when navigating to the agreement (composed by the embedding page: CAN detail vs. Portfolio spending).
  */
 
 /**
@@ -51,8 +53,10 @@ const CANBudgetLineTableRow = ({
     inReview,
     creatorId,
     creationDate,
-    description
+    description,
+    ancestry = []
 }) => {
+    const setBreadcrumbTrail = useSetBreadcrumbTrail();
     const lockedMessage = useChangeRequestsForTooltip(budgetLine);
     const { isExpanded, setIsRowActive, setIsExpanded } = useTableRow();
     const budgetLineCreatorName = useGetUserFullNameFromId(creatorId);
@@ -72,6 +76,12 @@ const CANBudgetLineTableRow = ({
                         <Link
                             className="text-ink text-no-underline"
                             to={`/agreements/${budgetLine.agreement.id}`}
+                            onClick={() =>
+                                setBreadcrumbTrail({
+                                    targetPath: `/agreements/${budgetLine.agreement.id}`,
+                                    ancestors: ancestry
+                                })
+                            }
                             aria-label={resolvedAgreementName}
                         >
                             <TextClip

--- a/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.test.jsx
+++ b/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.test.jsx
@@ -3,6 +3,7 @@ import CANBudgetLineTableRow from "./CANBudgetLineTableRow";
 import { formatDateNeeded } from "../../../helpers/utils";
 import { Provider } from "react-redux";
 import store from "../../../store";
+import { setupStore } from "../../../store";
 import { budgetLine } from "../../../tests/data";
 import userEvent from "@testing-library/user-event";
 import { BrowserRouter } from "react-router-dom"; // Add this import
@@ -98,5 +99,43 @@ describe("CANBudgetLineTableRow", () => {
         expect(screen.getByText("Procurement Shop")).toBeInTheDocument();
         expect(screen.getByText("$1,000.00")).toBeInTheDocument(); // amount
         expect(screen.getByText("$50.00")).toBeInTheDocument(); // fee
+    });
+
+    test("records the provided ancestry as the breadcrumb trail when the agreement link is clicked", async () => {
+        // Ancestry as it would arrive under the Portfolio spending tab:
+        // Portfolios > Portfolio A > CAN 1
+        const ancestry = [
+            { label: "Portfolios", to: "/portfolios" },
+            { label: "Portfolio A", to: "/portfolios/5" },
+            { label: "CAN 1", to: "/cans/1" }
+        ];
+        const testStore = setupStore();
+        render(
+            <Provider store={testStore}>
+                <BrowserRouter>
+                    <CANBudgetLineTableRow
+                        budgetLine={mockBudgetLine}
+                        blId={mockBudgetLine.id}
+                        agreementName="TBD"
+                        obligateDate={formatDateNeeded(mockBudgetLine.date_needed)}
+                        fiscalYear={mockBudgetLine.fiscal_year}
+                        amount={mockBudgetLine.amount}
+                        percentOfCAN={3}
+                        status={mockBudgetLine.status}
+                        inReview={mockBudgetLine.in_review}
+                        creatorId={mockBudgetLine.created_by}
+                        creationDate={mockBudgetLine.created_on}
+                        description={mockBudgetLine.line_description}
+                        ancestry={ancestry}
+                    />
+                </BrowserRouter>
+            </Provider>
+        );
+
+        await userEvent.click(screen.getByRole("link"));
+
+        const trail = testStore.getState().sessionUI.navContext.trail;
+        expect(trail.targetPath).toBe(`/agreements/${mockBudgetLine.agreement.id}`);
+        expect(trail.ancestors).toEqual(ancestry);
     });
 });

--- a/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.test.jsx
+++ b/frontend/src/components/CANs/CANBudgetLineTable/CANBudgetLineTableRow.test.jsx
@@ -1,12 +1,9 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import CANBudgetLineTableRow from "./CANBudgetLineTableRow";
 import { formatDateNeeded } from "../../../helpers/utils";
-import { Provider } from "react-redux";
-import store from "../../../store";
-import { setupStore } from "../../../store";
+import { renderWithProviders } from "../../../test-utils";
 import { budgetLine } from "../../../tests/data";
 import userEvent from "@testing-library/user-event";
-import { BrowserRouter } from "react-router-dom"; // Add this import
 
 const mockBudgetLine = {
     ...budgetLine,
@@ -34,28 +31,22 @@ const mockBudgetLine = {
 
 describe("CANBudgetLineTableRow", () => {
     test("renders table row data correctly", () => {
-        render(
-            <Provider store={store}>
-                <BrowserRouter>
-                    {" "}
-                    {/* Wrap with BrowserRouter */}
-                    <CANBudgetLineTableRow
-                        budgetLine={mockBudgetLine}
-                        blId={mockBudgetLine.id}
-                        agreementName="TBD"
-                        obligateDate={formatDateNeeded(mockBudgetLine.date_needed)}
-                        fiscalYear={mockBudgetLine.fiscal_year}
-                        amount={mockBudgetLine.amount}
-                        fee={mockBudgetLine.proc_shop_fee_percentage}
-                        percentOfCAN={3}
-                        status={mockBudgetLine.status}
-                        inReview={mockBudgetLine.in_review}
-                        creatorId={mockBudgetLine.created_by}
-                        creationDate={mockBudgetLine.created_on}
-                        procShopCode="TBD"
-                    />
-                </BrowserRouter>
-            </Provider>
+        renderWithProviders(
+            <CANBudgetLineTableRow
+                budgetLine={mockBudgetLine}
+                blId={mockBudgetLine.id}
+                agreementName="TBD"
+                obligateDate={formatDateNeeded(mockBudgetLine.date_needed)}
+                fiscalYear={mockBudgetLine.fiscal_year}
+                amount={mockBudgetLine.amount}
+                fee={mockBudgetLine.proc_shop_fee_percentage}
+                percentOfCAN={3}
+                status={mockBudgetLine.status}
+                inReview={mockBudgetLine.in_review}
+                creatorId={mockBudgetLine.created_by}
+                creationDate={mockBudgetLine.created_on}
+                procShopCode="TBD"
+            />
         );
 
         expect(screen.getByText("TBD")).toBeInTheDocument();
@@ -66,29 +57,23 @@ describe("CANBudgetLineTableRow", () => {
     });
 
     test("renders expanded data correctly", async () => {
-        render(
-            <Provider store={store}>
-                <BrowserRouter>
-                    {" "}
-                    {/* Wrap with BrowserRouter */}
-                    <CANBudgetLineTableRow
-                        budgetLine={mockBudgetLine}
-                        blId={mockBudgetLine.id}
-                        agreementName="TBD"
-                        obligateDate={formatDateNeeded(mockBudgetLine.date_needed)}
-                        fiscalYear={mockBudgetLine.fiscal_year}
-                        amount={mockBudgetLine.amount}
-                        fee={mockBudgetLine.proc_shop_fee_percentage}
-                        percentOfCAN={3}
-                        status={mockBudgetLine.status}
-                        inReview={mockBudgetLine.in_review}
-                        creatorId={mockBudgetLine.created_by}
-                        creationDate={mockBudgetLine.created_on}
-                        procShopCode="TBD"
-                        description={mockBudgetLine.line_description}
-                    />
-                </BrowserRouter>
-            </Provider>
+        renderWithProviders(
+            <CANBudgetLineTableRow
+                budgetLine={mockBudgetLine}
+                blId={mockBudgetLine.id}
+                agreementName="TBD"
+                obligateDate={formatDateNeeded(mockBudgetLine.date_needed)}
+                fiscalYear={mockBudgetLine.fiscal_year}
+                amount={mockBudgetLine.amount}
+                fee={mockBudgetLine.proc_shop_fee_percentage}
+                percentOfCAN={3}
+                status={mockBudgetLine.status}
+                inReview={mockBudgetLine.in_review}
+                creatorId={mockBudgetLine.created_by}
+                creationDate={mockBudgetLine.created_on}
+                procShopCode="TBD"
+                description={mockBudgetLine.line_description}
+            />
         );
 
         // Simulate expanding the row
@@ -109,32 +94,27 @@ describe("CANBudgetLineTableRow", () => {
             { label: "Portfolio A", to: "/portfolios/5" },
             { label: "CAN 1", to: "/cans/1" }
         ];
-        const testStore = setupStore();
-        render(
-            <Provider store={testStore}>
-                <BrowserRouter>
-                    <CANBudgetLineTableRow
-                        budgetLine={mockBudgetLine}
-                        blId={mockBudgetLine.id}
-                        agreementName="TBD"
-                        obligateDate={formatDateNeeded(mockBudgetLine.date_needed)}
-                        fiscalYear={mockBudgetLine.fiscal_year}
-                        amount={mockBudgetLine.amount}
-                        percentOfCAN={3}
-                        status={mockBudgetLine.status}
-                        inReview={mockBudgetLine.in_review}
-                        creatorId={mockBudgetLine.created_by}
-                        creationDate={mockBudgetLine.created_on}
-                        description={mockBudgetLine.line_description}
-                        ancestry={ancestry}
-                    />
-                </BrowserRouter>
-            </Provider>
+        const { store } = renderWithProviders(
+            <CANBudgetLineTableRow
+                budgetLine={mockBudgetLine}
+                blId={mockBudgetLine.id}
+                agreementName="TBD"
+                obligateDate={formatDateNeeded(mockBudgetLine.date_needed)}
+                fiscalYear={mockBudgetLine.fiscal_year}
+                amount={mockBudgetLine.amount}
+                percentOfCAN={3}
+                status={mockBudgetLine.status}
+                inReview={mockBudgetLine.in_review}
+                creatorId={mockBudgetLine.created_by}
+                creationDate={mockBudgetLine.created_on}
+                description={mockBudgetLine.line_description}
+                ancestry={ancestry}
+            />
         );
 
         await userEvent.click(screen.getByRole("link"));
 
-        const trail = testStore.getState().sessionUI.navContext.trail;
+        const trail = store.getState().sessionUI.navContext.trail;
         expect(trail.targetPath).toBe(`/agreements/${mockBudgetLine.agreement.id}`);
         expect(trail.ancestors).toEqual(ancestry);
     });

--- a/frontend/src/components/CANs/CANTable/CANTableRow.jsx
+++ b/frontend/src/components/CANs/CANTable/CANTableRow.jsx
@@ -3,6 +3,8 @@ import { formatCurrency } from "../../../helpers/currencyFormat.helpers";
 import Tooltip from "../../UI/USWDS/Tooltip";
 import { displayActivePeriod } from "./CANTableRow.helpers";
 import { NO_DATA } from "../../../constants";
+import { useSetBreadcrumbTrail } from "../../../hooks/useBreadcrumbTrail.hooks";
+import { LIST_CRUMBS } from "../../../helpers/breadcrumb.helpers";
 
 /**
  * CanTableRow component of CANTable
@@ -22,6 +24,8 @@ const CANTableRow = ({ activePeriod, canId, fundingSummary, name, nickname, obli
     const totalFunding = fundingSummary?.total_funding ?? 0;
     const fundingReceived = fundingSummary?.received_funding ?? 0;
     const availableFunds = fundingSummary?.available_funding ?? 0;
+    const setBreadcrumbTrail = useSetBreadcrumbTrail();
+    const canPath = `/cans/${canId}`;
 
     return (
         <tr>
@@ -31,7 +35,8 @@ const CANTableRow = ({ activePeriod, canId, fundingSummary, name, nickname, obli
                     position="right"
                 >
                     <Link
-                        to={`/cans/${canId}`}
+                        to={canPath}
+                        onClick={() => setBreadcrumbTrail({ targetPath: canPath, ancestors: [LIST_CRUMBS.cans] })}
                         className="text-ink text-no-underline"
                     >
                         {name}

--- a/frontend/src/components/CANs/CANTable/CANTableRow.test.jsx
+++ b/frontend/src/components/CANs/CANTable/CANTableRow.test.jsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import CANTableRow from "./CANTableRow";
-import { MemoryRouter } from "react-router-dom";
+import { renderWithProviders } from "../../../test-utils";
 
 // Mock the Tooltip component
 vi.mock("../../UI/USWDS/Tooltip", () => ({
@@ -27,14 +27,12 @@ describe("CANTableRow", () => {
     };
 
     it("renders the row with correct data", () => {
-        render(
-            <MemoryRouter>
-                <table>
-                    <tbody>
-                        <CANTableRow {...mockProps} />
-                    </tbody>
-                </table>
-            </MemoryRouter>
+        renderWithProviders(
+            <table>
+                <tbody>
+                    <CANTableRow {...mockProps} />
+                </tbody>
+            </table>
         );
 
         expect(screen.getByText("Test CAN")).toBeInTheDocument();
@@ -47,31 +45,27 @@ describe("CANTableRow", () => {
     });
 
     it("renders correct active period text for single year", () => {
-        render(
-            <MemoryRouter>
-                <table>
-                    <tbody>
-                        <CANTableRow
-                            {...mockProps}
-                            activePeriod={1}
-                        />
-                    </tbody>
-                </table>
-            </MemoryRouter>
+        renderWithProviders(
+            <table>
+                <tbody>
+                    <CANTableRow
+                        {...mockProps}
+                        activePeriod={1}
+                    />
+                </tbody>
+            </table>
         );
 
         expect(screen.getByText("1 year")).toBeInTheDocument();
     });
 
     it("renders tooltip with nickname", () => {
-        render(
-            <MemoryRouter>
-                <table>
-                    <tbody>
-                        <CANTableRow {...mockProps} />
-                    </tbody>
-                </table>
-            </MemoryRouter>
+        renderWithProviders(
+            <table>
+                <tbody>
+                    <CANTableRow {...mockProps} />
+                </tbody>
+            </table>
         );
 
         expect(screen.getByTestId("tooltip")).toBeInTheDocument();
@@ -79,33 +73,29 @@ describe("CANTableRow", () => {
     });
 
     it("renders TBD when totalFunding is 0", () => {
-        render(
-            <MemoryRouter>
-                <table>
-                    <tbody>
-                        <CANTableRow
-                            {...mockProps}
-                            fundingSummary={{ available_funding: 100_000, received_funding: 50_000, total_funding: 0 }}
-                        />
-                    </tbody>
-                </table>
-            </MemoryRouter>
+        renderWithProviders(
+            <table>
+                <tbody>
+                    <CANTableRow
+                        {...mockProps}
+                        fundingSummary={{ available_funding: 100_000, received_funding: 50_000, total_funding: 0 }}
+                    />
+                </tbody>
+            </table>
         );
         expect(screen.getByText("TBD")).toBeInTheDocument();
     });
 
     it("renders TBD when totalReceived is 0", () => {
-        render(
-            <MemoryRouter>
-                <table>
-                    <tbody>
-                        <CANTableRow
-                            {...mockProps}
-                            fundingSummary={{ available_funding: 100_000, received_funding: 0, total_funding: 100_000 }}
-                        />
-                    </tbody>
-                </table>
-            </MemoryRouter>
+        renderWithProviders(
+            <table>
+                <tbody>
+                    <CANTableRow
+                        {...mockProps}
+                        fundingSummary={{ available_funding: 100_000, received_funding: 0, total_funding: 100_000 }}
+                    />
+                </tbody>
+            </table>
         );
         expect(screen.getByText("TBD")).toBeInTheDocument();
     });

--- a/frontend/src/components/CANs/CanCard/CanCard.jsx
+++ b/frontend/src/components/CANs/CanCard/CanCard.jsx
@@ -8,6 +8,7 @@ import Tag from "../../UI/Tag";
 import style from "./styles.module.css";
 import { Link } from "react-router-dom";
 import { NO_DATA } from "../../../constants";
+import { useSetBreadcrumbTrail } from "../../../hooks/useBreadcrumbTrail.hooks";
 
 /**
  * @component CanCard
@@ -15,9 +16,11 @@ import { NO_DATA } from "../../../constants";
  * @param {Object} props - The props
  * @param {number} props.canId - The CAN id
  * @param {number} props.fiscalYear - The fiscal year
+ * @param {import("../../../sessionUISlice").BreadcrumbAncestor[]} [props.ancestry] - Breadcrumb ancestry to record when navigating to the CAN (composed by the embedding page).
  * @returns {JSX.Element} - The CAN card
  */
-const CanCard = ({ canId, fiscalYear }) => {
+const CanCard = ({ canId, fiscalYear, ancestry = [] }) => {
+    const setBreadcrumbTrail = useSetBreadcrumbTrail();
     const [receivedExpectedActiveId, setReceivedExpectedActiveId] = React.useState(0);
     const [spendingAvailableActiveId, setSpendingAvailableActiveId] = React.useState(0);
 
@@ -84,6 +87,7 @@ const CanCard = ({ canId, fiscalYear }) => {
         >
             <Link
                 to={`/cans/${can.id}`}
+                onClick={() => setBreadcrumbTrail({ targetPath: `/cans/${can.id}`, ancestors: ancestry })}
                 className="text-no-underline text-ink"
             >
                 <dl className={`margin-0 ${style.leftMarginContainer}`}>

--- a/frontend/src/components/CANs/CanCard/CanCard.test.jsx
+++ b/frontend/src/components/CANs/CanCard/CanCard.test.jsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { BrowserRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import store from "../../../store";
 import CanCard from "./CanCard";
 import { useGetCanFundingQuery } from "../../../api/opsAPI";
 
@@ -62,12 +64,14 @@ describe("CanCard", () => {
 
     it("renders CanCard with correct information", async () => {
         render(
-            <BrowserRouter>
-                <CanCard
-                    canId={mockCan.id}
-                    fiscalYear={mockFiscalYear}
-                />
-            </BrowserRouter>
+            <Provider store={store}>
+                <BrowserRouter>
+                    <CanCard
+                        canId={mockCan.id}
+                        fiscalYear={mockFiscalYear}
+                    />
+                </BrowserRouter>
+            </Provider>
         );
 
         // Check basic CAN information
@@ -96,12 +100,14 @@ describe("CanCard", () => {
 
     it("passes correct total_funding to the spending/available LineGraph", async () => {
         render(
-            <BrowserRouter>
-                <CanCard
-                    canId={mockCan.id}
-                    fiscalYear={mockFiscalYear}
-                />
-            </BrowserRouter>
+            <Provider store={store}>
+                <BrowserRouter>
+                    <CanCard
+                        canId={mockCan.id}
+                        fiscalYear={mockFiscalYear}
+                    />
+                </BrowserRouter>
+            </Provider>
         );
 
         await waitFor(() => {
@@ -133,12 +139,14 @@ describe("CanCard", () => {
         });
 
         render(
-            <BrowserRouter>
-                <CanCard
-                    canId={mockCan.id}
-                    fiscalYear={mockFiscalYear}
-                />
-            </BrowserRouter>
+            <Provider store={store}>
+                <BrowserRouter>
+                    <CanCard
+                        canId={mockCan.id}
+                        fiscalYear={mockFiscalYear}
+                    />
+                </BrowserRouter>
+            </Provider>
         );
 
         await waitFor(() => {
@@ -157,12 +165,14 @@ describe("CanCard", () => {
 
     it("applies fake-bold to Received label on hover", async () => {
         render(
-            <BrowserRouter>
-                <CanCard
-                    canId={mockCan.id}
-                    fiscalYear={mockFiscalYear}
-                />
-            </BrowserRouter>
+            <Provider store={store}>
+                <BrowserRouter>
+                    <CanCard
+                        canId={mockCan.id}
+                        fiscalYear={mockFiscalYear}
+                    />
+                </BrowserRouter>
+            </Provider>
         );
 
         await waitFor(() => {
@@ -178,12 +188,14 @@ describe("CanCard", () => {
 
     it("applies fake-bold to Expected label on hover", async () => {
         render(
-            <BrowserRouter>
-                <CanCard
-                    canId={mockCan.id}
-                    fiscalYear={mockFiscalYear}
-                />
-            </BrowserRouter>
+            <Provider store={store}>
+                <BrowserRouter>
+                    <CanCard
+                        canId={mockCan.id}
+                        fiscalYear={mockFiscalYear}
+                    />
+                </BrowserRouter>
+            </Provider>
         );
 
         await waitFor(() => {
@@ -199,12 +211,14 @@ describe("CanCard", () => {
 
     it("applies fake-bold to Spending label on hover", async () => {
         render(
-            <BrowserRouter>
-                <CanCard
-                    canId={mockCan.id}
-                    fiscalYear={mockFiscalYear}
-                />
-            </BrowserRouter>
+            <Provider store={store}>
+                <BrowserRouter>
+                    <CanCard
+                        canId={mockCan.id}
+                        fiscalYear={mockFiscalYear}
+                    />
+                </BrowserRouter>
+            </Provider>
         );
 
         await waitFor(() => {
@@ -220,12 +234,14 @@ describe("CanCard", () => {
 
     it("applies fake-bold to Available label on hover", async () => {
         render(
-            <BrowserRouter>
-                <CanCard
-                    canId={mockCan.id}
-                    fiscalYear={mockFiscalYear}
-                />
-            </BrowserRouter>
+            <Provider store={store}>
+                <BrowserRouter>
+                    <CanCard
+                        canId={mockCan.id}
+                        fiscalYear={mockFiscalYear}
+                    />
+                </BrowserRouter>
+            </Provider>
         );
 
         await waitFor(() => {
@@ -254,12 +270,14 @@ it("displays TBD when total_funding is 0", async () => {
     });
 
     render(
-        <BrowserRouter>
-            <CanCard
-                canId={mockCan.id}
-                fiscalYear={mockFiscalYear}
-            />
-        </BrowserRouter>
+        <Provider store={store}>
+            <BrowserRouter>
+                <CanCard
+                    canId={mockCan.id}
+                    fiscalYear={mockFiscalYear}
+                />
+            </BrowserRouter>
+        </Provider>
     );
 
     await waitFor(() => {

--- a/frontend/src/components/Portfolios/PortfolioFunding/PortfolioFunding.jsx
+++ b/frontend/src/components/Portfolios/PortfolioFunding/PortfolioFunding.jsx
@@ -9,7 +9,7 @@ import LineBar from "../../UI/DataViz/LineBar";
 
 const PortfolioFunding = () => {
     const [fyBudgetChartData, setFyBudgetChartData] = React.useState([]);
-    const { portfolioId, newFunding, fiscalYear, carryForward, totalFunding } = useOutletContext();
+    const { portfolioId, newFunding, fiscalYear, carryForward, totalFunding, linkAncestry } = useOutletContext();
 
     const [trigger] = useLazyGetPortfolioFundingSummaryQuery();
 
@@ -161,6 +161,7 @@ const PortfolioFunding = () => {
                             key={canId}
                             canId={canId}
                             fiscalYear={fiscalYear}
+                            ancestry={linkAncestry}
                         />
                     ))
                 )}

--- a/frontend/src/components/Portfolios/PortfolioSpending/PortfolioSpending.jsx
+++ b/frontend/src/components/Portfolios/PortfolioSpending/PortfolioSpending.jsx
@@ -19,7 +19,8 @@ const PortfolioSpending = () => {
         totalFunding,
         inExecutionFunding,
         obligatedFunding,
-        plannedFunding
+        plannedFunding,
+        linkAncestry
     } = useOutletContext();
 
     const {
@@ -112,6 +113,7 @@ const PortfolioSpending = () => {
                     totalFunding={totalFunding}
                     fiscalYear={fiscalYear}
                     tableType="portfolio"
+                    ancestry={linkAncestry}
                 />
             )}
         </>

--- a/frontend/src/components/UI/Header/Breadcrumb.jsx
+++ b/frontend/src/components/UI/Header/Breadcrumb.jsx
@@ -1,20 +1,49 @@
-import { Link, useMatches } from "react-router-dom";
+import { Link, useLocation, useMatches } from "react-router-dom";
+import { useSelector } from "react-redux";
 import PropTypes from "prop-types";
+import { trailMatchesPath } from "../../../helpers/breadcrumb.helpers";
 
 /**
  * Breadcrumb component
+ *
+ * Renders a context-aware trail when a stored nav-context trail applies to the
+ * current location (i.e. the user drilled in via a known navigation path);
+ * otherwise falls back to the canonical route hierarchy derived from React
+ * Router `handle.crumb` functions. `Home` and the leaf `currentName` are always
+ * rendered.
+ *
  * @param {Object} props - Properties passed to component
- * @param {string} props.currentName - The name of the current breadcrumb
+ * @param {string} props.currentName - The name of the current (leaf) breadcrumb
  * @returns {React.JSX.Element} - The rendered component
  */
 const Breadcrumb = ({ currentName }) => {
-    let matches = useMatches();
-    let crumbs = matches
-        // first get rid of any matches that don't have handle and crumb
-        .filter((match) => Boolean(match.handle?.crumb))
-        // now map them into an array of elements, passing the loader
-        // data to each one
-        .map((match) => match.handle.crumb(match.data));
+    const { pathname } = useLocation();
+    const trail = useSelector((state) => state.sessionUI?.navContext?.trail);
+    const matches = useMatches();
+
+    const useStoredTrail = trailMatchesPath(trail, pathname);
+
+    let intermediateCrumbs;
+    if (useStoredTrail) {
+        // Context-aware trail: render the stored ancestors as links.
+        intermediateCrumbs = trail.ancestors.map((ancestor, index) => (
+            <Link
+                key={index}
+                to={ancestor.to}
+                className="text-primary"
+            >
+                {ancestor.label}
+            </Link>
+        ));
+    } else {
+        // Fallback: canonical route hierarchy from `handle.crumb`.
+        intermediateCrumbs = matches
+            // first get rid of any matches that don't have handle and crumb
+            .filter((match) => Boolean(match.handle?.crumb))
+            // now map them into an array of elements, passing the loader
+            // data to each one
+            .map((match) => match.handle.crumb(match.data));
+    }
 
     return (
         <section className="bg-white">
@@ -26,12 +55,12 @@ const Breadcrumb = ({ currentName }) => {
                     <li className="usa-breadcrumb__list-item">
                         <Link
                             to="/"
-                            className="usa-breadbrumb__link text-primary"
+                            className="usa-breadcrumb__link text-primary"
                         >
                             Home
                         </Link>
                     </li>
-                    {crumbs.map((crumb, index) => (
+                    {intermediateCrumbs.map((crumb, index) => (
                         <li
                             key={index}
                             className="usa-breadcrumb__list-item"

--- a/frontend/src/components/UI/Header/Breadcrumb.stories.jsx
+++ b/frontend/src/components/UI/Header/Breadcrumb.stories.jsx
@@ -1,0 +1,75 @@
+import Breadcrumb from "./Breadcrumb";
+
+export default {
+    title: "UI/Header/Breadcrumb",
+    component: Breadcrumb,
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Context-aware breadcrumb trail. When a stored nav-context trail matches the current path, its ancestors render as links; otherwise the canonical route hierarchy is used. Home and the leaf name always render."
+            }
+        }
+    },
+    argTypes: {
+        currentName: { control: "text", description: "Leaf breadcrumb (current page) name" }
+    }
+};
+
+/** Fallback: no stored trail — only Home and the leaf render (route crumbs require a data router). */
+export const Fallback = {
+    args: {
+        currentName: "Agreement 1"
+    }
+};
+
+/** Context-aware: a stored trail for the current path renders ancestor links. */
+export const WithStoredTrail = {
+    args: {
+        currentName: "Agreement 1"
+    },
+    parameters: {
+        reactRouter: { initialEntries: ["/agreements/1"] },
+        store: {
+            preloadedState: {
+                sessionUI: {
+                    navContext: {
+                        trail: {
+                            targetPath: "/agreements/1",
+                            ancestors: [
+                                { label: "Portfolios", to: "/portfolios" },
+                                { label: "Portfolio A", to: "/portfolios/5" }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+/** Deep drill-down: Portfolios > Portfolio A > CAN 1 > Agreement 1. */
+export const DeepTrail = {
+    args: {
+        currentName: "Agreement 1"
+    },
+    parameters: {
+        reactRouter: { initialEntries: ["/agreements/1"] },
+        store: {
+            preloadedState: {
+                sessionUI: {
+                    navContext: {
+                        trail: {
+                            targetPath: "/agreements/1",
+                            ancestors: [
+                                { label: "Portfolios", to: "/portfolios" },
+                                { label: "Portfolio A", to: "/portfolios/5" },
+                                { label: "CAN 1", to: "/cans/1" }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+};

--- a/frontend/src/components/UI/Header/Breadcrumb.test.jsx
+++ b/frontend/src/components/UI/Header/Breadcrumb.test.jsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { createMemoryRouter, Link, RouterProvider } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { setupStore } from "../../../store";
+import Breadcrumb from "./Breadcrumb";
+
+/**
+ * Render Breadcrumb inside a data router so both the stored-trail path
+ * (needs `useLocation`) and the route-fallback path (needs `useMatches` +
+ * `handle.crumb`) are exercisable.
+ *
+ * @param {Object} options
+ * @param {string} [options.initialPath] - Location to render at.
+ * @param {Object} [options.preloadedState] - Redux preloaded state.
+ * @param {Object} [options.routeHandle] - `handle` attached to the leaf route (for the fallback path).
+ */
+const renderBreadcrumb = ({ initialPath = "/agreements/1", preloadedState = {}, routeHandle } = {}) => {
+    const store = setupStore(preloadedState);
+    const router = createMemoryRouter(
+        [
+            {
+                path: "/agreements/:id",
+                element: <Breadcrumb currentName="Agreement 1" />,
+                handle: routeHandle
+            },
+            {
+                path: "/cans/:id/*",
+                element: <Breadcrumb currentName="CAN 1" />,
+                handle: routeHandle
+            }
+        ],
+        { initialEntries: [initialPath] }
+    );
+    return {
+        store,
+        ...render(
+            <Provider store={store}>
+                <RouterProvider router={router} />
+            </Provider>
+        )
+    };
+};
+
+const agreementsRouteHandle = {
+    crumb: () => (
+        <Link
+            to="/agreements"
+            className="text-primary"
+        >
+            Agreements
+        </Link>
+    )
+};
+
+describe("Breadcrumb", () => {
+    it("always renders Home and the leaf currentName", () => {
+        renderBreadcrumb();
+        expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute("href", "/");
+        expect(screen.getByText("Agreement 1")).toBeInTheDocument();
+    });
+
+    it("renders the stored trail's ancestors when the trail matches the current path", () => {
+        renderBreadcrumb({
+            initialPath: "/agreements/1",
+            preloadedState: {
+                sessionUI: {
+                    navContext: {
+                        trail: {
+                            targetPath: "/agreements/1",
+                            ancestors: [
+                                { label: "Portfolios", to: "/portfolios" },
+                                { label: "Portfolio A", to: "/portfolios/5" }
+                            ]
+                        }
+                    }
+                }
+            }
+        });
+        expect(screen.getByRole("link", { name: "Portfolios" })).toHaveAttribute("href", "/portfolios");
+        expect(screen.getByRole("link", { name: "Portfolio A" })).toHaveAttribute("href", "/portfolios/5");
+        expect(screen.getByText("Agreement 1")).toBeInTheDocument();
+    });
+
+    it("falls back to the route hierarchy when the stored trail is for a different resource", () => {
+        renderBreadcrumb({
+            initialPath: "/agreements/1",
+            routeHandle: agreementsRouteHandle,
+            preloadedState: {
+                sessionUI: {
+                    navContext: {
+                        trail: {
+                            targetPath: "/agreements/99",
+                            ancestors: [{ label: "Portfolios", to: "/portfolios" }]
+                        }
+                    }
+                }
+            }
+        });
+        // Route-hierarchy crumb is shown; the stale trail's ancestors are not.
+        expect(screen.getByRole("link", { name: "Agreements" })).toHaveAttribute("href", "/agreements");
+        expect(screen.queryByRole("link", { name: "Portfolios" })).not.toBeInTheDocument();
+    });
+
+    it("falls back to the route hierarchy when there is no stored trail", () => {
+        renderBreadcrumb({
+            initialPath: "/agreements/1",
+            routeHandle: agreementsRouteHandle
+        });
+        expect(screen.getByRole("link", { name: "Agreements" })).toHaveAttribute("href", "/agreements");
+    });
+
+    it("keeps the stored trail on a detail-page tab sub-route", () => {
+        renderBreadcrumb({
+            initialPath: "/cans/1/spending",
+            preloadedState: {
+                sessionUI: {
+                    navContext: {
+                        trail: {
+                            targetPath: "/cans/1",
+                            ancestors: [{ label: "Portfolios", to: "/portfolios" }]
+                        }
+                    }
+                }
+            }
+        });
+        expect(screen.getByRole("link", { name: "Portfolios" })).toHaveAttribute("href", "/portfolios");
+    });
+});

--- a/frontend/src/helpers/breadcrumb.helpers.js
+++ b/frontend/src/helpers/breadcrumb.helpers.js
@@ -1,0 +1,99 @@
+/**
+ * Helpers for composing context-aware breadcrumb trails.
+ *
+ * The breadcrumb trail records how a user actually arrived at a detail page.
+ * It is written synchronously in an entry-point link's click handler — before
+ * navigation — because the click site is the only place where both the current
+ * page's ancestry and the destination path are known together.
+ *
+ * @typedef {import("../sessionUISlice").BreadcrumbAncestor} BreadcrumbAncestor
+ * @typedef {import("../sessionUISlice").BreadcrumbTrail} BreadcrumbTrail
+ */
+
+/**
+ * Canonical list-page crumbs, matching the labels used by the route
+ * `handle.crumb` fallbacks. Used as the first ancestor for each drill-down and
+ * as the `fallbackCrumb` when a detail page has no matching stored trail.
+ * @type {Record<string, BreadcrumbAncestor>}
+ */
+export const LIST_CRUMBS = {
+    portfolios: { label: "Portfolios", to: "/portfolios" },
+    agreements: { label: "Agreements", to: "/agreements" },
+    cans: { label: "CANs", to: "/cans" },
+    budgetLines: { label: "Budget Lines", to: "/budget-lines" }
+};
+
+/**
+ * Build a breadcrumb trail for a destination.
+ *
+ * Composition rule: the new trail is the ancestry the current page already
+ * carries (`parentAncestors`) plus the current page's own crumb (`ownCrumb`).
+ * Because each hop stores the ancestry of the previous hop, chains compose
+ * naturally across multiple drill-downs.
+ *
+ * @param {Object} params
+ * @param {string} params.targetPath - Destination base pathname (e.g. "/agreements/123"). No trailing tab segment.
+ * @param {BreadcrumbAncestor[]} [params.parentAncestors] - Ancestors of the page the link is rendered on.
+ * @param {BreadcrumbAncestor | null} [params.ownCrumb] - The current page's own crumb (label + link back to it). Omit for list pages, which are already represented by their route-fallback crumb.
+ * @returns {BreadcrumbTrail}
+ */
+export const buildTrail = ({ targetPath, parentAncestors = [], ownCrumb = null }) => {
+    const ancestors = ownCrumb ? [...parentAncestors, ownCrumb] : [...parentAncestors];
+    return { targetPath, ancestors };
+};
+
+/**
+ * Normalize a pathname to its base (id-bearing) form by stripping any trailing
+ * tab/sub-route segment. Detail pages render nested tabs whose pathname extends
+ * the base path (e.g. "/cans/1/spending"); the trail is keyed to the base path
+ * ("/cans/1") so it survives tab navigation.
+ *
+ * A "base" is the resource collection + id: two path segments (e.g. "/cans/1").
+ * Anything beyond the second segment is treated as a tab/sub-route and dropped.
+ *
+ * @param {string} pathname
+ * @returns {string} The base pathname (leading slash, at most two segments).
+ */
+export const toBasePath = (pathname) => {
+    if (!pathname) return "";
+    const segments = pathname.split("/").filter(Boolean);
+    return "/" + segments.slice(0, 2).join("/");
+};
+
+/**
+ * Decide whether a stored trail applies to the current location.
+ *
+ * Matches when the current pathname is the trail's target base path OR a
+ * sub-route (tab) beneath it — so the trail survives detail-page tab
+ * navigation — but never a sibling resource (e.g. "/cans/12" must not match a
+ * trail keyed to "/cans/1").
+ *
+ * @param {BreadcrumbTrail | null | undefined} trail
+ * @param {string} pathname - The current location pathname.
+ * @returns {boolean}
+ */
+export const trailMatchesPath = (trail, pathname) => {
+    if (!trail?.targetPath || !pathname) return false;
+    const base = trail.targetPath;
+    return pathname === base || pathname.startsWith(base + "/");
+};
+
+/**
+ * Resolve the ancestor list a detail page should pass to the entry-point links
+ * it renders. If a stored trail applies to the current location, the page's
+ * ancestors are that trail's ancestors plus the page's own crumb; otherwise
+ * the page falls back to its route-based crumb only.
+ *
+ * @param {Object} params
+ * @param {BreadcrumbTrail | null | undefined} params.trail - The stored trail.
+ * @param {string} params.pathname - The current location pathname.
+ * @param {BreadcrumbAncestor} params.ownCrumb - The current page's own crumb.
+ * @param {BreadcrumbAncestor} params.fallbackCrumb - The route-hierarchy crumb to use when no trail applies (e.g. the "CANs" list link).
+ * @returns {BreadcrumbAncestor[]} Ancestors to hand to child links.
+ */
+export const resolveAncestryForChildren = ({ trail, pathname, ownCrumb, fallbackCrumb }) => {
+    if (trailMatchesPath(trail, pathname)) {
+        return [...trail.ancestors, ownCrumb];
+    }
+    return [fallbackCrumb, ownCrumb];
+};

--- a/frontend/src/helpers/breadcrumb.helpers.js
+++ b/frontend/src/helpers/breadcrumb.helpers.js
@@ -24,43 +24,6 @@ export const LIST_CRUMBS = {
 };
 
 /**
- * Build a breadcrumb trail for a destination.
- *
- * Composition rule: the new trail is the ancestry the current page already
- * carries (`parentAncestors`) plus the current page's own crumb (`ownCrumb`).
- * Because each hop stores the ancestry of the previous hop, chains compose
- * naturally across multiple drill-downs.
- *
- * @param {Object} params
- * @param {string} params.targetPath - Destination base pathname (e.g. "/agreements/123"). No trailing tab segment.
- * @param {BreadcrumbAncestor[]} [params.parentAncestors] - Ancestors of the page the link is rendered on.
- * @param {BreadcrumbAncestor | null} [params.ownCrumb] - The current page's own crumb (label + link back to it). Omit for list pages, which are already represented by their route-fallback crumb.
- * @returns {BreadcrumbTrail}
- */
-export const buildTrail = ({ targetPath, parentAncestors = [], ownCrumb = null }) => {
-    const ancestors = ownCrumb ? [...parentAncestors, ownCrumb] : [...parentAncestors];
-    return { targetPath, ancestors };
-};
-
-/**
- * Normalize a pathname to its base (id-bearing) form by stripping any trailing
- * tab/sub-route segment. Detail pages render nested tabs whose pathname extends
- * the base path (e.g. "/cans/1/spending"); the trail is keyed to the base path
- * ("/cans/1") so it survives tab navigation.
- *
- * A "base" is the resource collection + id: two path segments (e.g. "/cans/1").
- * Anything beyond the second segment is treated as a tab/sub-route and dropped.
- *
- * @param {string} pathname
- * @returns {string} The base pathname (leading slash, at most two segments).
- */
-export const toBasePath = (pathname) => {
-    if (!pathname) return "";
-    const segments = pathname.split("/").filter(Boolean);
-    return "/" + segments.slice(0, 2).join("/");
-};
-
-/**
  * Decide whether a stored trail applies to the current location.
  *
  * Matches when the current pathname is the trail's target base path OR a

--- a/frontend/src/helpers/breadcrumb.helpers.test.js
+++ b/frontend/src/helpers/breadcrumb.helpers.test.js
@@ -1,74 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { buildTrail, toBasePath, trailMatchesPath, resolveAncestryForChildren } from "./breadcrumb.helpers";
+import { trailMatchesPath, resolveAncestryForChildren } from "./breadcrumb.helpers";
 
 const portfolios = { label: "Portfolios", to: "/portfolios" };
 const portfolioA = { label: "Portfolio A", to: "/portfolios/5" };
 const cans = { label: "CANs", to: "/cans" };
 const can1 = { label: "CAN 1", to: "/cans/1" };
-const agreements = { label: "Agreements", to: "/agreements" };
-
-describe("buildTrail", () => {
-    it("appends the current page's own crumb to the parent ancestors", () => {
-        const trail = buildTrail({
-            targetPath: "/agreements/1",
-            parentAncestors: [portfolios],
-            ownCrumb: portfolioA
-        });
-        expect(trail).toEqual({
-            targetPath: "/agreements/1",
-            ancestors: [portfolios, portfolioA]
-        });
-    });
-
-    it("composes multi-level drill-down chains", () => {
-        // Portfolios > Portfolio A already stored; user is on the CAN page which
-        // carries [Portfolios, Portfolio A, CAN 1]; clicking an agreement keeps it.
-        const trail = buildTrail({
-            targetPath: "/agreements/1",
-            parentAncestors: [portfolios, portfolioA, can1]
-        });
-        expect(trail.ancestors).toEqual([portfolios, portfolioA, can1]);
-        expect(trail.targetPath).toEqual("/agreements/1");
-    });
-
-    it("omits the own crumb when not provided (list-page entry)", () => {
-        const trail = buildTrail({
-            targetPath: "/cans/1",
-            parentAncestors: [cans]
-        });
-        expect(trail.ancestors).toEqual([cans]);
-    });
-
-    it("defaults parentAncestors to an empty array", () => {
-        const trail = buildTrail({ targetPath: "/agreements/1", ownCrumb: agreements });
-        expect(trail.ancestors).toEqual([agreements]);
-    });
-
-    it("does not mutate the passed parentAncestors array", () => {
-        const parents = [portfolios];
-        buildTrail({ targetPath: "/x/1", parentAncestors: parents, ownCrumb: portfolioA });
-        expect(parents).toEqual([portfolios]);
-    });
-});
-
-describe("toBasePath", () => {
-    it("returns the base for a two-segment path unchanged", () => {
-        expect(toBasePath("/cans/1")).toBe("/cans/1");
-    });
-
-    it("strips a trailing tab segment", () => {
-        expect(toBasePath("/cans/1/spending")).toBe("/cans/1");
-        expect(toBasePath("/agreements/123/budget-lines")).toBe("/agreements/123");
-    });
-
-    it("handles a single-segment (list) path", () => {
-        expect(toBasePath("/cans")).toBe("/cans");
-    });
-
-    it("returns empty string for empty input", () => {
-        expect(toBasePath("")).toBe("");
-    });
-});
 
 describe("trailMatchesPath", () => {
     const trail = { targetPath: "/cans/1", ancestors: [cans] };

--- a/frontend/src/helpers/breadcrumb.helpers.test.js
+++ b/frontend/src/helpers/breadcrumb.helpers.test.js
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { buildTrail, toBasePath, trailMatchesPath, resolveAncestryForChildren } from "./breadcrumb.helpers";
+
+const portfolios = { label: "Portfolios", to: "/portfolios" };
+const portfolioA = { label: "Portfolio A", to: "/portfolios/5" };
+const cans = { label: "CANs", to: "/cans" };
+const can1 = { label: "CAN 1", to: "/cans/1" };
+const agreements = { label: "Agreements", to: "/agreements" };
+
+describe("buildTrail", () => {
+    it("appends the current page's own crumb to the parent ancestors", () => {
+        const trail = buildTrail({
+            targetPath: "/agreements/1",
+            parentAncestors: [portfolios],
+            ownCrumb: portfolioA
+        });
+        expect(trail).toEqual({
+            targetPath: "/agreements/1",
+            ancestors: [portfolios, portfolioA]
+        });
+    });
+
+    it("composes multi-level drill-down chains", () => {
+        // Portfolios > Portfolio A already stored; user is on the CAN page which
+        // carries [Portfolios, Portfolio A, CAN 1]; clicking an agreement keeps it.
+        const trail = buildTrail({
+            targetPath: "/agreements/1",
+            parentAncestors: [portfolios, portfolioA, can1]
+        });
+        expect(trail.ancestors).toEqual([portfolios, portfolioA, can1]);
+        expect(trail.targetPath).toEqual("/agreements/1");
+    });
+
+    it("omits the own crumb when not provided (list-page entry)", () => {
+        const trail = buildTrail({
+            targetPath: "/cans/1",
+            parentAncestors: [cans]
+        });
+        expect(trail.ancestors).toEqual([cans]);
+    });
+
+    it("defaults parentAncestors to an empty array", () => {
+        const trail = buildTrail({ targetPath: "/agreements/1", ownCrumb: agreements });
+        expect(trail.ancestors).toEqual([agreements]);
+    });
+
+    it("does not mutate the passed parentAncestors array", () => {
+        const parents = [portfolios];
+        buildTrail({ targetPath: "/x/1", parentAncestors: parents, ownCrumb: portfolioA });
+        expect(parents).toEqual([portfolios]);
+    });
+});
+
+describe("toBasePath", () => {
+    it("returns the base for a two-segment path unchanged", () => {
+        expect(toBasePath("/cans/1")).toBe("/cans/1");
+    });
+
+    it("strips a trailing tab segment", () => {
+        expect(toBasePath("/cans/1/spending")).toBe("/cans/1");
+        expect(toBasePath("/agreements/123/budget-lines")).toBe("/agreements/123");
+    });
+
+    it("handles a single-segment (list) path", () => {
+        expect(toBasePath("/cans")).toBe("/cans");
+    });
+
+    it("returns empty string for empty input", () => {
+        expect(toBasePath("")).toBe("");
+    });
+});
+
+describe("trailMatchesPath", () => {
+    const trail = { targetPath: "/cans/1", ancestors: [cans] };
+
+    it("matches the exact base path", () => {
+        expect(trailMatchesPath(trail, "/cans/1")).toBe(true);
+    });
+
+    it("matches a sub-route (tab) beneath the base path", () => {
+        expect(trailMatchesPath(trail, "/cans/1/spending")).toBe(true);
+    });
+
+    it("does not match a sibling resource with a shared prefix", () => {
+        expect(trailMatchesPath(trail, "/cans/12")).toBe(false);
+    });
+
+    it("does not match an unrelated path", () => {
+        expect(trailMatchesPath(trail, "/agreements/1")).toBe(false);
+    });
+
+    it("returns false for a null trail", () => {
+        expect(trailMatchesPath(null, "/cans/1")).toBe(false);
+    });
+
+    it("returns false for an empty pathname", () => {
+        expect(trailMatchesPath(trail, "")).toBe(false);
+    });
+});
+
+describe("resolveAncestryForChildren", () => {
+    const ownCrumb = can1;
+    const fallbackCrumb = cans;
+
+    it("uses the stored trail's ancestors plus own crumb when the trail matches", () => {
+        const trail = { targetPath: "/cans/1", ancestors: [portfolios, portfolioA] };
+        const result = resolveAncestryForChildren({
+            trail,
+            pathname: "/cans/1/spending",
+            ownCrumb,
+            fallbackCrumb
+        });
+        expect(result).toEqual([portfolios, portfolioA, can1]);
+    });
+
+    it("falls back to [fallbackCrumb, ownCrumb] when no trail applies", () => {
+        const result = resolveAncestryForChildren({
+            trail: null,
+            pathname: "/cans/1",
+            ownCrumb,
+            fallbackCrumb
+        });
+        expect(result).toEqual([cans, can1]);
+    });
+
+    it("falls back when the trail is for a different resource", () => {
+        const trail = { targetPath: "/cans/99", ancestors: [portfolios] };
+        const result = resolveAncestryForChildren({
+            trail,
+            pathname: "/cans/1",
+            ownCrumb,
+            fallbackCrumb
+        });
+        expect(result).toEqual([cans, can1]);
+    });
+});

--- a/frontend/src/hooks/useBreadcrumbTrail.hooks.js
+++ b/frontend/src/hooks/useBreadcrumbTrail.hooks.js
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 import { useDispatch } from "react-redux";
 import { setTrail } from "../sessionUISlice";
-import { buildTrail } from "../helpers/breadcrumb.helpers";
 
 /**
  * Returns a click handler that records the breadcrumb trail for a destination
@@ -18,7 +17,7 @@ export const useSetBreadcrumbTrail = () => {
     const dispatch = useDispatch();
     return useCallback(
         ({ targetPath, ancestors = [] }) => {
-            dispatch(setTrail(buildTrail({ targetPath, parentAncestors: ancestors })));
+            dispatch(setTrail({ targetPath, ancestors: [...ancestors] }));
         },
         [dispatch]
     );

--- a/frontend/src/hooks/useBreadcrumbTrail.hooks.js
+++ b/frontend/src/hooks/useBreadcrumbTrail.hooks.js
@@ -1,0 +1,25 @@
+import { useCallback } from "react";
+import { useDispatch } from "react-redux";
+import { setTrail } from "../sessionUISlice";
+import { buildTrail } from "../helpers/breadcrumb.helpers";
+
+/**
+ * Returns a click handler that records the breadcrumb trail for a destination
+ * synchronously (before navigation), so the destination page renders with the
+ * correct context-aware crumbs and no first-paint flicker.
+ *
+ * @returns {(params: { targetPath: string, ancestors?: import("../sessionUISlice").BreadcrumbAncestor[] }) => void}
+ *   A function to call from an entry-point link's onClick. `ancestors` is the
+ *   full ancestor list for the destination (already composed by the caller,
+ *   e.g. via `resolveAncestryForChildren` on a detail page or a static list
+ *   crumb + own crumb on a list row).
+ */
+export const useSetBreadcrumbTrail = () => {
+    const dispatch = useDispatch();
+    return useCallback(
+        ({ targetPath, ancestors = [] }) => {
+            dispatch(setTrail(buildTrail({ targetPath, parentAncestors: ancestors })));
+        },
+        [dispatch]
+    );
+};

--- a/frontend/src/pages/cans/detail/Can.jsx
+++ b/frontend/src/pages/cans/detail/Can.jsx
@@ -1,8 +1,10 @@
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router-dom";
+import { useSelector } from "react-redux";
 import App from "../../../App";
 import CanDetailTabs from "../../../components/CANs/CanDetailTabs/CanDetailTabs";
 import PageHeader from "../../../components/UI/PageHeader";
 import { NO_DATA } from "../../../constants";
+import { LIST_CRUMBS, resolveAncestryForChildren } from "../../../helpers/breadcrumb.helpers";
 import CANFiscalYearSelect from "../list/CANFiscalYearSelect";
 import useCan from "./Can.hooks";
 import CanDetail from "./CanDetail";
@@ -50,6 +52,19 @@ const Can = () => {
         toggleDetailPageEditMode,
         toggleFundingPageEditMode
     } = useCan();
+
+    // Compose the ancestry that child entry-point links (CANBudgetLineTable) should
+    // record when navigating to an agreement. If the user drilled into this CAN via a
+    // known path (e.g. Portfolios > Portfolio A > CAN 1) the stored trail supplies the
+    // ancestors; otherwise fall back to the CANs list. The leaf is this CAN.
+    const { pathname } = useLocation();
+    const storedTrail = useSelector((state) => state.sessionUI?.navContext?.trail);
+    const linkAncestry = resolveAncestryForChildren({
+        trail: storedTrail,
+        pathname,
+        ownCrumb: { label: can?.display_name ?? "CAN", to: `/cans/${canId}` },
+        fallbackCrumb: LIST_CRUMBS.cans
+    });
 
     if (isLoading) {
         return <p>Loading CAN...</p>;
@@ -111,6 +126,7 @@ const Can = () => {
                             plannedFunding={plannedFunding}
                             totalFunding={totalFunding}
                             isTableLoading={isTableLoading}
+                            ancestry={linkAncestry}
                         />
                     }
                 />

--- a/frontend/src/pages/cans/detail/CanSpending.jsx
+++ b/frontend/src/pages/cans/detail/CanSpending.jsx
@@ -29,6 +29,7 @@ import { calculatePercent } from "../../../helpers/utils";
  * @property {number} obligatedFunding
  * @property {number} totalFunding
  * @property {boolean} [isTableLoading]
+ * @property {import("../../../sessionUISlice").BreadcrumbAncestor[]} [ancestry] - Breadcrumb ancestry passed to the budget-line table's agreement links.
  */
 
 /**
@@ -47,7 +48,8 @@ const CanSpending = ({
     inDraftFunding,
     obligatedFunding,
     totalFunding,
-    isTableLoading = false
+    isTableLoading = false,
+    ancestry = []
 }) => {
     const totalSpending = Number(plannedFunding) + Number(obligatedFunding) + Number(inExecutionFunding);
 
@@ -113,6 +115,7 @@ const CanSpending = ({
                     budgetLines={budgetLines}
                     totalFunding={totalFunding}
                     fiscalYear={fiscalYear}
+                    ancestry={ancestry}
                 />
             )}
         </article>

--- a/frontend/src/pages/portfolios/detail/PortfolioDetail.jsx
+++ b/frontend/src/pages/portfolios/detail/PortfolioDetail.jsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { Outlet, useParams, useSearchParams } from "react-router-dom";
+import { Outlet, useLocation, useParams, useSearchParams } from "react-router-dom";
+import { useSelector } from "react-redux";
 import App from "../../../App";
+import { LIST_CRUMBS, resolveAncestryForChildren } from "../../../helpers/breadcrumb.helpers";
 import {
     useGetPortfolioByIdQuery,
     useGetPortfolioFundingSummaryQuery,
@@ -39,6 +41,18 @@ const PortfolioDetail = () => {
     const { data: portfolioUrl } = useGetPortfolioUrlByIdQuery(portfolioId);
     const projectTypesCount = getTypesCounts(projects ?? [], "project_type");
 
+    // Compose the ancestry that child entry-point links (CanCard, CANBudgetLineTable)
+    // should record. A portfolio is reached directly from the Portfolios list, so its
+    // parent crumb is always the Portfolios list; the leaf is this portfolio.
+    const { pathname } = useLocation();
+    const storedTrail = useSelector((state) => state.sessionUI?.navContext?.trail);
+    const linkAncestry = resolveAncestryForChildren({
+        trail: storedTrail,
+        pathname,
+        ownCrumb: { label: portfolio?.name ?? "Portfolio", to: `/portfolios/${portfolioId}` },
+        fallbackCrumb: LIST_CRUMBS.portfolios
+    });
+
     const isLoading = portfolioIsLoading || portfolioFundingLoading;
 
     if (isLoading) {
@@ -74,7 +88,8 @@ const PortfolioDetail = () => {
                         inDraftFunding: portfolioFunding?.draft_funding?.amount ?? 0,
                         inExecutionFunding: portfolioFunding?.in_execution_funding?.amount ?? 0,
                         obligatedFunding: portfolioFunding?.obligated_funding?.amount ?? 0,
-                        plannedFunding: portfolioFunding?.planned_funding?.amount ?? 0
+                        plannedFunding: portfolioFunding?.planned_funding?.amount ?? 0,
+                        linkAncestry
                     }}
                 />
             </div>

--- a/frontend/src/sessionUISlice.js
+++ b/frontend/src/sessionUISlice.js
@@ -1,0 +1,60 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { logout } from "./components/Auth/authSlice";
+
+/**
+ * Session-scoped UI state that survives client-side navigation and tab switches
+ * but is intentionally lost on browser refresh / new tab (in-memory Redux) and
+ * cleared on logout.
+ *
+ * Deliverable A (breadcrumbs) uses `navContext.trail`.
+ * Deliverable B (filter persistence) will add a `listFilters` sub-state here so
+ * there is a single logout-reset hook for all session UI state.
+ *
+ * @typedef {Object} BreadcrumbAncestor
+ * @property {string} label - The crumb text.
+ * @property {string} to - The path the crumb links to.
+ *
+ * @typedef {Object} BreadcrumbTrail
+ * @property {string} targetPath - Destination base pathname the trail applies to (e.g. "/agreements/123").
+ * @property {BreadcrumbAncestor[]} ancestors - Crumbs shown before the leaf, in order.
+ */
+
+const initialState = {
+    navContext: {
+        /** @type {BreadcrumbTrail | null} */
+        trail: null
+    }
+};
+
+const sessionUISlice = createSlice({
+    name: "sessionUI",
+    initialState,
+    reducers: {
+        /**
+         * Record the breadcrumb trail for a destination, set synchronously at
+         * click time (before navigation) so the destination renders with the
+         * correct crumbs and no first-paint flicker.
+         * @param {typeof initialState} state
+         * @param {{ payload: BreadcrumbTrail }} action
+         */
+        setTrail: (state, action) => {
+            state.navContext.trail = action.payload;
+        },
+        /**
+         * Clear any stored breadcrumb trail.
+         * @param {typeof initialState} state
+         */
+        clearTrail: (state) => {
+            state.navContext.trail = null;
+        }
+    },
+    extraReducers: (builder) => {
+        // Single logout-reset hook for all session UI state. All logout
+        // call-sites dispatch this same action, so one case covers every path.
+        builder.addCase(logout, () => initialState);
+    }
+});
+
+export const { setTrail, clearTrail } = sessionUISlice.actions;
+
+export default sessionUISlice.reducer;

--- a/frontend/src/sessionUISlice.test.js
+++ b/frontend/src/sessionUISlice.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import sessionUIReducer, { setTrail, clearTrail } from "./sessionUISlice";
+import { logout } from "./components/Auth/authSlice";
+
+const initialState = {
+    navContext: {
+        trail: null
+    }
+};
+
+describe("sessionUISlice", () => {
+    it("returns the initial state", () => {
+        expect(sessionUIReducer(undefined, { type: "@@INIT" })).toEqual(initialState);
+    });
+
+    it("setTrail stores the trail", () => {
+        const trail = {
+            targetPath: "/agreements/1",
+            ancestors: [
+                { label: "Portfolios", to: "/portfolios" },
+                { label: "Portfolio A", to: "/portfolios/5" }
+            ]
+        };
+        const state = sessionUIReducer(initialState, setTrail(trail));
+        expect(state.navContext.trail).toEqual(trail);
+    });
+
+    it("setTrail overwrites a previously stored trail", () => {
+        const first = { targetPath: "/cans/1", ancestors: [{ label: "CANs", to: "/cans" }] };
+        const second = { targetPath: "/agreements/2", ancestors: [{ label: "Agreements", to: "/agreements" }] };
+        let state = sessionUIReducer(initialState, setTrail(first));
+        state = sessionUIReducer(state, setTrail(second));
+        expect(state.navContext.trail).toEqual(second);
+    });
+
+    it("clearTrail resets the trail to null", () => {
+        const populated = {
+            navContext: { trail: { targetPath: "/cans/1", ancestors: [{ label: "CANs", to: "/cans" }] } }
+        };
+        const state = sessionUIReducer(populated, clearTrail());
+        expect(state.navContext.trail).toBeNull();
+    });
+
+    it("resets to initial state on logout", () => {
+        const populated = {
+            navContext: { trail: { targetPath: "/cans/1", ancestors: [{ label: "CANs", to: "/cans" }] } }
+        };
+        const state = sessionUIReducer(populated, logout());
+        expect(state).toEqual(initialState);
+    });
+});

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -4,6 +4,7 @@ import authSlice from "./components/Auth/authSlice";
 import userSlice from "./pages/users/detail/userSlice";
 import userEditSlice from "./pages/users/edit/userSlice";
 import alertSlice from "./components/UI/Alert/alertSlice";
+import sessionUISlice from "./sessionUISlice";
 import { opsApi, resetApiOnLogoutMiddleware } from "./api/opsAPI";
 import { githubApi } from "./api/github";
 import { opsAuthApi } from "./api/opsAuthAPI.js";
@@ -16,7 +17,8 @@ const rootReducer = combineReducers({
     auth: authSlice,
     userDetail: userSlice,
     userDetailEdit: userEditSlice,
-    alert: alertSlice
+    alert: alertSlice,
+    sessionUI: sessionUISlice
 });
 
 export const setupStore = (preloadedState = {}) => {


### PR DESCRIPTION
## What changed

Breadcrumbs are now **context-aware**: the trail reflects how the user actually reached a detail page instead of the static route hierarchy. For example, an agreement opened from a portfolio shows `Home > Portfolios > Portfolio A > Agreement` rather than the generic `Home > Agreements > Agreement` (the complaint in the issue).

**Approach:** a session-scoped Redux slice (`sessionUISlice`) stores a breadcrumb trail that is written **synchronously at click time** in each entry-point link, keyed to the destination base path. `Breadcrumb.jsx` renders the stored ancestors when the trail matches the current path (prefix match, so it survives detail-page tab navigation), and otherwise falls back to the existing `useMatches()` route hierarchy for direct URL / global search / notification link / browser-refresh entry.

Key pieces:
- **`sessionUISlice`** — `navContext.trail` with `setTrail`/`clearTrail`, logout reset via `extraReducers` on the existing `logout` action. Intentionally shared for the upcoming filter-persistence work (Deliverable B).
- **`breadcrumb.helpers.js`** — trail composition + prefix-path matching; **`useBreadcrumbTrail`** hook dispatches at click.
- **`Breadcrumb.jsx`** — reads the trail via `useSelector` + `useLocation`; also fixes the pre-existing `usa-breadbrumb__link` CSS typo.
- **Entry-point links wired:** `AgreementTableRow`, `AllBLIRow`, `CANTableRow` (single-context) and `CanCard` + `CANBudgetLineTableRow` (ancestry threaded from `Can`/`PortfolioDetail` through `CanSpending`/`PortfolioSpending`/`PortfolioFunding`).

This is **Deliverable A** of the issue. Deliverable B (session-persistent list filters) builds on the same session slice and ships separately.

## Issue

https://github.com/HHS/OPRE-OPS/issues/3789

## How to test

1. Open an agreement from the **Agreements list** → breadcrumb reads `Home > Agreements > <name>`.
2. Open the **same agreement** from a **Portfolio** (Portfolio detail → Spending tab → click a budget line's agreement) → breadcrumb reads `Home > Portfolios > <portfolio> > <name>`.
3. From a Portfolio → Funding tab → click a CAN → `Home > Portfolios > <portfolio> > <CAN>`. Click the CAN's **Spending tab** → the trail **persists** across the tab change.
4. Reach a detail page by **direct URL / refresh** (no click) → falls back to the canonical route hierarchy (`Home > Agreements > …`), no broken crumbs.
5. Each crumb links back to the correct ancestor.

_Verified locally by walking all 5 enumerated paths + fallback + tab-survival in the running stack._

## A11y impact

- [x] No accessibility-impacting changes in this PR

_Breadcrumb markup/roles unchanged; only crumb contents differ. (Also fixes a mislabeled CSS class.)_

## Storybook

- [x] Story added for new component in `src/components/UI/`

_Added `Breadcrumb.stories.jsx` (fallback, stored-trail, and deep-trail variants)._

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated