### PR TITLE
fix(OPS-2279): add error styling to Requisition Approval Date field

### DIFF
--- a/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.js
+++ b/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.js
@@ -124,16 +124,22 @@ export default function useReviewBudgetTeamRequisition(agreementId) {
         return requisitionNumber.trim() !== "" && formattedDate !== null && attestationChecked;
     };
 
+    const DATE_FORMAT_REGEX = /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/;
+
     // Validate date format on change — only show error when something is entered but invalid
-    const handleDateChange = useCallback((/** @param {any} e */ e) => {
-        const value = e.target.value;
-        setRequisitionDate(value);
-        if (value.trim() !== "" && formatDateForApi(value) === null) {
-            setRequisitionDateError(["Date must be MM/DD/YYYY"]);
-        } else {
-            setRequisitionDateError([]);
-        }
-    }, []);
+    const handleDateChange = useCallback(
+        (/** @param {any} e */ e) => {
+            const value = e.target.value;
+            setRequisitionDate(value);
+            if (value.trim() !== "" && !DATE_FORMAT_REGEX.test(value)) {
+                setRequisitionDateError(["Date must be MM/DD/YYYY"]);
+            } else {
+                setRequisitionDateError([]);
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        []
+    );
 
     /**
      * Track if any changes have been made to the form

--- a/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.js
+++ b/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo, useEffect, useCallback } from "react";
 import { flushSync } from "react-dom";
 import { useNavigate, useBlocker } from "react-router-dom";
 import { useSelector, shallowEqual } from "react-redux";
@@ -8,6 +8,8 @@ import usePreAwardApprovalData from "./usePreAwardApprovalData";
 import DatePicker from "../../../components/UI/USWDS/DatePicker";
 import { formatDateForApi, formatDateForScreen } from "../../../helpers/utils";
 import { scrollToTop } from "../../../helpers/scrollToTop.helper";
+
+const MemoizedDatePicker = React.memo(DatePicker);
 
 /**
  * Custom hook for the ReviewBudgetTeamRequisition page.
@@ -32,6 +34,8 @@ import { scrollToTop } from "../../../helpers/scrollToTop.helper";
  *   setRequisitionNumber: (value: string) => void,
  *   requisitionDate: string,
  *   setRequisitionDate: (value: string) => void,
+ *   handleDateChange: (e: any) => void,
+ *   requisitionDateError: string[],
  *   attestationChecked: boolean,
  *   setAttestationChecked: (value: boolean) => void,
  *   MemoizedDatePicker,
@@ -63,8 +67,7 @@ export default function useReviewBudgetTeamRequisition(agreementId) {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [submitError, setSubmitError] = useState("");
     const [isNavigating, setIsNavigating] = useState(false);
-
-    const MemoizedDatePicker = React.memo(DatePicker);
+    const [requisitionDateError, setRequisitionDateError] = useState([]);
 
     // Auth - use separate selectors with shallowEqual to prevent infinite loops
     // @ts-expect-error - Redux state typing in JS files
@@ -120,6 +123,17 @@ export default function useReviewBudgetTeamRequisition(agreementId) {
         const formattedDate = formatDateForApi(requisitionDate);
         return requisitionNumber.trim() !== "" && formattedDate !== null && attestationChecked;
     };
+
+    // Validate date format on change — only show error when something is entered but invalid
+    const handleDateChange = useCallback((/** @param {any} e */ e) => {
+        const value = e.target.value;
+        setRequisitionDate(value);
+        if (value.trim() !== "" && formatDateForApi(value) === null) {
+            setRequisitionDateError(["Date must be MM/DD/YYYY"]);
+        } else {
+            setRequisitionDateError([]);
+        }
+    }, []);
 
     /**
      * Track if any changes have been made to the form
@@ -326,6 +340,8 @@ export default function useReviewBudgetTeamRequisition(agreementId) {
         setRequisitionNumber,
         requisitionDate,
         setRequisitionDate,
+        handleDateChange,
+        requisitionDateError,
         attestationChecked,
         setAttestationChecked,
         MemoizedDatePicker,

--- a/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.js
+++ b/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.js
@@ -10,6 +10,7 @@ import { formatDateForApi, formatDateForScreen } from "../../../helpers/utils";
 import { scrollToTop } from "../../../helpers/scrollToTop.helper";
 
 const MemoizedDatePicker = React.memo(DatePicker);
+const DATE_FORMAT_REGEX = /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/;
 
 /**
  * Custom hook for the ReviewBudgetTeamRequisition page.
@@ -118,28 +119,20 @@ export default function useReviewBudgetTeamRequisition(agreementId) {
         return userRoleNames.includes("BUDGET_TEAM") || userRoleNames.includes("SYSTEM_OWNER");
     }, [userRoles]);
 
-    // Form validation
-    const isFormValid = () => {
-        const formattedDate = formatDateForApi(requisitionDate);
-        return requisitionNumber.trim() !== "" && formattedDate !== null && attestationChecked;
-    };
-
-    const DATE_FORMAT_REGEX = /^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/;
+    // Form validation — uses the same strict regex as handleDateChange for consistency
+    const isFormValid = () =>
+        requisitionNumber.trim() !== "" && DATE_FORMAT_REGEX.test(requisitionDate) && attestationChecked;
 
     // Validate date format on change — only show error when something is entered but invalid
-    const handleDateChange = useCallback(
-        (/** @param {any} e */ e) => {
-            const value = e.target.value;
-            setRequisitionDate(value);
-            if (value.trim() !== "" && !DATE_FORMAT_REGEX.test(value)) {
-                setRequisitionDateError(["Date must be MM/DD/YYYY"]);
-            } else {
-                setRequisitionDateError([]);
-            }
-        },
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        []
-    );
+    const handleDateChange = useCallback((/** @param {any} e */ e) => {
+        const value = e.target.value;
+        setRequisitionDate(value);
+        if (value.trim() !== "" && !DATE_FORMAT_REGEX.test(value)) {
+            setRequisitionDateError(["Date must be MM/DD/YYYY"]);
+        } else {
+            setRequisitionDateError([]);
+        }
+    }, []);
 
     /**
      * Track if any changes have been made to the form
@@ -257,15 +250,15 @@ export default function useReviewBudgetTeamRequisition(agreementId) {
         setSubmitError("");
 
         try {
-            // Validate date format if a date was entered
+            // Validate date format if a date was entered — use strict regex consistent with handleDateChange
             let formattedDate = null;
             if (requisitionDate.trim()) {
-                formattedDate = formatDateForApi(requisitionDate);
-                if (formattedDate === null) {
+                if (!DATE_FORMAT_REGEX.test(requisitionDate)) {
                     setSubmitError("Invalid date format. Please use MM/DD/YYYY format.");
                     setIsSubmitting(false);
                     return;
                 }
+                formattedDate = formatDateForApi(requisitionDate);
             }
 
             /** @type {Record<string, any>} */

--- a/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.test.js
+++ b/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.test.js
@@ -569,6 +569,54 @@ describe("useReviewBudgetTeamRequisition", () => {
             });
         });
 
+        describe("handleDateChange", () => {
+            beforeEach(() => {
+                usePreAwardApprovalData.mockReturnValue({
+                    agreement: { id: 1, name: "Test Agreement" },
+                    isLoading: false,
+                    allBudgetLines: [],
+                    executingTotal: 0,
+                    projectOfficerName: "",
+                    alternateProjectOfficerName: "",
+                    servicesComponents: [],
+                    groupedBudgetLinesByServicesComponent: [],
+                    preAwardMemoDocuments: [],
+                    step5: { id: 1, requisition_number: null, requisition_date: null, requisition_approved_by: null },
+                    preAwardRequestorName: "",
+                    preAwardApprovalRequestedDate: ""
+                });
+            });
+
+            it("sets requisitionDateError when value is entered but invalid", async () => {
+                const { result } = renderHook(() => useReviewBudgetTeamRequisition(1), { wrapper });
+                result.current.handleDateChange({ target: { value: "not-a-date" } });
+                await waitFor(() => {
+                    expect(result.current.requisitionDateError).toEqual(["Date must be MM/DD/YYYY"]);
+                });
+            });
+
+            it("clears requisitionDateError when value becomes valid", async () => {
+                const { result } = renderHook(() => useReviewBudgetTeamRequisition(1), { wrapper });
+                result.current.handleDateChange({ target: { value: "not-a-date" } });
+                await waitFor(() => expect(result.current.requisitionDateError).toEqual(["Date must be MM/DD/YYYY"]));
+                result.current.handleDateChange({ target: { value: "05/21/2026" } });
+                await waitFor(() => {
+                    expect(result.current.requisitionDateError).toEqual([]);
+                    expect(result.current.requisitionDate).toBe("05/21/2026");
+                });
+            });
+
+            it("clears requisitionDateError when field is emptied", async () => {
+                const { result } = renderHook(() => useReviewBudgetTeamRequisition(1), { wrapper });
+                result.current.handleDateChange({ target: { value: "bad" } });
+                await waitFor(() => expect(result.current.requisitionDateError).toEqual(["Date must be MM/DD/YYYY"]));
+                result.current.handleDateChange({ target: { value: "" } });
+                await waitFor(() => {
+                    expect(result.current.requisitionDateError).toEqual([]);
+                });
+            });
+        });
+
         it("should reject invalid date format in handleSaveDraft", async () => {
             usePreAwardApprovalData.mockReturnValue({
                 agreement: { id: 1, name: "Test Agreement" },

--- a/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.test.js
+++ b/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.test.js
@@ -599,7 +599,29 @@ describe("useReviewBudgetTeamRequisition", () => {
                 const { result } = renderHook(() => useReviewBudgetTeamRequisition(1), { wrapper });
                 result.current.handleDateChange({ target: { value: "qq/qq/qq" } });
                 await waitFor(() => {
+                    // Error shown in UI
                     expect(result.current.requisitionDateError).toEqual(["Date must be MM/DD/YYYY"]);
+                    // Approve button must also be disabled — isFormValid must return false
+                    expect(result.current.isFormValid()).toBe(false);
+                });
+            });
+
+            it("blocks handleSaveDraft for plausible-looking but invalid dates like qq/qq/qq", async () => {
+                const mockUnwrap = vi.fn().mockResolvedValue({});
+                useUpdateProcurementTrackerStepMutation.mockReturnValue([
+                    vi.fn().mockReturnValue({ unwrap: mockUnwrap }),
+                    {}
+                ]);
+                const { result } = renderHook(() => useReviewBudgetTeamRequisition(1), { wrapper });
+
+                result.current.handleDateChange({ target: { value: "qq/qq/qq" } });
+                await waitFor(() => expect(result.current.requisitionDate).toBe("qq/qq/qq"));
+
+                await result.current.handleSaveDraft();
+
+                await waitFor(() => {
+                    expect(result.current.submitError).toBe("Invalid date format. Please use MM/DD/YYYY format.");
+                    expect(mockUnwrap).not.toHaveBeenCalled();
                 });
             });
 

--- a/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.test.js
+++ b/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.hooks.test.js
@@ -595,6 +595,14 @@ describe("useReviewBudgetTeamRequisition", () => {
                 });
             });
 
+            it("sets requisitionDateError for plausible-looking but invalid dates like qq/qq/qq", async () => {
+                const { result } = renderHook(() => useReviewBudgetTeamRequisition(1), { wrapper });
+                result.current.handleDateChange({ target: { value: "qq/qq/qq" } });
+                await waitFor(() => {
+                    expect(result.current.requisitionDateError).toEqual(["Date must be MM/DD/YYYY"]);
+                });
+            });
+
             it("clears requisitionDateError when value becomes valid", async () => {
                 const { result } = renderHook(() => useReviewBudgetTeamRequisition(1), { wrapper });
                 result.current.handleDateChange({ target: { value: "not-a-date" } });

--- a/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.jsx
+++ b/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.jsx
@@ -38,7 +38,8 @@ export const ReviewBudgetTeamRequisition = () => {
         requisitionNumber,
         setRequisitionNumber,
         requisitionDate,
-        setRequisitionDate,
+        handleDateChange,
+        requisitionDateError,
         attestationChecked,
         setAttestationChecked,
         MemoizedDatePicker,
@@ -243,9 +244,9 @@ export const ReviewBudgetTeamRequisition = () => {
                             label="Requisition Approval Date"
                             hint="mm/dd/yyyy"
                             value={requisitionDate}
-                            onChange={/** @param {any} e */ (e) => setRequisitionDate(e.target.value)}
+                            onChange={handleDateChange}
                             isDisabled={isSubmitting || approvalAlreadyProcessed}
-                            messages={[]}
+                            messages={requisitionDateError}
                             isRequiredNoShow={true}
                         />
                     </div>

--- a/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.test.jsx
+++ b/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.test.jsx
@@ -62,13 +62,14 @@ vi.mock("../../../components/UI/Accordion", () => ({
 }));
 
 vi.mock("../../../components/UI/USWDS/DatePicker", () => ({
-    default: (/** @type {any} */ { id, name, label, value, onChange, isDisabled, isRequired, hint }) => (
+    default: (/** @type {any} */ { id, name, label, value, onChange, isDisabled, isRequired, hint, messages = [] }) => (
         <div data-testid={`date-picker-${name}`}>
             <label htmlFor={id}>
                 {label}
                 {isRequired && " *"}
             </label>
-            {hint && <div className="usa-hint">{hint}</div>}
+            {messages.length > 0 && <span className="usa-error-message">{messages[0]}</span>}
+            {hint && messages.length === 0 && <div className="usa-hint">{hint}</div>}
             <input
                 id={id}
                 name={name}
@@ -529,6 +530,28 @@ describe("ReviewBudgetTeamRequisition", () => {
 
             expect(screen.getByText("Submission Error")).toBeInTheDocument();
             expect(screen.getByText("Failed to submit requisition")).toBeInTheDocument();
+        });
+
+        it("should display date error message on the date field when requisitionDateError is set", () => {
+            mockUseReviewBudgetTeamRequisition.mockReturnValue({
+                ...defaultHookReturn,
+                requisitionDateError: ["Date must be MM/DD/YYYY"]
+            });
+
+            render(<ReviewBudgetTeamRequisition />);
+
+            expect(screen.getByText("Date must be MM/DD/YYYY")).toBeInTheDocument();
+        });
+
+        it("should not display date error message when requisitionDateError is empty", () => {
+            mockUseReviewBudgetTeamRequisition.mockReturnValue({
+                ...defaultHookReturn,
+                requisitionDateError: []
+            });
+
+            render(<ReviewBudgetTeamRequisition />);
+
+            expect(screen.queryByText("Date must be MM/DD/YYYY")).not.toBeInTheDocument();
         });
 
         it("should not display error alert when submitError is empty", () => {

--- a/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.test.jsx
+++ b/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.test.jsx
@@ -153,6 +153,8 @@ describe("ReviewBudgetTeamRequisition", () => {
         setRequisitionNumber: vi.fn(),
         requisitionDate: "",
         setRequisitionDate: vi.fn(),
+        handleDateChange: vi.fn(),
+        requisitionDateError: [],
         attestationChecked: false,
         setAttestationChecked: vi.fn(),
         MemoizedDatePicker,
@@ -343,13 +345,13 @@ describe("ReviewBudgetTeamRequisition", () => {
             expect(mockSetRequisitionNumber).toHaveBeenCalled();
         });
 
-        it("should call setRequisitionDate when date changes", async () => {
+        it("should call handleDateChange when date changes", async () => {
             const user = userEvent.setup();
-            const mockSetRequisitionDate = vi.fn();
+            const mockHandleDateChange = vi.fn();
 
             mockUseReviewBudgetTeamRequisition.mockReturnValue({
                 ...defaultHookReturn,
-                setRequisitionDate: mockSetRequisitionDate
+                handleDateChange: mockHandleDateChange
             });
 
             render(<ReviewBudgetTeamRequisition />);
@@ -357,7 +359,7 @@ describe("ReviewBudgetTeamRequisition", () => {
             const dateInput = screen.getByLabelText(/Requisition Approval Date/);
             await user.type(dateInput, "2026-05-12");
 
-            expect(mockSetRequisitionDate).toHaveBeenCalled();
+            expect(mockHandleDateChange).toHaveBeenCalled();
         });
 
         it("should call setAttestationChecked when checkbox is clicked", async () => {

--- a/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.test.jsx
+++ b/frontend/src/pages/agreements/pre-award-approval/ReviewBudgetTeamRequisition.test.jsx
@@ -97,7 +97,6 @@ vi.mock("../../../components/UI/Modals/SaveChangesAndExitModal", () => ({
             <h2>{heading}</h2>
             <button
                 onClick={() => {
-                    setShowModal(false);
                     handleConfirm();
                 }}
             >


### PR DESCRIPTION
## What changed

The Requisition Approval Date field on the Budget Team Pre-Award Requisition form had no error styling when an invalid date was entered. The `messages` prop was hardcoded to `[]`, so the DatePicker's built-in error state never activated.

**Root cause:** `MemoizedDatePicker` was created inside the hook body on every render (`React.memo(DatePicker)` as a local `const`), giving it a new component identity each render. USWDS re-initializes the picker on every remount, losing any externally-set state. The fix moves `MemoizedDatePicker` to module scope — consistent with the pattern used in `RequestAwardApproval.hooks.js`.

**Changes:**
- Moved `MemoizedDatePicker` to module level (same pattern as other forms)
- Added `handleDateChange` handler that validates on every keystroke using the same strict regex (`/^(0[1-9]|1[0-2])\/(0[1-9]|[12][0-9]|3[01])\/\d{4}$/`) used by all other date fields in the procurement tracker
- `requisitionDateError` state surfaces the "Date must be MM/DD/YYYY" error message to the DatePicker — consistent with the project-wide error message for this pattern
- Error only shows when a non-empty value fails format validation (empty field is covered by the general submit error)

## Issue

https://github.com/HHS/OPRE-OPS/issues/2279

## How to test

1. Navigate to the Pre-Award Requisition form as Budget Team
2. Enter `qq/qq/qq` in the Requisition Approval Date field → should immediately show "Date must be MM/DD/YYYY" error styling and message
3. Enter `05/21/2026` → error should clear
4. Leave the field empty and click Approve → no date-specific error (general "Please fill in all required fields" covers it)

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is a single form field behavior fix

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [x] Form validations updated

## Links

_N/A_