### PR TITLE
feat: session-persistent list filters (issue #3789 Deliverable B)

### DIFF
--- a/frontend/src/hooks/useListFilters.hooks.js
+++ b/frontend/src/hooks/useListFilters.hooks.js
@@ -1,0 +1,51 @@
+import { useCallback } from "react";
+import { useSelector, useDispatch, useStore } from "react-redux";
+import { setListFilters, setListFiscalYear } from "../sessionUISlice";
+
+/**
+ * Session-persistent replacement for a list page's local `useState` filter
+ * state. Returns a `useState`-compatible API backed by the shared
+ * `sessionUISlice`, so applied filters survive client-side navigation (e.g.
+ * returning to a list via breadcrumb) and reset on logout.
+ *
+ * Both setters accept an object OR a functional updater `(prev) => next`,
+ * matching the `useState` contract that the *FilterButton / *FilterTags
+ * sub-components rely on. Updaters are resolved against the latest committed
+ * store state (via `useStore().getState()`) rather than a possibly-stale
+ * render-time closure.
+ *
+ * @param {string} page - The page key registered in the slice (e.g. "agreements").
+ * @returns {{
+ *   filters: Object,
+ *   setFilters: (updater: Object | ((prev: Object) => Object)) => void,
+ *   selectedFiscalYear: string|number|undefined,
+ *   setSelectedFiscalYear: (updater: (string|number) | ((prev: string|number) => (string|number))) => void
+ * }}
+ */
+export const useListFilters = (page) => {
+    const dispatch = useDispatch();
+    const store = useStore();
+
+    const filters = useSelector((state) => state.sessionUI.listFilters[page]?.filters);
+    const selectedFiscalYear = useSelector((state) => state.sessionUI.listFilters[page]?.selectedFiscalYear);
+
+    const setFilters = useCallback(
+        (updater) => {
+            const current = store.getState().sessionUI.listFilters[page]?.filters;
+            const next = typeof updater === "function" ? updater(current) : updater;
+            dispatch(setListFilters({ page, filters: next }));
+        },
+        [dispatch, store, page]
+    );
+
+    const setSelectedFiscalYear = useCallback(
+        (updater) => {
+            const current = store.getState().sessionUI.listFilters[page]?.selectedFiscalYear;
+            const next = typeof updater === "function" ? updater(current) : updater;
+            dispatch(setListFiscalYear({ page, selectedFiscalYear: next }));
+        },
+        [dispatch, store, page]
+    );
+
+    return { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear };
+};

--- a/frontend/src/hooks/useListFilters.hooks.js
+++ b/frontend/src/hooks/useListFilters.hooks.js
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useSelector, useDispatch, useStore } from "react-redux";
-import { setListFilters, setListFiscalYear } from "../sessionUISlice";
+import { setListFilters, setListFiscalYear, resetListFilters } from "../sessionUISlice";
 
 /**
  * Session-persistent replacement for a list page's local `useState` filter
@@ -19,19 +19,20 @@ import { setListFilters, setListFiscalYear } from "../sessionUISlice";
  *   filters: Object,
  *   setFilters: (updater: Object | ((prev: Object) => Object)) => void,
  *   selectedFiscalYear: string|number|undefined,
- *   setSelectedFiscalYear: (updater: (string|number) | ((prev: string|number) => (string|number))) => void
+ *   setSelectedFiscalYear: (updater: (string|number) | ((prev: string|number) => (string|number))) => void,
+ *   changeFiscalYear: (newFiscalYear: string|number) => void
  * }}
  */
 export const useListFilters = (page) => {
     const dispatch = useDispatch();
     const store = useStore();
 
-    const filters = useSelector((state) => state.sessionUI.listFilters[page]?.filters);
-    const selectedFiscalYear = useSelector((state) => state.sessionUI.listFilters[page]?.selectedFiscalYear);
+    const filters = useSelector((state) => state.sessionUI?.listFilters?.[page]?.filters);
+    const selectedFiscalYear = useSelector((state) => state.sessionUI?.listFilters?.[page]?.selectedFiscalYear);
 
     const setFilters = useCallback(
         (updater) => {
-            const current = store.getState().sessionUI.listFilters[page]?.filters;
+            const current = store.getState().sessionUI?.listFilters?.[page]?.filters;
             const next = typeof updater === "function" ? updater(current) : updater;
             dispatch(setListFilters({ page, filters: next }));
         },
@@ -40,12 +41,26 @@ export const useListFilters = (page) => {
 
     const setSelectedFiscalYear = useCallback(
         (updater) => {
-            const current = store.getState().sessionUI.listFilters[page]?.selectedFiscalYear;
+            const current = store.getState().sessionUI?.listFilters?.[page]?.selectedFiscalYear;
             const next = typeof updater === "function" ? updater(current) : updater;
             dispatch(setListFiscalYear({ page, selectedFiscalYear: next }));
         },
         [dispatch, store, page]
     );
 
-    return { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear };
+    // Change the fiscal year AND reset this page's other filters to defaults, as
+    // a single atomic gesture. Persistence keeps filters across navigation, but
+    // changing FY is an explicit "start over for a new year" action — a filter
+    // (e.g. a budget range) valid in one FY is not meaningful in another. This
+    // is the one place all FY-aware list pages funnel through, so the reset
+    // behavior stays consistent (see resetListFilters in sessionUISlice).
+    const changeFiscalYear = useCallback(
+        (newFiscalYear) => {
+            dispatch(resetListFilters({ page }));
+            dispatch(setListFiscalYear({ page, selectedFiscalYear: newFiscalYear }));
+        },
+        [dispatch, page]
+    );
+
+    return { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear, changeFiscalYear };
 };

--- a/frontend/src/hooks/useListFilters.hooks.test.jsx
+++ b/frontend/src/hooks/useListFilters.hooks.test.jsx
@@ -73,4 +73,16 @@ describe("useListFilters", () => {
         act(() => resultCans.current.setFilters((prev) => ({ ...prev, can: [{ id: 1 }] })));
         expect(resultAgreements.current.filters).toEqual(listFilterDefaults.agreements.filters);
     });
+
+    it("changeFiscalYear resets filters to defaults AND sets the new fiscal year atomically", () => {
+        const store = setupStore();
+        const { result } = renderWithStore("cans", store);
+        // Apply a budget + portfolio filter, then change the fiscal year.
+        act(() => result.current.setFilters((prev) => ({ ...prev, can: [{ id: 9 }], budget: [10, 50] })));
+        act(() => result.current.changeFiscalYear(2030));
+        // Filters are back to defaults (not carried across the FY change)...
+        expect(result.current.filters).toEqual(listFilterDefaults.cans.filters);
+        // ...and the new FY is applied.
+        expect(result.current.selectedFiscalYear).toBe(2030);
+    });
 });

--- a/frontend/src/hooks/useListFilters.hooks.test.jsx
+++ b/frontend/src/hooks/useListFilters.hooks.test.jsx
@@ -1,0 +1,76 @@
+import { renderHook, act } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { describe, it, expect } from "vitest";
+import { setupStore } from "../store";
+import { logout } from "../components/Auth/authSlice";
+import { listFilterDefaults } from "../sessionUISlice";
+import { useListFilters } from "./useListFilters.hooks";
+
+/**
+ * Render useListFilters against a shared store instance so we can simulate an
+ * unmount/remount (navigate away and back) within one session.
+ */
+const renderWithStore = (page, store) => {
+    const wrapper = ({ children }) => <Provider store={store}>{children}</Provider>;
+    return renderHook(() => useListFilters(page), { wrapper });
+};
+
+describe("useListFilters", () => {
+    it("returns the page's default filters initially", () => {
+        const store = setupStore();
+        const { result } = renderWithStore("cans", store);
+        expect(result.current.filters).toEqual(listFilterDefaults.cans.filters);
+        expect(result.current.selectedFiscalYear).toEqual(listFilterDefaults.cans.selectedFiscalYear);
+    });
+
+    it("accepts an object update", () => {
+        const store = setupStore();
+        const { result } = renderWithStore("cans", store);
+        const next = { ...listFilterDefaults.cans.filters, can: [{ id: 7, title: "C7" }] };
+        act(() => result.current.setFilters(next));
+        expect(result.current.filters).toEqual(next);
+    });
+
+    it("accepts a functional updater resolved against the latest state", () => {
+        const store = setupStore();
+        const { result } = renderWithStore("agreements", store);
+        act(() => result.current.setFilters((prev) => ({ ...prev, portfolio: [{ id: 1 }] })));
+        act(() => result.current.setFilters((prev) => ({ ...prev, agreementType: [{ id: 2 }] })));
+        // Both updates compose — the second updater saw the first's result.
+        expect(result.current.filters.portfolio).toEqual([{ id: 1 }]);
+        expect(result.current.filters.agreementType).toEqual([{ id: 2 }]);
+    });
+
+    it("persists filters + fiscal year across unmount/remount within a session", () => {
+        const store = setupStore();
+        const { result: resultBefore, unmount } = renderWithStore("cans", store);
+        act(() => resultBefore.current.setFilters((prev) => ({ ...prev, can: [{ id: 9 }] })));
+        act(() => resultBefore.current.setSelectedFiscalYear(2031));
+        // Navigate away.
+        unmount();
+
+        // Return to the list (fresh mount, same store).
+        const { result: resultAfter } = renderWithStore("cans", store);
+        expect(resultAfter.current.filters.can).toEqual([{ id: 9 }]);
+        expect(resultAfter.current.selectedFiscalYear).toBe(2031);
+    });
+
+    it("clears persisted filters on logout", () => {
+        const store = setupStore();
+        const { result, rerender } = renderWithStore("cans", store);
+        act(() => result.current.setFilters((prev) => ({ ...prev, can: [{ id: 9 }] })));
+        act(() => {
+            store.dispatch(logout());
+        });
+        rerender();
+        expect(result.current.filters).toEqual(listFilterDefaults.cans.filters);
+    });
+
+    it("keeps each page's filters independent", () => {
+        const store = setupStore();
+        const { result: resultCans } = renderWithStore("cans", store);
+        const { result: resultAgreements } = renderWithStore("agreements", store);
+        act(() => resultCans.current.setFilters((prev) => ({ ...prev, can: [{ id: 1 }] })));
+        expect(resultAgreements.current.filters).toEqual(listFilterDefaults.agreements.filters);
+    });
+});

--- a/frontend/src/pages/agreements/list/AgreementsList.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.jsx
@@ -26,7 +26,6 @@ import PaginationNav from "../../../components/UI/PaginationNav/PaginationNav";
 import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
 import { USER_ROLES } from "../../../components/Users/User.constants";
 import { useListFilters } from "../../../hooks/useListFilters.hooks";
-import { listFilterDefaults } from "../../../sessionUISlice";
 import { ITEMS_PER_PAGE } from "../../../constants";
 import { exportTableToXlsx } from "../../../helpers/tableExport.helpers";
 import { convertCodeForDisplay, formatDate, getCurrentFiscalYear } from "../../../helpers/utils";
@@ -51,7 +50,8 @@ const AgreementsList = () => {
     // Filters + selected fiscal year persist across client-side navigation via
     // the session slice, so returning to this list (e.g. via breadcrumb) keeps
     // the user's selections applied.
-    const { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear } = useListFilters("agreements");
+    const { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear, changeFiscalYear } =
+        useListFilters("agreements");
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions();
     const [currentPage, setCurrentPage] = useState(1); // 1-indexed for UI
     const [pageSize] = useState(ITEMS_PER_PAGE);
@@ -140,8 +140,7 @@ const AgreementsList = () => {
 
     // Handle fiscal year change - clear filters when changing fiscal year selection
     const handleChangeFiscalYear = (newValue) => {
-        setFilters({ ...listFilterDefaults.agreements.filters });
-        setSelectedFiscalYear(newValue);
+        changeFiscalYear(newValue);
     };
 
     const [trigger] = useLazyGetUserQuery();

--- a/frontend/src/pages/agreements/list/AgreementsList.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { PacmanLoader } from "react-spinners";
@@ -25,6 +25,8 @@ import FiscalYear from "../../../components/UI/FiscalYear";
 import PaginationNav from "../../../components/UI/PaginationNav/PaginationNav";
 import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
 import { USER_ROLES } from "../../../components/Users/User.constants";
+import { useListFilters } from "../../../hooks/useListFilters.hooks";
+import { listFilterDefaults } from "../../../sessionUISlice";
 import { ITEMS_PER_PAGE } from "../../../constants";
 import { exportTableToXlsx } from "../../../helpers/tableExport.helpers";
 import { convertCodeForDisplay, formatDate, getCurrentFiscalYear } from "../../../helpers/utils";
@@ -46,19 +48,13 @@ const AgreementsList = () => {
     const isBudgetTeam = userRoles.some((role) => role?.name === USER_ROLES.BUDGET_TEAM);
     const [isExporting, setIsExporting] = useState(false);
     const [searchParams] = useSearchParams();
-    const [filters, setFilters] = useState({
-        portfolio: [],
-        fiscalYear: [],
-        projectTitle: [],
-        agreementType: [],
-        agreementName: [],
-        contractNumber: [],
-        awardType: []
-    });
+    // Filters + selected fiscal year persist across client-side navigation via
+    // the session slice, so returning to this list (e.g. via breadcrumb) keeps
+    // the user's selections applied.
+    const { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear } = useListFilters("agreements");
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions();
     const [currentPage, setCurrentPage] = useState(1); // 1-indexed for UI
     const [pageSize] = useState(ITEMS_PER_PAGE);
-    const [selectedFiscalYear, setSelectedFiscalYear] = React.useState(getCurrentFiscalYear());
 
     const myAgreementsUrl = searchParams.get("filter") === "my-agreements";
     const changeRequestUrl = searchParams.get("filter") === "change-requests";
@@ -140,19 +136,11 @@ const AgreementsList = () => {
                 setSelectedFiscalYear("All");
             }
         }
-    }, [filters.fiscalYear, selectedFiscalYear]);
+    }, [filters.fiscalYear, selectedFiscalYear, setSelectedFiscalYear]);
 
     // Handle fiscal year change - clear filters when changing fiscal year selection
     const handleChangeFiscalYear = (newValue) => {
-        setFilters({
-            portfolio: [],
-            fiscalYear: [],
-            projectTitle: [],
-            agreementType: [],
-            agreementName: [],
-            contractNumber: [],
-            awardType: []
-        });
+        setFilters({ ...listFilterDefaults.agreements.filters });
         setSelectedFiscalYear(newValue);
     };
 

--- a/frontend/src/pages/agreements/list/AgreementsList.test.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.test.jsx
@@ -12,6 +12,7 @@ import {
 import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
 import { getCurrentFiscalYear } from "../../../helpers/utils";
 import store from "../../../store";
+import { logout } from "../../../components/Auth/authSlice";
 import AgreementsList from "./AgreementsList";
 
 // Mock the API hooks
@@ -166,6 +167,9 @@ afterEach(() => {
     const root = document.createElement("div");
     root.setAttribute("id", "root");
     document.body.appendChild(root);
+    // Filters/FY now persist in the shared session slice; reset it between tests
+    // so persisted selections don't leak across test cases (logout resets it).
+    store.dispatch(logout());
 });
 
 describe("AgreementsList - Pagination", () => {

--- a/frontend/src/pages/budgetLines/list/BudgetLinesItems.hooks.js
+++ b/frontend/src/pages/budgetLines/list/BudgetLinesItems.hooks.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { useSearchParams } from "react-router-dom";
 import { getFiscalYearHelpers } from "./fiscalYearFilterHelpers";
+import { useListFilters } from "../../../hooks/useListFilters.hooks";
 
 export const useBudgetLinesList = () => {
     const [searchParams] = useSearchParams();
@@ -13,16 +14,10 @@ export const useBudgetLinesList = () => {
     // Memoize helpers to avoid unnecessary re-renders
     const fyHelpers = React.useMemo(() => getFiscalYearHelpers(useApproachB), [useApproachB]);
 
-    // Initialize with approach-specific initial state
-    const [filters, setFilters] = React.useState(() => ({
-        fiscalYears: fyHelpers.getInitialState(),
-        portfolios: [],
-        bliStatus: [],
-        budgetRange: null,
-        agreementTypes: [],
-        agreementTitles: [],
-        canActivePeriods: []
-    }));
+    // Filters persist across client-side navigation via the session slice. The
+    // fiscalYears default (null) matches fyHelpers.getInitialState() for both
+    // A/B approaches, so the derived helpers stay here, out of the slice.
+    const { filters, setFilters } = useListFilters("budgetLines");
 
     return {
         myBudgetLineItemsUrl: searchParams.get("filter") === "my-budget-lines",

--- a/frontend/src/pages/cans/list/CANFilterButton/CANFilterButton.hooks.js
+++ b/frontend/src/pages/cans/list/CANFilterButton/CANFilterButton.hooks.js
@@ -48,7 +48,17 @@ export const useCANFilterButton = (filters, setFilters, fyBudgetRange) => {
     }, [fyBudgetRange, filters.budget]);
 
     const applyFilter = () => {
-        if (budget === fyBudgetRange) {
+        // Compare by VALUE, not reference: `fyBudgetRange` is a fresh useMemo
+        // array each render and `budget` may originate from the persisted Redux
+        // slice, so a `===` reference check would never match. When the pending
+        // budget equals the full available range, treat it as "no budget filter"
+        // and omit it from the applied filters.
+        const isFullRange =
+            Array.isArray(budget) &&
+            Array.isArray(fyBudgetRange) &&
+            budget[0] === fyBudgetRange[0] &&
+            budget[1] === fyBudgetRange[1];
+        if (isFullRange) {
             setFilters((prevState) => {
                 return {
                     ...prevState,

--- a/frontend/src/pages/cans/list/CANFilterButton/CANFilterButton.hooks.js
+++ b/frontend/src/pages/cans/list/CANFilterButton/CANFilterButton.hooks.js
@@ -59,13 +59,16 @@ export const useCANFilterButton = (filters, setFilters, fyBudgetRange) => {
             budget[0] === fyBudgetRange[0] &&
             budget[1] === fyBudgetRange[1];
         if (isFullRange) {
+            // Full range === no budget filter: clear any previously-applied budget
+            // (setting [] rather than omitting it, so a persisted budget is removed).
             setFilters((prevState) => {
                 return {
                     ...prevState,
                     activePeriod: activePeriod,
                     transfer: transfer,
                     portfolio: portfolio,
-                    can: can
+                    can: can,
+                    budget: []
                 };
             });
         } else {

--- a/frontend/src/pages/cans/list/CANFilterButton/CANFilterButton.hooks.test.jsx
+++ b/frontend/src/pages/cans/list/CANFilterButton/CANFilterButton.hooks.test.jsx
@@ -1,0 +1,44 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { useCANFilterButton } from "./CANFilterButton.hooks";
+
+/**
+ * Regression test for the budget-clear bug: when the pending budget equals the
+ * full available range, applyFilter must CLEAR the persisted budget filter
+ * (set it to []), not silently retain the previous value via `...prevState`.
+ */
+describe("useCANFilterButton — applyFilter budget handling", () => {
+    const fyBudgetRange = [0, 100];
+
+    it("clears the budget filter when the selected range equals the full available range", () => {
+        // Persisted filters already contain a narrower budget from a prior apply.
+        const filters = { activePeriod: [], transfer: [], portfolio: [], can: [], budget: [10, 50] };
+        const setFilters = vi.fn();
+
+        const { result } = renderHook(() => useCANFilterButton(filters, setFilters, fyBudgetRange));
+
+        // The effect seeds `budget` to fyBudgetRange, then filters.budget ([10,50]) wins.
+        // Simulate the user dragging the slider back to the full range.
+        act(() => result.current.setBudget(fyBudgetRange));
+        act(() => result.current.applyFilter());
+
+        // setFilters is called with a functional updater; resolve it against prev state.
+        const updater = setFilters.mock.calls.at(-1)[0];
+        const next = typeof updater === "function" ? updater(filters) : updater;
+        expect(next.budget).toEqual([]); // cleared, not [10,50]
+    });
+
+    it("applies the budget filter when a narrower range is selected", () => {
+        const filters = { activePeriod: [], transfer: [], portfolio: [], can: [], budget: [] };
+        const setFilters = vi.fn();
+
+        const { result } = renderHook(() => useCANFilterButton(filters, setFilters, fyBudgetRange));
+
+        act(() => result.current.setBudget([20, 80]));
+        act(() => result.current.applyFilter());
+
+        const updater = setFilters.mock.calls.at(-1)[0];
+        const next = typeof updater === "function" ? updater(filters) : updater;
+        expect(next.budget).toEqual([20, 80]);
+    });
+});

--- a/frontend/src/pages/cans/list/CanList.jsx
+++ b/frontend/src/pages/cans/list/CanList.jsx
@@ -28,7 +28,7 @@ const CanList = () => {
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions();
     // Filters + selected fiscal year persist across client-side navigation via
     // the session slice (see useListFilters).
-    const { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear } = useListFilters("cans");
+    const { filters, setFilters, selectedFiscalYear, changeFiscalYear } = useListFilters("cans");
     const [currentPage, setCurrentPage] = React.useState(1); // 1-indexed for UI
     const [pageSize] = React.useState(ITEMS_PER_PAGE);
 
@@ -191,7 +191,7 @@ const CanList = () => {
                 FYSelect={
                     <CANFiscalYearSelect
                         fiscalYear={fiscalYear}
-                        setSelectedFiscalYear={setSelectedFiscalYear}
+                        setSelectedFiscalYear={changeFiscalYear}
                     />
                 }
                 FilterTags={

--- a/frontend/src/pages/cans/list/CanList.jsx
+++ b/frontend/src/pages/cans/list/CanList.jsx
@@ -8,7 +8,8 @@ import CANTableLoading from "../../../components/CANs/CANTable/CANTableLoading";
 import CANTags from "../../../components/CANs/CanTabs";
 import TablePageLayout from "../../../components/Layouts/TablePageLayout";
 import PaginationNav from "../../../components/UI/PaginationNav/PaginationNav";
-import { getCurrentFiscalYear, codesToDisplayText } from "../../../helpers/utils";
+import { codesToDisplayText } from "../../../helpers/utils";
+import { useListFilters } from "../../../hooks/useListFilters.hooks";
 import CANFilterButton from "./CANFilterButton";
 import CANFilterTags from "./CANFilterTags";
 import CANFiscalYearSelect from "./CANFiscalYearSelect";
@@ -25,16 +26,11 @@ import { ITEMS_PER_PAGE } from "../../../constants";
 const CanList = () => {
     const navigate = useNavigate();
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions();
-    const [selectedFiscalYear, setSelectedFiscalYear] = React.useState(getCurrentFiscalYear());
+    // Filters + selected fiscal year persist across client-side navigation via
+    // the session slice (see useListFilters).
+    const { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear } = useListFilters("cans");
     const [currentPage, setCurrentPage] = React.useState(1); // 1-indexed for UI
     const [pageSize] = React.useState(ITEMS_PER_PAGE);
-    const [filters, setFilters] = React.useState({
-        activePeriod: [],
-        transfer: [],
-        portfolio: [],
-        can: [],
-        budget: []
-    });
 
     // Determine fiscal year filter - send empty array when "All" is selected
     const getFiscalYearFilter = () => {

--- a/frontend/src/pages/cans/list/CanList.test.jsx
+++ b/frontend/src/pages/cans/list/CanList.test.jsx
@@ -1,6 +1,7 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderWithProviders } from "../../../test-utils";
 import CanList from "./CanList";
 import { useGetCanFilterOptionsQuery, useGetCansFundingQuery, useGetCansQuery } from "../../../api/opsAPI";
 
@@ -107,14 +108,14 @@ describe("CanList", () => {
             isFetching: false
         });
 
-        render(<CanList />);
+        renderWithProviders(<CanList />);
 
         expect(screen.getByRole("table", { name: "Loading CANs" })).toBeInTheDocument();
         expect(screen.getByRole("columnheader", { name: "CAN" })).toBeInTheDocument();
     });
 
     it("renders the CAN table once data has loaded", () => {
-        render(<CanList />);
+        renderWithProviders(<CanList />);
 
         expect(screen.getByTestId("can-table")).toBeInTheDocument();
         expect(screen.getByTestId("can-summary-cards")).toBeInTheDocument();
@@ -123,7 +124,7 @@ describe("CanList", () => {
     it("sends empty fiscalYear array when 'All' is selected, resulting in no fiscal_year query param", async () => {
         const user = userEvent.setup();
 
-        render(<CanList />);
+        renderWithProviders(<CanList />);
 
         // Initially, should call with current fiscal year as array
         expect(useGetCansQuery).toHaveBeenCalledWith(

--- a/frontend/src/pages/portfolios/list/PortfolioList.hooks.js
+++ b/frontend/src/pages/portfolios/list/PortfolioList.hooks.js
@@ -24,7 +24,7 @@ export const usePortfolioList = ({ currentUserId, searchParams }) => {
     const tabFromUrl = searchParams.get("tab") || "all";
     // Filters + selected fiscal year persist across client-side navigation via
     // the session slice (see useListFilters).
-    const { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear } = useListFilters("portfolios");
+    const { filters, setFilters, selectedFiscalYear, changeFiscalYear } = useListFilters("portfolios");
     const [activeTab, setActiveTab] = useState(tabFromUrl);
 
     const fiscalYear = Number(selectedFiscalYear);
@@ -33,22 +33,16 @@ export const usePortfolioList = ({ currentUserId, searchParams }) => {
     const unfilteredBudgetRangeRef = useRef(null);
     const prevFiscalYearRef = useRef(selectedFiscalYear);
 
-    // Reset filters and cached budget range when fiscal year changes
+    // When the fiscal year actually changes, the persisted filters are reset by
+    // `changeFiscalYear` (in the slice); here we only drop the cached slider
+    // range so it recomputes from the new fiscal year's data. Guarded by a ref so
+    // it no-ops on remount with an unchanged (persisted) fiscal year.
     useEffect(() => {
         if (prevFiscalYearRef.current !== selectedFiscalYear) {
-            // Reset all filters including budget range
-            setFilters((prev) => ({
-                ...prev,
-                portfolios: [],
-                budgetRange: DEFAULT_PORTFOLIO_BUDGET_RANGE,
-                availablePct: []
-            }));
-
-            // Reset cached budget range so it recalculates from new fiscal year data
             unfilteredBudgetRangeRef.current = null;
             prevFiscalYearRef.current = selectedFiscalYear;
         }
-    }, [selectedFiscalYear, setFilters]);
+    }, [selectedFiscalYear]);
 
     // Prepare filter parameters for API call
     const portfolioIds = Array.isArray(filters.portfolios) ? filters.portfolios.map((p) => p.id) : [];
@@ -158,7 +152,7 @@ export const usePortfolioList = ({ currentUserId, searchParams }) => {
     return {
         // State
         selectedFiscalYear,
-        setSelectedFiscalYear,
+        setSelectedFiscalYear: changeFiscalYear,
         activeTab,
         setActiveTab,
         filters,

--- a/frontend/src/pages/portfolios/list/PortfolioList.hooks.js
+++ b/frontend/src/pages/portfolios/list/PortfolioList.hooks.js
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useGetPortfoliosQuery, useGetPortfolioFundingSummaryBatchQuery } from "../../../api/opsAPI";
-import { getCurrentFiscalYear } from "../../../helpers/utils";
 import { filterMyPortfolios } from "./PortfolioList.helpers";
 import { DEFAULT_PORTFOLIO_BUDGET_RANGE } from "../../../constants";
+import { useListFilters } from "../../../hooks/useListFilters.hooks";
 
 /**
  * Custom hook for managing portfolio list state and data fetching
@@ -22,13 +22,10 @@ export const usePortfolioList = ({ currentUserId, searchParams }) => {
 
     // Simple state initialization with defaults
     const tabFromUrl = searchParams.get("tab") || "all";
-    const [selectedFiscalYear, setSelectedFiscalYear] = useState(getCurrentFiscalYear());
+    // Filters + selected fiscal year persist across client-side navigation via
+    // the session slice (see useListFilters).
+    const { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear } = useListFilters("portfolios");
     const [activeTab, setActiveTab] = useState(tabFromUrl);
-    const [filters, setFilters] = useState({
-        portfolios: [],
-        budgetRange: DEFAULT_PORTFOLIO_BUDGET_RANGE,
-        availablePct: []
-    });
 
     const fiscalYear = Number(selectedFiscalYear);
 
@@ -51,7 +48,7 @@ export const usePortfolioList = ({ currentUserId, searchParams }) => {
             unfilteredBudgetRangeRef.current = null;
             prevFiscalYearRef.current = selectedFiscalYear;
         }
-    }, [selectedFiscalYear]);
+    }, [selectedFiscalYear, setFilters]);
 
     // Prepare filter parameters for API call
     const portfolioIds = Array.isArray(filters.portfolios) ? filters.portfolios.map((p) => p.id) : [];

--- a/frontend/src/pages/portfolios/list/PortfolioList.hooks.test.js
+++ b/frontend/src/pages/portfolios/list/PortfolioList.hooks.test.js
@@ -1,14 +1,20 @@
 import { renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { usePortfolioList } from "./PortfolioList.hooks";
 import * as opsAPI from "../../../api/opsAPI";
 import { DEFAULT_PORTFOLIO_BUDGET_RANGE } from "../../../constants";
+import { setupStore } from "../../../store";
 
 // Mock the API
 vi.mock("../../../api/opsAPI", () => ({
     useGetPortfoliosQuery: vi.fn(),
     useGetPortfolioFundingSummaryBatchQuery: vi.fn()
 }));
+
+// usePortfolioList now sources filters from the session slice (useListFilters),
+// so the hook must run inside a Redux Provider. Use a fresh store per test.
+const wrapper = ({ children }) => <Provider store={setupStore()}>{children}</Provider>;
 
 describe("usePortfolioList", () => {
     const mockSearchParams = new URLSearchParams();
@@ -77,7 +83,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         expect(result.current.isLoading).toBe(true);
         expect(result.current.isError).toBe(false);
@@ -97,7 +105,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         expect(result.current.isLoading).toBe(false);
         expect(result.current.isError).toBe(true);
@@ -117,7 +127,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         expect(result.current.isLoading).toBe(false);
         expect(result.current.portfoliosWithFunding).toHaveLength(3);
@@ -141,7 +153,9 @@ describe("usePortfolioList", () => {
 
         mockSearchParams.set("tab", "my");
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         // User 1 is team leader for portfolios 1 and 3
         expect(result.current.filteredPortfolios).toHaveLength(2);
@@ -163,7 +177,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         expect(result.current.fyBudgetRange).toEqual([10000000, 50000000]);
     });
@@ -182,7 +198,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         // Should default to current fiscal year (as string since getCurrentFiscalYear returns string)
         const currentYear = new Date().getFullYear();
@@ -205,7 +223,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         expect(result.current.activeTab).toBe("all");
     });
@@ -226,7 +246,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         expect(result.current.activeTab).toBe("my");
     });
@@ -245,7 +267,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         expect(result.current.filters.portfolios).toEqual([]);
         expect(result.current.filters.budgetRange).toEqual(DEFAULT_PORTFOLIO_BUDGET_RANGE);
@@ -266,7 +290,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         // Should only include portfolio 1, others filtered out
         expect(result.current.portfoliosWithFunding).toHaveLength(1);
@@ -287,7 +313,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         expect(result.current.fyBudgetRange).toEqual(DEFAULT_PORTFOLIO_BUDGET_RANGE);
     });
@@ -326,7 +354,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         // Should return buffered range (±10%) to avoid slider division by zero
         // Budget is 50000, so range should be [45000, 55001] (Math.ceil handles floating point)
@@ -367,7 +397,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         // Should return buffered range (±10%) to avoid slider division by zero
         // All budgets are 50000, so range should be [45000, 55001] (Math.ceil handles floating point)
@@ -388,7 +420,9 @@ describe("usePortfolioList", () => {
             isError: false
         });
 
-        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }));
+        const { result } = renderHook(() => usePortfolioList({ currentUserId, searchParams: mockSearchParams }), {
+            wrapper
+        });
 
         // This should not crash the hook
         expect(() => {

--- a/frontend/src/pages/procurementDashboard/ProcurementDashboardPage.jsx
+++ b/frontend/src/pages/procurementDashboard/ProcurementDashboardPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useLocation } from "react-router-dom";
 import icons from "../../uswds/img/sprite.svg";
 import App from "../../App";
@@ -9,6 +9,7 @@ import { useGetAllAgreements } from "../../hooks/useGetAllAgreements";
 import { BLI_STATUS } from "../../helpers/budgetLines.helpers";
 import { exportMultiSheetToXlsx } from "../../helpers/tableExport.helpers";
 import { getCurrentFiscalYear } from "../../helpers/utils";
+import { useListFilters } from "../../hooks/useListFilters.hooks";
 import ProcurementDashboardFilterButton from "./ProcurementDashboardFilterButton";
 import ProcurementDashboardFilterTags from "./ProcurementDashboardFilterTags";
 import ProcurementDashboardTabs from "./summary/ProcurementDashboardTabs";
@@ -29,7 +30,8 @@ const ProcurementDashboard = () => {
     const filterParam = new URLSearchParams(search).get("filter");
     const awardTypeFilter = FILTER_TO_AWARD_TYPE[filterParam] ?? null;
 
-    const [filters, setFilters] = useState({ procShop: [], division: [] });
+    // Filters persist across client-side navigation via the session slice.
+    const { filters, setFilters } = useListFilters("procurementDashboard");
 
     const { data: procurementShops = [] } = useGetProcurementShopsQuery();
     const { data: divisions = [] } = useGetDivisionsQuery();

--- a/frontend/src/pages/procurementDashboard/ProcurementDashboardPage.test.jsx
+++ b/frontend/src/pages/procurementDashboard/ProcurementDashboardPage.test.jsx
@@ -6,6 +6,7 @@ import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import ProcurementDashboard from "./ProcurementDashboardPage";
 import { opsApi } from "../../api/opsAPI";
+import sessionUIReducer from "../../sessionUISlice";
 
 const mockUseGetAllAgreements = vi.fn();
 const mockUseGetProcurementShopsQuery = vi.fn();
@@ -56,7 +57,7 @@ vi.mock("./summary/ProcurementDashboardTabs", () => ({
 
 function renderWithProviders(ui, { route = "/procurement-dashboard" } = {}) {
     const store = configureStore({
-        reducer: { [opsApi.reducerPath]: opsApi.reducer },
+        reducer: { [opsApi.reducerPath]: opsApi.reducer, sessionUI: sessionUIReducer },
         middleware: (gDM) => gDM().concat(opsApi.middleware)
     });
     return render(

--- a/frontend/src/pages/projects/list/ProjectsList.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.jsx
@@ -12,7 +12,7 @@ import PaginationNav from "../../../components/UI/PaginationNav/PaginationNav";
 import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
 import { ITEMS_PER_PAGE } from "../../../constants";
 import { exportTableToXlsx } from "../../../helpers/tableExport.helpers";
-import { getCurrentFiscalYear } from "../../../helpers/utils";
+import { useListFilters } from "../../../hooks/useListFilters.hooks";
 import useAlert from "../../../hooks/use-alert.hooks";
 import icons from "../../../uswds/img/sprite.svg";
 import { handleProjectsExport, PROJECT_SORT_CODES } from "./ProjectsList.helpers";
@@ -27,18 +27,13 @@ const ProjectsList = () => {
     const navigate = useNavigate();
     const [currentPage, setCurrentPage] = React.useState(1);
     const [pageSize] = React.useState(ITEMS_PER_PAGE);
-    const [selectedFiscalYear, setSelectedFiscalYear] = React.useState(getCurrentFiscalYear());
     const [isExporting, setIsExporting] = React.useState(false);
     const { setAlert } = useAlert();
     const [getAllProjectsTrigger] = useLazyGetProjectsQuery();
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions(PROJECT_SORT_CODES.TITLE, false);
-    const [filters, setFilters] = React.useState({
-        fiscalYear: [],
-        portfolio: [],
-        projectSearch: [],
-        agreementSearch: [],
-        projectType: []
-    });
+    // Filters + selected fiscal year persist across client-side navigation via
+    // the session slice (see useListFilters).
+    const { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear } = useListFilters("projects");
 
     const { data: projectFilterOptions, isLoading: isLoadingProjectFilterOptions } = useGetProjectsFilterOptionsQuery();
 

--- a/frontend/src/pages/projects/list/ProjectsList.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.jsx
@@ -33,7 +33,7 @@ const ProjectsList = () => {
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions(PROJECT_SORT_CODES.TITLE, false);
     // Filters + selected fiscal year persist across client-side navigation via
     // the session slice (see useListFilters).
-    const { filters, setFilters, selectedFiscalYear, setSelectedFiscalYear } = useListFilters("projects");
+    const { filters, setFilters, selectedFiscalYear, changeFiscalYear } = useListFilters("projects");
 
     const { data: projectFilterOptions, isLoading: isLoadingProjectFilterOptions } = useGetProjectsFilterOptionsQuery();
 
@@ -71,8 +71,7 @@ const ProjectsList = () => {
     }, [isError, navigate]);
 
     const handleChangeFiscalYear = (newValue) => {
-        setSelectedFiscalYear(newValue);
-        setFilters((prev) => ({ ...prev, fiscalYear: [] }));
+        changeFiscalYear(newValue);
     };
 
     const fiscalYearDropdownValue = filters.fiscalYear.length >= 2 ? "Multi" : selectedFiscalYear;

--- a/frontend/src/pages/projects/list/ProjectsList.test.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.test.jsx
@@ -6,6 +6,7 @@ import { Provider } from "react-redux";
 import { configureStore } from "@reduxjs/toolkit";
 import ProjectsList from "./ProjectsList";
 import { opsApi } from "../../../api/opsAPI";
+import sessionUIReducer from "../../../sessionUISlice";
 
 const mockNavigate = vi.fn();
 const mockUseGetProjectsQuery = vi.fn();
@@ -69,6 +70,7 @@ describe("ProjectsList", () => {
         mockStore = configureStore({
             reducer: {
                 [opsApi.reducerPath]: opsApi.reducer,
+                sessionUI: sessionUIReducer,
                 auth: () => ({
                     isLoggedIn: true,
                     activeUser: { id: 1, roles: [] }

--- a/frontend/src/sessionUISlice.js
+++ b/frontend/src/sessionUISlice.js
@@ -1,5 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 import { logout } from "./components/Auth/authSlice";
+import { getCurrentFiscalYear } from "./helpers/utils";
+import { DEFAULT_PORTFOLIO_BUDGET_RANGE } from "./constants";
 
 /**
  * Session-scoped UI state that survives client-side navigation and tab switches
@@ -7,8 +9,11 @@ import { logout } from "./components/Auth/authSlice";
  * cleared on logout.
  *
  * Deliverable A (breadcrumbs) uses `navContext.trail`.
- * Deliverable B (filter persistence) will add a `listFilters` sub-state here so
- * there is a single logout-reset hook for all session UI state.
+ * Deliverable B (filter persistence) uses `listFilters` — per-page filter +
+ * fiscal-year selections that persist across client-side navigation so a user
+ * returning to a list via breadcrumb keeps their filters applied.
+ *
+ * Both share a single logout-reset hook (see `extraReducers`).
  *
  * @typedef {Object} BreadcrumbAncestor
  * @property {string} label - The crumb text.
@@ -19,11 +24,102 @@ import { logout } from "./components/Auth/authSlice";
  * @property {BreadcrumbAncestor[]} ancestors - Crumbs shown before the leaf, in order.
  */
 
+/**
+ * Per-page default filter state. Each shape is copied VERBATIM from the list
+ * page's original `useState` initializer so behavior is unchanged on first
+ * load. `selectedFiscalYear` is persisted alongside `filters` because the
+ * resolved query blends both — persisting only `filters` would silently reset
+ * the fiscal year on return.
+ *
+ * The BudgetLines fiscal-year filter is derived (approach A/B, query-param
+ * driven) and resolves to `null` today, so a `null` default is safe here; the
+ * derived helpers stay in the page, out of the slice.
+ */
+const listFilterDefaults = {
+    agreements: {
+        filters: {
+            portfolio: [],
+            fiscalYear: [],
+            projectTitle: [],
+            agreementType: [],
+            agreementName: [],
+            contractNumber: [],
+            awardType: []
+        },
+        selectedFiscalYear: getCurrentFiscalYear()
+    },
+    cans: {
+        filters: {
+            activePeriod: [],
+            transfer: [],
+            portfolio: [],
+            can: [],
+            budget: []
+        },
+        selectedFiscalYear: getCurrentFiscalYear()
+    },
+    budgetLines: {
+        filters: {
+            fiscalYears: null,
+            portfolios: [],
+            bliStatus: [],
+            budgetRange: null,
+            agreementTypes: [],
+            agreementTitles: [],
+            canActivePeriods: []
+        }
+        // No page-level selectedFiscalYear: the FY dropdown is derived from
+        // filters.fiscalYears via the A/B helpers.
+    },
+    portfolios: {
+        filters: {
+            portfolios: [],
+            budgetRange: DEFAULT_PORTFOLIO_BUDGET_RANGE,
+            availablePct: []
+        },
+        selectedFiscalYear: getCurrentFiscalYear()
+    },
+    projects: {
+        filters: {
+            fiscalYear: [],
+            portfolio: [],
+            projectSearch: [],
+            agreementSearch: [],
+            projectType: []
+        },
+        selectedFiscalYear: getCurrentFiscalYear()
+    },
+    procurementDashboard: {
+        filters: {
+            procShop: [],
+            division: []
+        }
+        // No fiscal-year selection: the dashboard is pinned to the current FY.
+    }
+};
+
+/**
+ * Build the initial listFilters state from the per-page defaults. Deep-cloned
+ * so the exported defaults are never mutated by Immer.
+ * @returns {Record<string, {filters: Object, selectedFiscalYear?: string|number}>}
+ */
+const buildListFiltersInitialState = () =>
+    Object.fromEntries(
+        Object.entries(listFilterDefaults).map(([page, def]) => [
+            page,
+            {
+                filters: structuredClone(def.filters),
+                ...("selectedFiscalYear" in def ? { selectedFiscalYear: def.selectedFiscalYear } : {})
+            }
+        ])
+    );
+
 const initialState = {
     navContext: {
         /** @type {BreadcrumbTrail | null} */
         trail: null
-    }
+    },
+    listFilters: buildListFiltersInitialState()
 };
 
 const sessionUISlice = createSlice({
@@ -46,6 +142,40 @@ const sessionUISlice = createSlice({
          */
         clearTrail: (state) => {
             state.navContext.trail = null;
+        },
+        /**
+         * Replace the applied filters for a list page.
+         * @param {typeof initialState} state
+         * @param {{ payload: { page: string, filters: Object } }} action
+         */
+        setListFilters: (state, action) => {
+            const { page, filters } = action.payload;
+            if (!state.listFilters[page]) return;
+            state.listFilters[page].filters = filters;
+        },
+        /**
+         * Set the selected fiscal year for a list page.
+         * @param {typeof initialState} state
+         * @param {{ payload: { page: string, selectedFiscalYear: string|number } }} action
+         */
+        setListFiscalYear: (state, action) => {
+            const { page, selectedFiscalYear } = action.payload;
+            if (!state.listFilters[page]) return;
+            state.listFilters[page].selectedFiscalYear = selectedFiscalYear;
+        },
+        /**
+         * Reset a single list page's filters (and fiscal year) back to its defaults.
+         * @param {typeof initialState} state
+         * @param {{ payload: { page: string } }} action
+         */
+        resetListFilters: (state, action) => {
+            const { page } = action.payload;
+            const def = listFilterDefaults[page];
+            if (!def) return;
+            state.listFilters[page] = {
+                filters: structuredClone(def.filters),
+                ...("selectedFiscalYear" in def ? { selectedFiscalYear: def.selectedFiscalYear } : {})
+            };
         }
     },
     extraReducers: (builder) => {
@@ -55,6 +185,7 @@ const sessionUISlice = createSlice({
     }
 });
 
-export const { setTrail, clearTrail } = sessionUISlice.actions;
+export { listFilterDefaults };
+export const { setTrail, clearTrail, setListFilters, setListFiscalYear, resetListFilters } = sessionUISlice.actions;
 
 export default sessionUISlice.reducer;

--- a/frontend/src/sessionUISlice.js
+++ b/frontend/src/sessionUISlice.js
@@ -99,20 +99,24 @@ const listFilterDefaults = {
 };
 
 /**
- * Build the initial listFilters state from the per-page defaults. Deep-cloned
- * so the exported defaults are never mutated by Immer.
+ * Build a fresh per-page state entry from its default. Deep-clones `filters`
+ * so the exported defaults are never mutated (by Immer freezing or otherwise),
+ * and includes `selectedFiscalYear` only for pages that have a page-level FY.
+ * Single source of truth for both initial-state construction and reset.
+ * @param {{filters: Object, selectedFiscalYear?: string|number}} def
+ * @returns {{filters: Object, selectedFiscalYear?: string|number}}
+ */
+const buildPageState = (def) => ({
+    filters: structuredClone(def.filters),
+    ...("selectedFiscalYear" in def ? { selectedFiscalYear: def.selectedFiscalYear } : {})
+});
+
+/**
+ * Build the initial listFilters state from the per-page defaults.
  * @returns {Record<string, {filters: Object, selectedFiscalYear?: string|number}>}
  */
 const buildListFiltersInitialState = () =>
-    Object.fromEntries(
-        Object.entries(listFilterDefaults).map(([page, def]) => [
-            page,
-            {
-                filters: structuredClone(def.filters),
-                ...("selectedFiscalYear" in def ? { selectedFiscalYear: def.selectedFiscalYear } : {})
-            }
-        ])
-    );
+    Object.fromEntries(Object.entries(listFilterDefaults).map(([page, def]) => [page, buildPageState(def)]));
 
 const initialState = {
     navContext: {
@@ -172,10 +176,7 @@ const sessionUISlice = createSlice({
             const { page } = action.payload;
             const def = listFilterDefaults[page];
             if (!def) return;
-            state.listFilters[page] = {
-                filters: structuredClone(def.filters),
-                ...("selectedFiscalYear" in def ? { selectedFiscalYear: def.selectedFiscalYear } : {})
-            };
+            state.listFilters[page] = buildPageState(def);
         }
     },
     extraReducers: (builder) => {

--- a/frontend/src/sessionUISlice.test.js
+++ b/frontend/src/sessionUISlice.test.js
@@ -1,16 +1,26 @@
 import { describe, expect, it } from "vitest";
-import sessionUIReducer, { setTrail, clearTrail } from "./sessionUISlice";
+import sessionUIReducer, {
+    setTrail,
+    clearTrail,
+    setListFilters,
+    setListFiscalYear,
+    resetListFilters,
+    listFilterDefaults
+} from "./sessionUISlice";
 import { logout } from "./components/Auth/authSlice";
 
-const initialState = {
-    navContext: {
-        trail: null
-    }
-};
+// The reducer's initial state is derived from the slice defaults; build the
+// expected shape the same way so the test doesn't duplicate literals.
+const freshState = () => sessionUIReducer(undefined, { type: "@@INIT" });
 
-describe("sessionUISlice", () => {
-    it("returns the initial state", () => {
-        expect(sessionUIReducer(undefined, { type: "@@INIT" })).toEqual(initialState);
+describe("sessionUISlice — navContext", () => {
+    it("returns the initial state with a null trail and per-page filter defaults", () => {
+        const state = freshState();
+        expect(state.navContext.trail).toBeNull();
+        expect(state.listFilters.agreements.filters).toEqual(listFilterDefaults.agreements.filters);
+        expect(state.listFilters.cans.selectedFiscalYear).toEqual(listFilterDefaults.cans.selectedFiscalYear);
+        expect(state.listFilters.budgetLines).not.toHaveProperty("selectedFiscalYear");
+        expect(state.listFilters.procurementDashboard).not.toHaveProperty("selectedFiscalYear");
     });
 
     it("setTrail stores the trail", () => {
@@ -21,31 +31,78 @@ describe("sessionUISlice", () => {
                 { label: "Portfolio A", to: "/portfolios/5" }
             ]
         };
-        const state = sessionUIReducer(initialState, setTrail(trail));
+        const state = sessionUIReducer(freshState(), setTrail(trail));
         expect(state.navContext.trail).toEqual(trail);
     });
 
     it("setTrail overwrites a previously stored trail", () => {
         const first = { targetPath: "/cans/1", ancestors: [{ label: "CANs", to: "/cans" }] };
         const second = { targetPath: "/agreements/2", ancestors: [{ label: "Agreements", to: "/agreements" }] };
-        let state = sessionUIReducer(initialState, setTrail(first));
+        let state = sessionUIReducer(freshState(), setTrail(first));
         state = sessionUIReducer(state, setTrail(second));
         expect(state.navContext.trail).toEqual(second);
     });
 
     it("clearTrail resets the trail to null", () => {
-        const populated = {
-            navContext: { trail: { targetPath: "/cans/1", ancestors: [{ label: "CANs", to: "/cans" }] } }
-        };
-        const state = sessionUIReducer(populated, clearTrail());
+        let state = sessionUIReducer(
+            freshState(),
+            setTrail({ targetPath: "/cans/1", ancestors: [{ label: "CANs", to: "/cans" }] })
+        );
+        state = sessionUIReducer(state, clearTrail());
         expect(state.navContext.trail).toBeNull();
     });
+});
 
-    it("resets to initial state on logout", () => {
-        const populated = {
-            navContext: { trail: { targetPath: "/cans/1", ancestors: [{ label: "CANs", to: "/cans" }] } }
-        };
-        const state = sessionUIReducer(populated, logout());
-        expect(state).toEqual(initialState);
+describe("sessionUISlice — listFilters", () => {
+    it("setListFilters replaces the filters for a page", () => {
+        const next = { ...listFilterDefaults.agreements.filters, portfolio: [{ id: 1, title: "P1" }] };
+        const state = sessionUIReducer(freshState(), setListFilters({ page: "agreements", filters: next }));
+        expect(state.listFilters.agreements.filters).toEqual(next);
+    });
+
+    it("setListFilters ignores an unknown page", () => {
+        const before = freshState();
+        const after = sessionUIReducer(before, setListFilters({ page: "nope", filters: { a: 1 } }));
+        expect(after.listFilters).toEqual(before.listFilters);
+    });
+
+    it("setListFiscalYear updates only the target page's fiscal year", () => {
+        const state = sessionUIReducer(freshState(), setListFiscalYear({ page: "cans", selectedFiscalYear: 2030 }));
+        expect(state.listFilters.cans.selectedFiscalYear).toBe(2030);
+        expect(state.listFilters.agreements.selectedFiscalYear).toBe(listFilterDefaults.agreements.selectedFiscalYear);
+    });
+
+    it("resetListFilters restores a page to its defaults", () => {
+        let state = sessionUIReducer(
+            freshState(),
+            setListFilters({ page: "cans", filters: { ...listFilterDefaults.cans.filters, can: [{ id: 9 }] } })
+        );
+        state = sessionUIReducer(state, setListFiscalYear({ page: "cans", selectedFiscalYear: 2040 }));
+        state = sessionUIReducer(state, resetListFilters({ page: "cans" }));
+        expect(state.listFilters.cans).toEqual({
+            filters: listFilterDefaults.cans.filters,
+            selectedFiscalYear: listFilterDefaults.cans.selectedFiscalYear
+        });
+    });
+
+    it("does not share references between the store and the exported defaults", () => {
+        const state = sessionUIReducer(freshState(), setListFilters({ page: "cans", filters: { can: [{ id: 1 }] } }));
+        // mutating the store's filters must not touch the exported defaults
+        expect(listFilterDefaults.cans.filters.can).toEqual([]);
+        expect(state.listFilters.cans.filters.can).toEqual([{ id: 1 }]);
+    });
+});
+
+describe("sessionUISlice — logout reset", () => {
+    it("resets ALL session UI state (trail + filters) on logout", () => {
+        let state = sessionUIReducer(
+            freshState(),
+            setTrail({ targetPath: "/cans/1", ancestors: [{ label: "CANs", to: "/cans" }] })
+        );
+        state = sessionUIReducer(state, setListFilters({ page: "agreements", filters: { portfolio: [{ id: 1 }] } }));
+        state = sessionUIReducer(state, logout());
+        expect(state).toEqual(freshState());
+        expect(state.navContext.trail).toBeNull();
+        expect(state.listFilters.agreements.filters).toEqual(listFilterDefaults.agreements.filters);
     });
 });


### PR DESCRIPTION
## What changed

Filter selections on the list pages now **persist across client-side navigation** for the duration of the session, so returning to a list (e.g. via a breadcrumb) keeps the user's filters — and selected fiscal year — applied. Filters are intentionally lost on browser refresh / new tab (in-memory Redux) and cleared on logout.

**Approach:** extend the session-scoped `sessionUISlice` (introduced in Deliverable A) with a `listFilters` sub-state keyed by page, and add a `useListFilters(page)` hook exposing a `useState`-compatible API (object **or** functional-updater form) so the existing `*FilterButton` / `*FilterTags` sub-components keep working unchanged. All six list pages source their filters (and fiscal year, where applicable) from the slice instead of local `useState`. Logout reset reuses A's single `extraReducers` hook.

**Pages:** Agreements, CANs, Budget Lines, Portfolios, Projects, Procurement Dashboard.

Key pieces:
- **`sessionUISlice` `listFilters`** — per-page default shapes copied verbatim from each page's original `useState`; `selectedFiscalYear` persisted alongside filters where the resolved query blends both. `setListFilters` / `setListFiscalYear` / `resetListFilters` actions; `buildPageState` is the single deep-clone source for init + reset.
- **`useListFilters(page)`** — `filters` / `setFilters` / `selectedFiscalYear` / `setSelectedFiscalYear`, plus **`changeFiscalYear`** which atomically resets the page's filters and sets the new FY (one shared code path for all FY-aware pages).
- **`CANFilterButton`** — fixed a reference-equality budget check to compare by value.

This is **Deliverable B** of the issue and stacks on **Deliverable A** (#5995) — the PR is based on the A branch so the diff shows only B's changes. Rebase to `main` once A merges.

## Issue

https://github.com/HHS/OPRE-OPS/issues/3789

## How to test

1. Go to any list page (e.g. **Portfolios**), apply a filter → open a detail page → navigate back. The filter is **still applied**.
2. Change the **fiscal year** on a list, navigate away and back → the FY selection **persists**.
3. **Fiscal-year change resets filters** consistently across Agreements, CANs, Projects, and Portfolios (a filter valid in one FY is not carried into another).
4. On **CANs**, apply a budget-range filter, reopen the filter modal, drag the slider back to the full range, and Apply → the budget filter is **cleared** (not retained).
5. **Refresh** the browser → filters clear (in-memory only, by design). **Log out** → filters clear.

_Verified locally by driving the running stack (apply → navigate → back → still applied; FY persists; refresh clears)._

## A11y impact

- [x] No accessibility-impacting changes in this PR

_No markup/ARIA changes; filter state moves from local component state to Redux with identical rendering._

## Storybook

- [x] N/A — change is page-specific or non-visual

_Changes are in a Redux slice, a hook, and page/hook wiring — no `src/components/UI/` component added or changed._

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated

## Notes for reviewers

- **Behavior change:** CANs and Projects now clear other filters when the fiscal year changes (previously CANs reset nothing and Projects cleared only the FY chip). This aligns with the product decision "changing FY still clears other filters" and makes all four FY-aware pages consistent.
- A follow-up commit in this branch addresses code-review findings (budget-clear bug, FY-reset unification, defensive selector chaining, dedup).

## Links
- Depends on: #5995 (Deliverable A)
