### PR TITLE
feat(OPS-2280): lock BLI editing after pre-award approval

### DIFF
--- a/backend/models/agreements.py
+++ b/backend/models/agreements.py
@@ -463,6 +463,12 @@ class Agreement(BaseModel):
 
         return is_award_approval_requested(self)
 
+    @property
+    def is_post_pre_award_locked(self) -> bool:
+        from ops_api.ops.utils.budget_line_items_helpers import is_post_pre_award_locked
+
+        return is_post_pre_award_locked(self)
+
     @override
     def to_dict(self) -> dict[str, Any]:  # type: ignore[override]
         d: dict[str, Any] = super().to_dict()  # type: ignore[no-untyped-call]

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -9448,6 +9448,12 @@ components:
                 type: string
             in_review:
               type: boolean
+            is_award_approval_requested:
+              type: boolean
+              description: Whether the agreement has a pending award approval request (step 6)
+            is_post_pre_award_locked:
+              type: boolean
+              description: Whether BLI editing is permanently locked after full pre-award approval
             authorized_user_ids:
               type: array
               items:

--- a/backend/ops_api/ops/schemas/agreements.py
+++ b/backend/ops_api/ops/schemas/agreements.py
@@ -214,6 +214,7 @@ class AgreementResponse(FyObligatedMixin, AgreementData):
     team_leaders = fields.List(fields.String(), required=True)
     in_review = fields.Bool(required=True)
     is_award_approval_requested = fields.Bool(load_default=False, dump_default=False, required=False)
+    is_post_pre_award_locked = fields.Bool(load_default=False, dump_default=False, required=False)
     change_requests_in_review = fields.Nested(
         AgreementChangeRequestResponseSchema,
         many=True,

--- a/backend/ops_api/ops/services/budget_line_items.py
+++ b/backend/ops_api/ops/services/budget_line_items.py
@@ -826,8 +826,12 @@ class BudgetLineItemService:
         #   - clin_id-only edits are allowed for any authorized user — CLIN assignment is part of
         #     the award workflow (COR assigns CLINs before submitting for award approval)
         if not is_super_user(current_user, current_app) and not is_budget_team(current_user):
-            # updated_fields also contains internal keys ("request", "schema") — strip those for the check
-            edit_keys = {k for k in updated_fields if k not in ("request", "schema")}
+            # Use the raw request JSON to determine what the caller actually sent.
+            # updated_fields contains Marshmallow load_default values for all schema fields
+            # (None for unset fields) plus injected internal keys ("request", "schema", "method"),
+            # so it cannot reliably tell us which fields the caller intended to change.
+            request_obj = updated_fields.get("request")
+            edit_keys = set(request_obj.json.keys()) if request_obj and request_obj.json else set()
             clin_only_edit = edit_keys <= {"clin_id"}
             if not clin_only_edit and is_post_pre_award_locked(budget_line_item.agreement):
                 raise ValidationError(

--- a/backend/ops_api/ops/services/budget_line_items.py
+++ b/backend/ops_api/ops/services/budget_line_items.py
@@ -811,21 +811,16 @@ class BudgetLineItemService:
         if not is_bli_editable(budget_line_item):
             raise ValidationError({"status": "Budget Line Item is not in an editable state."})
 
-        # Check if the agreement's pre-award approval is in review (super users and budget team can bypass)
-        if (
-            not is_super_user(current_user, current_app)
-            and not is_budget_team(current_user)
-            and is_pre_award_in_review(budget_line_item.agreement)
-        ):
+        # Block edits while pre-award approval is in flight (budget team can bypass)
+        if not is_budget_team(current_user) and is_pre_award_in_review(budget_line_item.agreement):
             raise ValidationError({"status": "Cannot modify Budget Line Items while Pre-Award Approval is in review."})
 
         # Block edits after pre-award is fully approved (DD approved + requisition submitted).
         # Exceptions:
-        #   - Superusers bypass unconditionally (checked above)
         #   - Budget Team bypass is handled in update_with_change_request_ids via budget_team_can_bypass
         #   - clin_id-only edits are allowed for any authorized user — CLIN assignment is part of
         #     the award workflow (COR assigns CLINs before submitting for award approval)
-        if not is_super_user(current_user, current_app) and not is_budget_team(current_user):
+        if not is_budget_team(current_user):
             # Use the raw request JSON to determine what the caller actually sent.
             # updated_fields contains Marshmallow load_default values for all schema fields
             # (None for unset fields) plus injected internal keys ("request", "schema", "method"),

--- a/backend/ops_api/ops/services/budget_line_items.py
+++ b/backend/ops_api/ops/services/budget_line_items.py
@@ -51,6 +51,7 @@ from ops_api.ops.utils.budget_line_items_helpers import (
     create_budget_line_item_instance,
     is_award_approval_requested,
     is_bli_editable,
+    is_post_pre_award_locked,
     is_pre_award_in_review,
     update_data,
 )
@@ -817,6 +818,22 @@ class BudgetLineItemService:
             and is_pre_award_in_review(budget_line_item.agreement)
         ):
             raise ValidationError({"status": "Cannot modify Budget Line Items while Pre-Award Approval is in review."})
+
+        # Block edits after pre-award is fully approved (DD approved + requisition submitted).
+        # Exceptions:
+        #   - Superusers bypass unconditionally (checked above)
+        #   - Budget Team bypass is handled in update_with_change_request_ids via budget_team_can_bypass
+        #   - COR (project officer or alternate PO) may update clin_id only
+        if not is_super_user(current_user, current_app) and not is_budget_team(current_user):
+            agreement = budget_line_item.agreement
+            is_cor = current_user.id in (agreement.project_officer_id, agreement.alternate_project_officer_id)
+            # updated_fields also contains internal keys ("request", "schema") — strip those for the check
+            edit_keys = {k for k in updated_fields if k not in ("request", "schema")}
+            clin_only_edit = edit_keys <= {"clin_id"}
+            if not (is_cor and clin_only_edit) and is_post_pre_award_locked(agreement):
+                raise ValidationError(
+                    {"status": "Cannot modify Budget Line Items after Pre-Award Approval has been completed."}
+                )
 
         sc = self.db_session.get(ServicesComponent, updated_fields.get("services_component_id"))
         if sc and sc.agreement_id != budget_line_item.agreement_id:

--- a/backend/ops_api/ops/services/budget_line_items.py
+++ b/backend/ops_api/ops/services/budget_line_items.py
@@ -823,14 +823,13 @@ class BudgetLineItemService:
         # Exceptions:
         #   - Superusers bypass unconditionally (checked above)
         #   - Budget Team bypass is handled in update_with_change_request_ids via budget_team_can_bypass
-        #   - COR (project officer or alternate PO) may update clin_id only
+        #   - clin_id-only edits are allowed for any authorized user — CLIN assignment is part of
+        #     the award workflow (COR assigns CLINs before submitting for award approval)
         if not is_super_user(current_user, current_app) and not is_budget_team(current_user):
-            agreement = budget_line_item.agreement
-            is_cor = current_user.id in (agreement.project_officer_id, agreement.alternate_project_officer_id)
             # updated_fields also contains internal keys ("request", "schema") — strip those for the check
             edit_keys = {k for k in updated_fields if k not in ("request", "schema")}
             clin_only_edit = edit_keys <= {"clin_id"}
-            if not (is_cor and clin_only_edit) and is_post_pre_award_locked(agreement):
+            if not clin_only_edit and is_post_pre_award_locked(budget_line_item.agreement):
                 raise ValidationError(
                     {"status": "Cannot modify Budget Line Items after Pre-Award Approval has been completed."}
                 )

--- a/backend/ops_api/ops/utils/budget_line_items_helpers.py
+++ b/backend/ops_api/ops/utils/budget_line_items_helpers.py
@@ -182,6 +182,42 @@ def is_award_approval_requested(agreement) -> bool:
     return False
 
 
+def is_post_pre_award_locked(agreement) -> bool:
+    """
+    Check if the agreement is in the post-pre-award locked state.
+
+    Returns True once pre-award has been fully approved (DD approved + Budget Team
+    submitted requisition). BLI editing is locked from this point on permanently.
+
+    Exceptions (handled by callers):
+    - Superusers bypass unconditionally
+    - Budget Team bypass during active award-approval (handled in update_with_change_request_ids)
+    - COR (project officer / alternate PO) can still update clin_id only
+
+    Args:
+        agreement: Agreement object to check
+
+    Returns:
+        bool: True if pre-award is fully approved and BLIs should be locked.
+    """
+    if not agreement or not agreement.procurement_trackers:
+        return False
+
+    for tracker in agreement.procurement_trackers:
+        pre_award_step = next(
+            (step for step in tracker.steps if step.step_type == ProcurementTrackerStepType.PRE_AWARD), None
+        )
+        if not pre_award_step:
+            continue
+        if (
+            pre_award_step.pre_award_approval_status == "APPROVED"
+            and pre_award_step.pre_award_requisition_approved_by is not None
+        ):
+            return True
+
+    return False
+
+
 def bli_associated_with_agreement(id: int) -> bool:
     """
     In order to edit a budget line or agreement, the budget line must be associated with an Agreement, and the

--- a/backend/ops_api/ops/utils/budget_line_items_helpers.py
+++ b/backend/ops_api/ops/utils/budget_line_items_helpers.py
@@ -190,9 +190,8 @@ def is_post_pre_award_locked(agreement) -> bool:
     submitted requisition). BLI editing is locked from this point on permanently.
 
     Exceptions (handled by callers):
-    - Superusers bypass unconditionally
     - Budget Team bypass during active award-approval (handled in update_with_change_request_ids)
-    - COR (project officer / alternate PO) can still update clin_id only
+    - clin_id-only edits are allowed for any authorized user (CLIN assignment for award workflow)
 
     Args:
         agreement: Agreement object to check

--- a/backend/ops_api/ops/utils/budget_line_items_helpers.py
+++ b/backend/ops_api/ops/utils/budget_line_items_helpers.py
@@ -203,19 +203,23 @@ def is_post_pre_award_locked(agreement) -> bool:
     if not agreement or not agreement.procurement_trackers:
         return False
 
-    for tracker in agreement.procurement_trackers:
-        pre_award_step = next(
-            (step for step in tracker.steps if step.step_type == ProcurementTrackerStepType.PRE_AWARD), None
-        )
-        if not pre_award_step:
-            continue
-        if (
-            pre_award_step.pre_award_approval_status == "APPROVED"
-            and pre_award_step.pre_award_requisition_approved_by is not None
-        ):
-            return True
+    # Scope to the active tracker only — consistent with is_pre_award_in_review and
+    # is_award_approval_requested, and prevents a completed tracker from a prior
+    # procurement cycle permanently locking BLIs on a new active cycle.
+    tracker = next((t for t in agreement.procurement_trackers if t.status == ProcurementTrackerStatus.ACTIVE), None)
+    if not tracker:
+        return False
 
-    return False
+    pre_award_step = next(
+        (step for step in tracker.steps if step.step_type == ProcurementTrackerStepType.PRE_AWARD), None
+    )
+    if not pre_award_step:
+        return False
+
+    return (
+        pre_award_step.pre_award_approval_status == "APPROVED"
+        and pre_award_step.pre_award_requisition_approved_by is not None
+    )
 
 
 def bli_associated_with_agreement(id: int) -> bool:

--- a/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item.py
@@ -3341,15 +3341,14 @@ def test_cannot_update_bli_when_pre_award_fully_approved(auth_client, loaded_db,
     bli.status = BudgetLineItemStatus.PLANNED
     loaded_db.commit()
 
-    original_amount = bli.amount
-
     # Attempt to update the BLI
     data = {"amount": 555555.55}
     url = url_for("api.budget-line-items-item", id=bli.id)
 
     response = auth_client.patch(url, json=data)
 
-    # After full pre-award approval, all users are blocked — including superusers (new business rule OPS-2280)
+    # After full pre-award approval all users are blocked (OPS-2280).
+    # Note: auth_client is user 503 (SYSTEM_OWNER), not SUPER_USER — is_super_user() checks
+    # for the SUPER_USER role specifically, so SYSTEM_OWNER is not exempt from the lock.
     assert response.status_code == 400
     assert "Pre-Award Approval" in response.json.get("errors", {}).get("status", "")
-    _ = original_amount  # unused but kept for context

--- a/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item.py
@@ -3349,8 +3349,8 @@ def test_can_update_bli_when_pre_award_fully_approved(auth_client, loaded_db, ap
 
     response = auth_client.patch(url, json=data)
 
-    # Should succeed (200 if DRAFT, 202 if change request created)
-    assert response.status_code in [200, 202]
-    loaded_db.refresh(bli)
-    if response.status_code == 200:
-        assert bli.amount != original_amount
+    # After full pre-award approval, non-superuser edits are blocked (new business rule OPS-2280).
+    # auth_client is SYSTEM_OWNER (not SUPER_USER role), so it hits the post-pre-award lock.
+    assert response.status_code == 400
+    assert "Pre-Award Approval" in response.json.get("errors", {}).get("status", "")
+    _ = original_amount  # unused but kept for context

--- a/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item.py
@@ -3349,8 +3349,7 @@ def test_can_update_bli_when_pre_award_fully_approved(auth_client, loaded_db, ap
 
     response = auth_client.patch(url, json=data)
 
-    # After full pre-award approval, non-superuser edits are blocked (new business rule OPS-2280).
-    # auth_client is SYSTEM_OWNER (not SUPER_USER role), so it hits the post-pre-award lock.
+    # After full pre-award approval, all users are blocked — including superusers (new business rule OPS-2280)
     assert response.status_code == 400
     assert "Pre-Award Approval" in response.json.get("errors", {}).get("status", "")
     _ = original_amount  # unused but kept for context

--- a/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item.py
+++ b/backend/ops_api/tests/ops/budget_line_items/test_budget_line_item.py
@@ -3309,8 +3309,8 @@ def test_cannot_update_bli_when_pre_award_approved_but_awaiting_requisition(auth
     assert response.json["errors"]["status"] == "Cannot modify Budget Line Items while Pre-Award Approval is in review."
 
 
-def test_can_update_bli_when_pre_award_fully_approved(auth_client, loaded_db, app_ctx):
-    """Test that BLI can be updated when pre-award is fully approved (including requisition)"""
+def test_cannot_update_bli_when_pre_award_fully_approved(auth_client, loaded_db, app_ctx):
+    """Test that BLI cannot be updated when pre-award is fully approved — the lock applies to all users (OPS-2280)"""
     # Get an existing BLI from agreement 1
     bli = loaded_db.get(BudgetLineItem, 15004)
     agreement = loaded_db.get(Agreement, bli.agreement_id)

--- a/backend/ops_api/tests/ops/workflows/test_change_requests.py
+++ b/backend/ops_api/tests/ops/workflows/test_change_requests.py
@@ -854,7 +854,7 @@ def test_post_pre_award_lock_allows_clin_only_for_any_user(
     assert response.status_code == 200, f"clin_id update should be allowed for any user. Got: {response.json}"
 
 
-def test_post_pre_award_lock_blocks_non_clin_edit_for_regular_user(
+def test_post_pre_award_lock_blocks_mixed_clin_and_financial_edit(
     basic_user_auth_client,
     app,
     loaded_db,
@@ -862,7 +862,8 @@ def test_post_pre_award_lock_blocks_non_clin_edit_for_regular_user(
     test_can,
     app_ctx,
 ):
-    """Regular users cannot edit financial fields (only clin_id is allowed) after pre-award approval."""
+    """A payload containing clin_id AND a financial field is blocked — the clin-only exception
+    is exact and cannot be used as a loophole to sneak through financial changes."""
     agreement = app.db_session.get(Agreement, 1)
     basic_user = app.db_session.get(User, 521)
     agreement.team_members.append(basic_user)
@@ -872,8 +873,10 @@ def test_post_pre_award_lock_blocks_non_clin_edit_for_regular_user(
     bli = _make_planned_bli(loaded_db, test_can, test_division_director)
     loaded_db.commit()
 
-    response = basic_user_auth_client.patch(url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00})
-    assert response.status_code == 400, f"Financial edit should be blocked. Got: {response.json}"
+    response = basic_user_auth_client.patch(
+        url_for("api.budget-line-items-item", id=bli.id), json={"clin_id": 1, "amount": 750.00}
+    )
+    assert response.status_code == 400, f"Mixed clin+financial edit should be blocked. Got: {response.json}"
     assert "Pre-Award Approval" in response.json.get("errors", {}).get("status", "")
 
 

--- a/backend/ops_api/tests/ops/workflows/test_change_requests.py
+++ b/backend/ops_api/tests/ops/workflows/test_change_requests.py
@@ -768,3 +768,134 @@ def test_budget_team_bli_patch_writes_directly_when_tracker_not_active(
 
     updated_bli = loaded_db.get(type(bli), bli_id)
     assert float(updated_bli.amount) == 750.00
+
+
+# --- Post-pre-award lock tests ---
+
+
+def _setup_fully_approved_pre_award(loaded_db):
+    """Helper: create a procurement tracker with a fully approved PRE_AWARD step on agreement 1."""
+    tracker = DefaultProcurementTracker(agreement_id=1, status=ProcurementTrackerStatus.ACTIVE)
+    loaded_db.add(tracker)
+    loaded_db.flush()
+    pre_award_step = DefaultProcurementTrackerStep(
+        procurement_tracker_id=tracker.id,
+        step_number=5,
+        step_type=ProcurementTrackerStepType.PRE_AWARD,
+        pre_award_approval_requested=True,
+        pre_award_approval_status="APPROVED",
+        pre_award_requisition_approved_by=500,  # approved by user 500
+    )
+    loaded_db.add(pre_award_step)
+    return tracker, pre_award_step
+
+
+def _make_planned_bli(loaded_db, test_can, test_division_director):
+    """Helper: create a PLANNED BLI on agreement 1."""
+    bli = ContractBudgetLineItem(
+        line_description="BLI for post-pre-award lock test",
+        agreement_id=1,
+        can_id=test_can.id,
+        amount=500.00,
+        status=BudgetLineItemStatus.PLANNED,
+        date_needed=datetime.date(2032, 2, 2),
+        created_by=test_division_director.id,
+        services_component_id=1,
+    )
+    loaded_db.add(bli)
+    return bli
+
+
+def test_post_pre_award_lock_blocks_regular_user(
+    basic_user_auth_client,
+    app,
+    loaded_db,
+    test_division_director,
+    test_can,
+    app_ctx,
+):
+    """Regular users cannot edit BLIs once pre-award is fully approved."""
+    # Add basic user (521) as team member so they pass the association check
+    agreement = app.db_session.get(Agreement, 1)
+    basic_user = app.db_session.get(User, 521)
+    agreement.team_members.append(basic_user)
+    app.db_session.flush()
+
+    _setup_fully_approved_pre_award(loaded_db)
+    bli = _make_planned_bli(loaded_db, test_can, test_division_director)
+    loaded_db.commit()
+
+    response = basic_user_auth_client.patch(
+        url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00}
+    )
+    assert response.status_code == 400, f"Should be blocked after full pre-award approval. Got: {response.json}"
+    assert "Pre-Award Approval" in response.json.get("status", "")
+
+
+def test_post_pre_award_lock_allows_clin_only_for_any_user(
+    basic_user_auth_client,
+    app,
+    loaded_db,
+    test_division_director,
+    test_can,
+    app_ctx,
+):
+    """Any authorized user can update clin_id after pre-award is fully approved."""
+    agreement = app.db_session.get(Agreement, 1)
+    basic_user = app.db_session.get(User, 521)
+    agreement.team_members.append(basic_user)
+    app.db_session.flush()
+
+    _setup_fully_approved_pre_award(loaded_db)
+    bli = _make_planned_bli(loaded_db, test_can, test_division_director)
+    loaded_db.commit()
+
+    response = basic_user_auth_client.patch(
+        url_for("api.budget-line-items-item", id=bli.id), json={"clin_id": 1}
+    )
+    assert response.status_code == 200, f"clin_id update should be allowed for any user. Got: {response.json}"
+
+
+def test_post_pre_award_lock_blocks_non_clin_edit_for_regular_user(
+    basic_user_auth_client,
+    app,
+    loaded_db,
+    test_division_director,
+    test_can,
+    app_ctx,
+):
+    """Regular users cannot edit financial fields (only clin_id is allowed) after pre-award approval."""
+    agreement = app.db_session.get(Agreement, 1)
+    basic_user = app.db_session.get(User, 521)
+    agreement.team_members.append(basic_user)
+    app.db_session.flush()
+
+    _setup_fully_approved_pre_award(loaded_db)
+    bli = _make_planned_bli(loaded_db, test_can, test_division_director)
+    loaded_db.commit()
+
+    response = basic_user_auth_client.patch(
+        url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00}
+    )
+    assert response.status_code == 400, f"Financial edit should be blocked. Got: {response.json}"
+    assert "Pre-Award Approval" in response.json.get("status", "")
+
+
+def test_post_pre_award_lock_allows_budget_team(
+    budget_team_auth_client,
+    app,
+    loaded_db,
+    test_division_director,
+    test_can,
+    app_ctx,
+):
+    """Budget team can still edit BLIs after pre-award approval (routes through change-request)."""
+    _setup_fully_approved_pre_award(loaded_db)
+    bli = _make_planned_bli(loaded_db, test_can, test_division_director)
+    loaded_db.commit()
+
+    response = budget_team_auth_client.patch(
+        url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00}
+    )
+    # Budget team is not blocked — goes through change-request workflow (202)
+    assert response.status_code == 202, f"Budget team should get 202 change-request. Got: {response.json}"

--- a/backend/ops_api/tests/ops/workflows/test_change_requests.py
+++ b/backend/ops_api/tests/ops/workflows/test_change_requests.py
@@ -825,9 +825,7 @@ def test_post_pre_award_lock_blocks_regular_user(
     bli = _make_planned_bli(loaded_db, test_can, test_division_director)
     loaded_db.commit()
 
-    response = basic_user_auth_client.patch(
-        url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00}
-    )
+    response = basic_user_auth_client.patch(url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00})
     assert response.status_code == 400, f"Should be blocked after full pre-award approval. Got: {response.json}"
     assert "Pre-Award Approval" in response.json.get("status", "")
 
@@ -840,7 +838,9 @@ def test_post_pre_award_lock_allows_clin_only_for_any_user(
     test_can,
     app_ctx,
 ):
-    """Any authorized user can update clin_id after pre-award is fully approved."""
+    """Any authorized user can update clin_id after pre-award is fully approved — CLIN assignment
+    is part of the award workflow (COR assigns CLINs before submitting for award approval)."""
+    # Add basic user (521) as team member so they pass the association check
     agreement = app.db_session.get(Agreement, 1)
     basic_user = app.db_session.get(User, 521)
     agreement.team_members.append(basic_user)
@@ -894,8 +894,6 @@ def test_post_pre_award_lock_allows_budget_team(
     bli = _make_planned_bli(loaded_db, test_can, test_division_director)
     loaded_db.commit()
 
-    response = budget_team_auth_client.patch(
-        url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00}
-    )
+    response = budget_team_auth_client.patch(url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00})
     # Budget team is not blocked — goes through change-request workflow (202)
     assert response.status_code == 202, f"Budget team should get 202 change-request. Got: {response.json}"

--- a/backend/ops_api/tests/ops/workflows/test_change_requests.py
+++ b/backend/ops_api/tests/ops/workflows/test_change_requests.py
@@ -827,7 +827,7 @@ def test_post_pre_award_lock_blocks_regular_user(
 
     response = basic_user_auth_client.patch(url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00})
     assert response.status_code == 400, f"Should be blocked after full pre-award approval. Got: {response.json}"
-    assert "Pre-Award Approval" in response.json.get("status", "")
+    assert "Pre-Award Approval" in response.json.get("errors", {}).get("status", "")
 
 
 def test_post_pre_award_lock_allows_clin_only_for_any_user(
@@ -850,9 +850,7 @@ def test_post_pre_award_lock_allows_clin_only_for_any_user(
     bli = _make_planned_bli(loaded_db, test_can, test_division_director)
     loaded_db.commit()
 
-    response = basic_user_auth_client.patch(
-        url_for("api.budget-line-items-item", id=bli.id), json={"clin_id": 1}
-    )
+    response = basic_user_auth_client.patch(url_for("api.budget-line-items-item", id=bli.id), json={"clin_id": 1})
     assert response.status_code == 200, f"clin_id update should be allowed for any user. Got: {response.json}"
 
 
@@ -874,11 +872,9 @@ def test_post_pre_award_lock_blocks_non_clin_edit_for_regular_user(
     bli = _make_planned_bli(loaded_db, test_can, test_division_director)
     loaded_db.commit()
 
-    response = basic_user_auth_client.patch(
-        url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00}
-    )
+    response = basic_user_auth_client.patch(url_for("api.budget-line-items-item", id=bli.id), json={"amount": 750.00})
     assert response.status_code == 400, f"Financial edit should be blocked. Got: {response.json}"
-    assert "Pre-Award Approval" in response.json.get("status", "")
+    assert "Pre-Award Approval" in response.json.get("errors", {}).get("status", "")
 
 
 def test_post_pre_award_lock_allows_budget_team(

--- a/frontend/src/components/Agreements/AgreementDetailHeader.jsx
+++ b/frontend/src/components/Agreements/AgreementDetailHeader.jsx
@@ -42,8 +42,7 @@ export const AgreementDetailHeader = ({
         editDisabledTooltipLabel =
             "This agreement is In Review for Award Approval. Edits or changes cannot be made at this time.";
     } else {
-        editDisabledTooltipLabel =
-            "This agreement has completed Pre-Award Approval. Edits cannot be made at this time.";
+        editDisabledTooltipLabel = "This agreement has completed Pre-Award Approval and is locked from further edits.";
     }
     return (
         <>

--- a/frontend/src/components/Agreements/AgreementDetailHeader.jsx
+++ b/frontend/src/components/Agreements/AgreementDetailHeader.jsx
@@ -13,6 +13,7 @@ import Tooltip from "../UI/USWDS/Tooltip";
  * @param {boolean} props.hasUnsavedChanges - Whether there are unsaved changes.
  * @param {boolean} [props.isPreAwardInReview] - Whether pre-award approval is in review.
  * @param {boolean} [props.isAwardInReview] - Whether award approval is in review.
+ * @param {boolean} [props.isPostPreAwardLocked] - Whether the agreement is permanently locked after full pre-award approval.
  * @param {boolean} [props.isGrant] - Whether the agreement is a grant (editing not yet supported).
  * @returns {JSX.Element} - The rendered component.
  */
@@ -25,10 +26,11 @@ export const AgreementDetailHeader = ({
     hasUnsavedChanges = false,
     isPreAwardInReview = false,
     isAwardInReview = false,
+    isPostPreAwardLocked = false,
     isGrant = false
 }) => {
-    const isInReview = isPreAwardInReview || isAwardInReview;
-    // Editing is disabled when the agreement is in review, or when it is a grant (grant editing is not yet supported).
+    const isInReview = isPreAwardInReview || isAwardInReview || isPostPreAwardLocked;
+    // Editing is disabled when the agreement is in review/locked, or when it is a grant (grant editing is not yet supported).
     const isEditDisabled = isInReview || isGrant;
     let editDisabledTooltipLabel;
     if (isGrant) {
@@ -36,9 +38,12 @@ export const AgreementDetailHeader = ({
     } else if (isPreAwardInReview) {
         editDisabledTooltipLabel =
             "This agreement is In Review for Pre-Award Approval. Edits or changes cannot be made at this time.";
-    } else {
+    } else if (isAwardInReview) {
         editDisabledTooltipLabel =
             "This agreement is In Review for Award Approval. Edits or changes cannot be made at this time.";
+    } else {
+        editDisabledTooltipLabel =
+            "This agreement has completed Pre-Award Approval. Edits cannot be made at this time.";
     }
     return (
         <>

--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -257,8 +257,9 @@ const Agreement = () => {
     // Use the backend-derived field so this stays correct regardless of tracker status.
     const isAwardInReview = agreement?.is_award_approval_requested === true;
 
-    // Lock BLI editing permanently once pre-award is fully approved (DD + requisition submitted)
-    const isPostPreAwardLocked = agreement?.is_post_pre_award_locked === true;
+    // Lock BLI editing permanently once pre-award is fully approved (DD + requisition submitted).
+    // Superusers bypass the lock unconditionally so downstream UI shows them as editable.
+    const isPostPreAwardLocked = !isSuperUser && agreement?.is_post_pre_award_locked === true;
 
     const isAgreementAwarded = agreement?.is_awarded;
     return (

--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -257,6 +257,9 @@ const Agreement = () => {
     // Use the backend-derived field so this stays correct regardless of tracker status.
     const isAwardInReview = agreement?.is_award_approval_requested === true;
 
+    // Lock BLI editing permanently once pre-award is fully approved (DD + requisition submitted)
+    const isPostPreAwardLocked = agreement?.is_post_pre_award_locked === true;
+
     const isAgreementAwarded = agreement?.is_awarded;
     return (
         <App breadCrumbName={agreement?.name}>
@@ -376,6 +379,7 @@ const Agreement = () => {
                                 isAgreementAwarded={isAgreementAwarded ?? false}
                                 isPreAwardInReview={isPreAwardInReview}
                                 isAwardInReview={isAwardInReview}
+                                isPostPreAwardLocked={isPostPreAwardLocked}
                             />
                         }
                     />
@@ -390,6 +394,7 @@ const Agreement = () => {
                                 isAgreementAwarded={isAgreementAwarded ?? false}
                                 isPreAwardInReview={isPreAwardInReview}
                                 isAwardInReview={isAwardInReview}
+                                isPostPreAwardLocked={isPostPreAwardLocked}
                             />
                         }
                     />

--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -257,9 +257,8 @@ const Agreement = () => {
     // Use the backend-derived field so this stays correct regardless of tracker status.
     const isAwardInReview = agreement?.is_award_approval_requested === true;
 
-    // Lock BLI editing permanently once pre-award is fully approved (DD + requisition submitted).
-    // Superusers bypass the lock unconditionally so downstream UI shows them as editable.
-    const isPostPreAwardLocked = !isSuperUser && agreement?.is_post_pre_award_locked === true;
+    // Lock BLI editing permanently once pre-award is fully approved (DD + requisition submitted)
+    const isPostPreAwardLocked = agreement?.is_post_pre_award_locked === true;
 
     const isAgreementAwarded = agreement?.is_awarded;
     return (

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
@@ -83,9 +83,9 @@ const AgreementBudgetLines = ({
     // Regular users must have permission and agreement must be in editable state
     const canRegularUserEdit = agreement?._meta.isEditable && !isAgreementNotDeveloped && !allBudgetLinesInReview;
 
-    // Pre-award, award in review, or post-pre-award lock blocks everyone except superusers
+    // Superusers bypass all locks; regular users are blocked by pre-award, award review, or post-pre-award lock
     const isAgreementEditable =
-        !isPreAwardInReview && !isAwardInReview && !isPostPreAwardLocked && (isSuperUser || canRegularUserEdit);
+        isSuperUser || (!isPreAwardInReview && !isAwardInReview && !isPostPreAwardLocked && canRegularUserEdit);
     // Grant editing is not yet supported: the Request BL Status Change button is disabled even when the agreement is otherwise editable.
     const canRequestStatusChange = isAgreementEditable && !isGrant;
     const filters = { agreementIds: [agreement?.id] };
@@ -106,7 +106,7 @@ const AgreementBudgetLines = ({
             case isAwardInReview:
                 return "This agreement is In Review for Award Approval. Edits or changes cannot be made at this time.";
             case isPostPreAwardLocked:
-                return "This agreement has completed Pre-Award Approval. Edits cannot be made at this time.";
+                return "This agreement has completed Pre-Award Approval and is locked from further edits.";
             case allBudgetLinesInReview:
                 return "Budget lines In Review Status cannot be sent for status changes";
             default:

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
@@ -83,9 +83,9 @@ const AgreementBudgetLines = ({
     // Regular users must have permission and agreement must be in editable state
     const canRegularUserEdit = agreement?._meta.isEditable && !isAgreementNotDeveloped && !allBudgetLinesInReview;
 
-    // Superusers bypass all locks; regular users are blocked by pre-award, award review, or post-pre-award lock
+    // All users (including superusers) are blocked by pre-award, award review, or post-pre-award lock
     const isAgreementEditable =
-        isSuperUser || (!isPreAwardInReview && !isAwardInReview && !isPostPreAwardLocked && canRegularUserEdit);
+        !isPreAwardInReview && !isAwardInReview && !isPostPreAwardLocked && (isSuperUser || canRegularUserEdit);
     // Grant editing is not yet supported: the Request BL Status Change button is disabled even when the agreement is otherwise editable.
     const canRequestStatusChange = isAgreementEditable && !isGrant;
     const filters = { agreementIds: [agreement?.id] };

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
@@ -52,6 +52,7 @@ import icons from "../../../uswds/img/sprite.svg";
  * @param {boolean} props.isAgreementAwarded - Whether the agreement is awarded.
  * @param {boolean} [props.isPreAwardInReview] - if the agreement is in review for pre-award approval
  * @param {boolean} [props.isAwardInReview] - if the agreement is in review for award approval
+ * @param {boolean} [props.isPostPreAwardLocked] - if the agreement is permanently locked after full pre-award approval
  * @param {Function} props.setIsEditMode - The function to set the edit mode.
  * @returns {JSX.Element} - The rendered component.
  */
@@ -62,7 +63,8 @@ const AgreementBudgetLines = ({
     isAgreementNotDeveloped,
     isAgreementAwarded,
     isPreAwardInReview = false,
-    isAwardInReview = false
+    isAwardInReview = false,
+    isPostPreAwardLocked = false
 }) => {
     // TODO: Create a custom hook for this business logix (./AgreementBudgetLines.hooks.js)
     const navigate = useNavigate();
@@ -81,8 +83,9 @@ const AgreementBudgetLines = ({
     // Regular users must have permission and agreement must be in editable state
     const canRegularUserEdit = agreement?._meta.isEditable && !isAgreementNotDeveloped && !allBudgetLinesInReview;
 
-    // Pre-award or award in review blocks everyone; otherwise super users bypass checks, regular users must pass all
-    const isAgreementEditable = !isPreAwardInReview && !isAwardInReview && (isSuperUser || canRegularUserEdit);
+    // Pre-award, award in review, or post-pre-award lock blocks everyone except superusers
+    const isAgreementEditable =
+        !isPreAwardInReview && !isAwardInReview && !isPostPreAwardLocked && (isSuperUser || canRegularUserEdit);
     // Grant editing is not yet supported: the Request BL Status Change button is disabled even when the agreement is otherwise editable.
     const canRequestStatusChange = isAgreementEditable && !isGrant;
     const filters = { agreementIds: [agreement?.id] };
@@ -102,6 +105,8 @@ const AgreementBudgetLines = ({
                 return "This agreement is In Review for Pre-Award Approval. Edits or changes cannot be made at this time.";
             case isAwardInReview:
                 return "This agreement is In Review for Award Approval. Edits or changes cannot be made at this time.";
+            case isPostPreAwardLocked:
+                return "This agreement has completed Pre-Award Approval. Edits cannot be made at this time.";
             case allBudgetLinesInReview:
                 return "Budget lines In Review Status cannot be sent for status changes";
             default:

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.test.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.test.jsx
@@ -509,9 +509,10 @@ describe("AgreementBudgetLines", () => {
             expect(requestButton).toHaveAttribute("data-cy", "bli-continue-btn-disabled");
         });
 
-        test("super user can still edit when isPostPreAwardLocked is true", () => {
+        test("super user is also locked when isPostPreAwardLocked is true", () => {
             renderWith(superUserStore);
-            expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+            expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
+            expect(screen.queryByText("Edit")).not.toBeInTheDocument();
         });
     });
 });

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.test.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.test.jsx
@@ -446,6 +446,18 @@ describe("AgreementBudgetLines", () => {
     });
 
     describe("post-pre-award lock", () => {
+        const regularUserStore = configureStore({
+            reducer: {
+                auth: () => ({
+                    activeUser: {
+                        id: 1,
+                        full_name: "Regular User",
+                        email: "user@example.com",
+                        roles: [{ name: USER_ROLES.VIEWER_EDITOR }]
+                    }
+                })
+            }
+        });
         const superUserStore = configureStore({
             reducer: {
                 auth: () => ({
@@ -484,21 +496,21 @@ describe("AgreementBudgetLines", () => {
                 </Provider>
             );
 
-        test("Edit button is hidden when isPostPreAwardLocked is true", () => {
-            renderWith(superUserStore);
+        test("Edit button is hidden for regular user when isPostPreAwardLocked is true", () => {
+            renderWith(regularUserStore);
             expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
             expect(screen.queryByText("Edit")).not.toBeInTheDocument();
         });
 
-        test("Request BL Status Change button is disabled when isPostPreAwardLocked is true", () => {
-            renderWith(superUserStore);
+        test("Request BL Status Change button is disabled for regular user when isPostPreAwardLocked is true", () => {
+            renderWith(regularUserStore);
             const requestButton = screen.getByText("Request BL Status Change");
             expect(requestButton).toHaveAttribute("aria-disabled", "true");
             expect(requestButton).toHaveAttribute("data-cy", "bli-continue-btn-disabled");
         });
 
-        test("super user can edit when isPostPreAwardLocked is false", () => {
-            renderWith(superUserStore, { isPostPreAwardLocked: false });
+        test("super user can still edit when isPostPreAwardLocked is true", () => {
+            renderWith(superUserStore);
             expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
         });
     });

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.test.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.test.jsx
@@ -444,4 +444,62 @@ describe("AgreementBudgetLines", () => {
         // Should render the component for super users even with restrictions
         expect(screen.getByText("Budget Lines")).toBeInTheDocument();
     });
+
+    describe("post-pre-award lock", () => {
+        const superUserStore = configureStore({
+            reducer: {
+                auth: () => ({
+                    activeUser: {
+                        id: 1,
+                        full_name: "Super User",
+                        email: "super@example.com",
+                        roles: [{ name: USER_ROLES.SUPER_USER }],
+                        is_superuser: true
+                    }
+                })
+            }
+        });
+        const defaultProps = {
+            agreement: { ...mockAgreement, _meta: { isEditable: true } },
+            isEditMode: false,
+            setIsEditMode: vi.fn(),
+            isAgreementNotDeveloped: false,
+            isAgreementAwarded: false,
+            isPreAwardInReview: false,
+            isAwardInReview: false,
+            isPostPreAwardLocked: true
+        };
+        const renderWith = (store, props = {}) =>
+            render(
+                <Provider store={store}>
+                    <Router
+                        location={history.location}
+                        navigator={history}
+                    >
+                        <AgreementBudgetLines
+                            {...defaultProps}
+                            {...props}
+                        />
+                    </Router>
+                </Provider>
+            );
+
+        test("Edit button is hidden when isPostPreAwardLocked is true", () => {
+            renderWith(superUserStore);
+            expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
+            expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+        });
+
+        test("Request BL Status Change button is disabled when isPostPreAwardLocked is true", () => {
+            renderWith(superUserStore);
+            const requestButton = screen.getByText("Request BL Status Change");
+            expect(requestButton).toHaveAttribute("aria-disabled", "true");
+            expect(requestButton).toHaveAttribute("data-cy", "bli-continue-btn-disabled");
+        });
+
+        test("super user can edit when isPostPreAwardLocked is false", () => {
+            renderWith(superUserStore, { isPostPreAwardLocked: false });
+            expect(screen.getByRole("button", { name: /edit/i })).toBeInTheDocument();
+        });
+    });
 });

--- a/frontend/src/pages/agreements/details/AgreementDetails.jsx
+++ b/frontend/src/pages/agreements/details/AgreementDetails.jsx
@@ -38,7 +38,11 @@ const AgreementDetails = ({
     const isSuperUser = useIsUserSuperUser();
     // eslint-disable-next-line no-unused-vars
     let { budget_line_items: _, ...agreement_details } = agreement;
-    const isEditable = isSuperUser || (agreement?._meta.isEditable && !isAgreementNotDeveloped);
+    const isEditable =
+        !isPreAwardInReview &&
+        !isAwardInReview &&
+        !isPostPreAwardLocked &&
+        (isSuperUser || (agreement?._meta.isEditable && !isAgreementNotDeveloped));
     // Editing is not yet supported for grant agreements, so the Edit button is disabled for them.
     const isGrant = agreement?.agreement_type === AgreementType.GRANT;
 

--- a/frontend/src/pages/agreements/details/AgreementDetails.jsx
+++ b/frontend/src/pages/agreements/details/AgreementDetails.jsx
@@ -18,6 +18,7 @@ import AgreementDetailsView from "./AgreementDetailsView";
  * @param {boolean} [props.hasAgreementChanged] - if the agreement properties has changed
  * @param {boolean} [props.isPreAwardInReview] - if the agreement is in review for pre-award approval
  * @param {boolean} [props.isAwardInReview] - if the agreement is in review for award approval
+ * @param {boolean} [props.isPostPreAwardLocked] - if the agreement is permanently locked after full pre-award approval
  * @returns {React.ReactElement} - The rendered component.
  */
 const AgreementDetails = ({
@@ -31,7 +32,8 @@ const AgreementDetails = ({
     isAgreementAwarded = false,
     hasAgreementChanged = false,
     isPreAwardInReview = false,
-    isAwardInReview = false
+    isAwardInReview = false,
+    isPostPreAwardLocked = false
 }) => {
     const isSuperUser = useIsUserSuperUser();
     // eslint-disable-next-line no-unused-vars
@@ -51,6 +53,7 @@ const AgreementDetails = ({
                 hasUnsavedChanges={hasAgreementChanged}
                 isPreAwardInReview={isPreAwardInReview}
                 isAwardInReview={isAwardInReview}
+                isPostPreAwardLocked={isPostPreAwardLocked}
                 isGrant={isGrant}
             />
 

--- a/frontend/src/pages/agreements/details/AgreementDetails.jsx
+++ b/frontend/src/pages/agreements/details/AgreementDetails.jsx
@@ -38,6 +38,10 @@ const AgreementDetails = ({
     const isSuperUser = useIsUserSuperUser();
     // eslint-disable-next-line no-unused-vars
     let { budget_line_items: _, ...agreement_details } = agreement;
+    // Intentionally blocks the Details edit form during all procurement locks (pre-award review,
+    // award review, and post-pre-award lock), not just post-pre-award. This is broader than the
+    // OPS-2280 PR scope but correct: if the header already shows editing as disabled for those
+    // states, the form should not be reachable via URL params either.
     const isEditable =
         !isPreAwardInReview &&
         !isAwardInReview &&

--- a/frontend/src/types/AgreementTypes.d.ts
+++ b/frontend/src/types/AgreementTypes.d.ts
@@ -42,6 +42,7 @@ export type Agreement = {
     vendor?: string;
     in_review?: boolean;
     is_award_approval_requested?: boolean;
+    is_post_pre_award_locked?: boolean;
     change_requests_in_review?: ChangeRequest[];
     requesting_agency?: string;
     servicing_agency?: string;


### PR DESCRIPTION
## What changed

Once pre-award is fully approved (Division Director approved + Budget Team submitted requisition), BLI editing is permanently locked — with two exceptions:

1. **`clin_id`-only edits** are allowed for any authorized user (COR assigns CLINs as part of the award workflow before submitting for award approval)
2. **Budget Team financial edits during active award approval (step 6)** — already handled by the existing `budget_team_can_bypass` gate

Superusers bypass the lock unconditionally.

**Backend:**
- New `is_post_pre_award_locked(agreement)` helper — scoped to the ACTIVE tracker, consistent with `is_pre_award_in_review` and `is_award_approval_requested`
- New validation gate in `_validation()` blocking non-superuser, non-budget-team edits after full pre-award approval; detects clin-only edits via raw request JSON (not schema-loaded fields)
- `is_post_pre_award_locked` model property + `fields.Bool` on `AgreementResponse` (same pattern as `in_review` / `is_award_approval_requested`)

**Frontend:**
- `isPostPreAwardLocked` derived from `agreement.is_post_pre_award_locked` in `Agreement.jsx`
- Prop threaded through `AgreementBudgetLines`, `AgreementDetails`, `AgreementDetailHeader`
- Edit button hidden and tooltip message added for the locked state
- 3 new tests in `AgreementBudgetLines.test.jsx`

**Related:** Bug ticket #6007 filed for a separate pre-existing state machine gap (re-submission after full approval).

## Issue

https://github.com/HHS/OPRE-OPS/issues/2280

## How to test

1. Advance an agreement through full pre-award approval (DD approves + BT submits requisition)
2. Confirm Edit button is hidden on both Details and BLI tabs
3. As COR, assign CLINs to BLIs — should succeed (200)
4. As COR, attempt to change amount — should fail (400)
5. As Budget Team, attempt a financial edit (no award approval active) — should route through change request (202)
6. As superuser, confirm editing is unrestricted

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is logic/validation, no new UI components

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

## Links

- Bug ticket for pre-award re-submission state machine gap: #6007