### PR TITLE
fix: refetch procurement tracker on mount so pre-award banner clears after decline

### DIFF
--- a/frontend/src/pages/agreements/details/Agreement.jsx
+++ b/frontend/src/pages/agreements/details/Agreement.jsx
@@ -139,8 +139,12 @@ const Agreement = () => {
         user_agreement_notifications = query_response.data;
     }
 
-    // Query procurement tracker to check for pre-award approval status
+    // Query procurement tracker to check for pre-award approval status.
+    // Refetch on mount so the "In Review" banner reflects fresh tracker state after a
+    // Division Director approves/declines (e.g. when the COR reopens the page). Without this,
+    // a stale cached tracker can keep the banner visible even though the decline persisted.
     const { data: procurementTrackers } = useGetProcurementTrackersByAgreementIdQuery(agreementId, {
+        refetchOnMountOrArgChange: true,
         skip: !agreementId
     });
 


### PR DESCRIPTION
## What changed

The **"Pre-Award Approval In Review"** banner on the agreement detail page is driven entirely by procurement tracker data. That query (`useGetProcurementTrackersByAgreementIdQuery` in `Agreement.jsx`) lacked `refetchOnMountOrArgChange`, even though the agreement query directly above it has it.

Because the RTK Query cache only resets on a full logout, reopening the agreement — or switching users without a clean logout — could render a **stale, pre-decline tracker**, keeping the banner visible even though the Division Director's decline persisted correctly on the backend.

This PR adds `refetchOnMountOrArgChange: true` to the tracker query so the banner always reflects fresh tracker state on mount, matching the agreement query.

**Investigation note:** I reproduced the DD-decline flow through the real service layer against seeded data. Current `main` already persists `approval_requested=false` + `approval_status=DECLINED`, and the serialized API response yields `isPreAwardInReview = false` (banner hidden). The released `v1.436.1` had byte-identical decline + banner logic and unchanged backend, so the follow-up report was a **stale-cache** issue, not a state/logic bug.

## Issue

Follow-up to https://github.com/HHS/OPRE-OPS/issues/5990 — [reviewer comment](https://github.com/HHS/OPRE-OPS/issues/5990#issuecomment-5121184080): after the DD declines, the COR still sees the "in review" warning.

## How to test

1. Find/create an agreement with an executing budget line and submit it for pre-award approval.
2. Log in as the Division Director and decline the request.
3. Log back in as the COR (User Demo) and open the agreement detail page.
4. **Expected:** the "Pre-Award Approval In Review" banner is **not** shown (the agreement reflects the declined state). Previously a stale cached tracker could keep the banner visible.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Screenshots

_N/A — no visual changes; behavior is cache-freshness only._

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated
