### PR TITLE
feat: add out-of-band ChangeRequest approval script

### DIFF
--- a/backend/data_tools/src/approve_change_requests.py
+++ b/backend/data_tools/src/approve_change_requests.py
@@ -1,0 +1,358 @@
+"""
+Approve one or more ChangeRequest records out-of-band, on behalf of an assigned
+reviewer, when no one with the right authority is available to approve via the UI.
+
+Usage (from backend/ directory):
+    python data_tools/src/approve_change_requests.py \\
+        --env dev \\
+        --approving-user-email jane.doe@example.com \\
+        --change-request-id 4821 --change-request-id 4822 \\
+        --reviewer-notes "Confirmed with COR via email 2026-07-30"
+
+Set DRY_RUN=1 to preview changes without committing:
+    DRY_RUN=1 python data_tools/src/approve_change_requests.py --env dev \\
+        --approving-user-email jane.doe@example.com --change-request-id 4821
+"""
+
+import os
+import sys
+import time
+from datetime import date, datetime
+
+import click
+from dotenv import load_dotenv
+from loguru import logger
+from sqlalchemy import func, inspect, select, text
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
+
+from data_tools.src.common.db import init_db_from_config, setup_triggers
+from data_tools.src.common.utils import commit_or_rollback, get_config, get_or_create_sys_user
+from models import (
+    Agreement,
+    BudgetLineItem,
+    BudgetLineItemStatus,
+    ChangeRequest,
+    ChangeRequestNotification,
+    ChangeRequestStatus,
+    ChangeRequestType,
+    Division,
+    NotificationType,
+    OpsEvent,
+    OpsEventStatus,
+    OpsEventType,
+    User,
+    agreement_history_trigger_func,
+)
+from models.procurement_workflow import (
+    get_or_create_procurement_records_for_new_award,
+    link_blis_to_action,
+)
+
+load_dotenv(os.getenv("ENV_FILE", ".env"))
+
+os.environ["TZ"] = "UTC"
+time.tzset()
+
+log_format = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+    "<level>{level: <8}</level> | "
+    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> | "
+    "<level>{message}</level>"
+)
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+logger.remove()
+logger.add(sys.stderr, format=log_format, level=LOG_LEVEL)
+
+OUT_OF_BAND_MARKER = "[Approved via out-of-band script on behalf of assigned reviewer]"
+
+
+def apply_change_request_data(target, data: dict) -> None:
+    """Set each key in data onto target if it's a real mapped column attribute,
+    converting the small set of fields that need type coercion first.
+
+    requested_change_data stores plain JSON-safe primitives (as produced by
+    PATCHRequestBodySchema.dump() when the change request was created) — e.g.
+    status as a plain string like "IN_EXECUTION", date_needed as an ISO string
+    like "2043-02-02". The real approval path (ChangeRequestService._apply_budget_line_item_changes)
+    converts these back to real types via schema.load() before setattr; this
+    reproduces just that conversion for the fields that need it.
+    """
+    coerced = dict(data)
+    if "status" in coerced and coerced["status"] is not None:
+        coerced["status"] = BudgetLineItemStatus(coerced["status"])
+    if "date_needed" in coerced and coerced["date_needed"] is not None:
+        coerced["date_needed"] = date.fromisoformat(coerced["date_needed"])
+
+    mapped_columns = {c_attr.key for c_attr in inspect(target).mapper.column_attrs}
+    for key, value in coerced.items():
+        if key in mapped_columns:
+            setattr(target, key, value)
+
+
+def build_reviewer_notes(operator_note: str | None) -> str:
+    if operator_note:
+        return f"{operator_note} {OUT_OF_BAND_MARKER}"
+    return OUT_OF_BAND_MARKER
+
+
+def build_change_request_history_dict(change_request: "ChangeRequest", requestor_user: "User") -> dict:
+    """Build the event_details['change_request'] dict shape that
+    models.agreement_history.create_change_request_history_event expects."""
+    return {
+        "id": change_request.id,
+        "requested_change_data": change_request.requested_change_data,
+        "requested_change_diff": change_request.requested_change_diff,
+        "reviewed_by_id": change_request.reviewed_by_id,
+        "status": change_request.status.name,
+        "budget_line_item_id": getattr(change_request, "budget_line_item_id", None),
+        "agreement_id": change_request.agreement_id,
+        "created_by_user": {"full_name": requestor_user.full_name if requestor_user else "Unknown User"},
+    }
+
+
+def convert_bli_status_to_pretty_string(status_name: str | None) -> str:
+    """Local, trimmed copy of ops_api's convert_BLI_status_name_to_pretty_string."""
+    try:
+        return BudgetLineItemStatus(status_name).__str__() if status_name else BudgetLineItemStatus.DRAFT.__str__()
+    except ValueError:
+        return BudgetLineItemStatus.DRAFT.__str__()
+
+
+def build_review_outcome_notification(change_request: "ChangeRequest") -> tuple[str | None, str | None]:
+    """Ported, trimmed version of ops_api's build_review_outcome_title_and_message —
+    only the APPROVED branches are needed here since this script never rejects."""
+    if change_request.change_request_type == ChangeRequestType.AGREEMENT_CHANGE_REQUEST:
+        return "Procurement Shop Change Approved", "Your procurement shop change request has been approved."
+
+    # BUDGET_LINE_ITEM_CHANGE_REQUEST
+    if "status" in change_request.requested_change_data:
+        status_diff = change_request.requested_change_diff["status"]
+        new_status = convert_bli_status_to_pretty_string(status_diff["new"])
+        old_status = convert_bli_status_to_pretty_string(status_diff["old"])
+        return (
+            f"Budget Lines Approved from {old_status} to {new_status} Status",
+            f"The status change you submitted was approved: {old_status} → {new_status}.",
+        )
+    if (
+        "amount" in change_request.requested_change_data
+        or "can_id" in change_request.requested_change_data
+        or "date_needed" in change_request.requested_change_data
+    ):
+        return "Budget Change Request APPROVED", "Your budget change request has been approved."
+    return None, None
+
+
+def _collect_agreement_division_director_ids(agreement: "Agreement") -> tuple[set[int], set[int]]:
+    """Walk agreement.budget_line_items -> can -> portfolio -> division to collect the
+    set of division director/deputy ids with authority over this agreement."""
+    director_ids: set[int] = set()
+    deputy_ids: set[int] = set()
+    for bli in agreement.budget_line_items:
+        if bli.can and bli.can.portfolio and bli.can.portfolio.division:
+            division = bli.can.portfolio.division
+            if division.division_director_id:
+                director_ids.add(division.division_director_id)
+            if division.deputy_division_director_id:
+                deputy_ids.add(division.deputy_division_director_id)
+    return director_ids, deputy_ids
+
+
+def warn_if_not_division_director(session: Session, change_request: "ChangeRequest", approving_user: "User") -> None:
+    """Log a warning (never raises, never blocks) if approving_user is not the actual
+    division director/deputy for this change request. Ported, warn-only version of
+    ChangeRequestService._is_division_director_of_change_request."""
+    if change_request.change_request_type == ChangeRequestType.AGREEMENT_CHANGE_REQUEST:
+        agreement = session.get(Agreement, change_request.agreement_id)
+        if agreement is None:
+            return
+        director_ids, deputy_ids = _collect_agreement_division_director_ids(agreement)
+        if approving_user.id not in director_ids and approving_user.id not in deputy_ids:
+            logger.warning(
+                f"Approving user {approving_user.email} (id={approving_user.id}) is not a division "
+                f"director/deputy for ChangeRequest {change_request.id}'s agreement — proceeding anyway "
+                "(out-of-band approval)."
+            )
+        return
+
+    # BudgetLineItemChangeRequest (also covers status/budget field changes)
+    division_id = change_request.managing_division_id
+    if division_id is None:
+        return
+    division = session.get(Division, division_id)
+    if division is None:
+        return
+    if approving_user.id not in (division.division_director_id, division.deputy_division_director_id):
+        logger.warning(
+            f"Approving user {approving_user.email} (id={approving_user.id}) is not the division "
+            f"director/deputy for ChangeRequest {change_request.id}'s managing division "
+            f"({division_id}) — proceeding anyway (out-of-band approval)."
+        )
+
+
+def approve_change_request(
+    session: Session,
+    change_request_id: int,
+    approving_user: User,
+    sys_user: User,
+    reviewer_notes: str | None = None,
+) -> bool:
+    """Approve one ChangeRequest exactly as a real UI "Approve" click would.
+
+    Returns True if the change request was approved, False if it was skipped
+    (not found, already reviewed, an unsupported type, or its target
+    BudgetLineItem/Agreement no longer exists).
+    """
+    change_request = session.get(ChangeRequest, change_request_id)
+    if change_request is None:
+        logger.error(f"ChangeRequest {change_request_id} not found — skipping.")
+        return False
+
+    if change_request.status != ChangeRequestStatus.IN_REVIEW:
+        logger.error(
+            f"ChangeRequest {change_request_id} is not IN_REVIEW (current status: "
+            f"{change_request.status}) — skipping."
+        )
+        return False
+
+    if change_request.change_request_type not in (
+        ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+        ChangeRequestType.AGREEMENT_CHANGE_REQUEST,
+    ):
+        logger.error(
+            f"ChangeRequest {change_request_id} has an unsupported change_request_type "
+            f"({change_request.change_request_type}) — skipping."
+        )
+        return False
+
+    # Warn-only director check — always proceeds regardless of result.
+    warn_if_not_division_director(session, change_request, approving_user)
+
+    requestor = session.get(User, change_request.created_by)
+
+    change_request.reviewed_by_id = approving_user.id
+    change_request.reviewed_on = datetime.now()
+    change_request.reviewer_notes = build_reviewer_notes(reviewer_notes)
+    change_request.status = ChangeRequestStatus.APPROVED
+
+    if change_request.change_request_type == ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST:
+        target = session.get(BudgetLineItem, change_request.budget_line_item_id)
+        if target is None:
+            logger.error(
+                f"BudgetLineItem {change_request.budget_line_item_id} not found for "
+                f"ChangeRequest {change_request_id} — skipping."
+            )
+            return False
+        apply_change_request_data(target, change_request.requested_change_data)
+    else:  # AGREEMENT_CHANGE_REQUEST
+        target = session.get(Agreement, change_request.agreement_id)
+        if target is None:
+            logger.error(
+                f"Agreement {change_request.agreement_id} not found for ChangeRequest "
+                f"{change_request_id} — skipping."
+            )
+            return False
+        apply_change_request_data(target, change_request.requested_change_data)
+
+    session.flush()
+
+    change_request_dict = build_change_request_history_dict(change_request, requestor)
+    ops_event = OpsEvent(
+        event_type=OpsEventType.UPDATE_CHANGE_REQUEST,
+        event_status=OpsEventStatus.SUCCESS,
+        created_by=approving_user.id,
+        event_details={"change_request": change_request_dict},
+    )
+    session.add(ops_event)
+    session.flush()
+    agreement_history_trigger_func(ops_event, session, sys_user, dry_run=True)
+
+    title, message = build_review_outcome_notification(change_request)
+    if title and message:
+        session.add(
+            ChangeRequestNotification(
+                change_request_id=change_request.id,
+                title=title,
+                message=message,
+                is_read=False,
+                recipient_id=change_request.created_by,
+                notification_type=NotificationType.CHANGE_REQUEST_NOTIFICATION,
+            )
+        )
+
+    if (
+        change_request.change_request_type == ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST
+        and change_request.requested_change_data.get("status") == BudgetLineItemStatus.IN_EXECUTION.value
+    ):
+        agreement = session.get(Agreement, change_request.agreement_id)
+        if agreement is not None and not agreement.is_awarded:
+            action, _tracker, _, _ = get_or_create_procurement_records_for_new_award(
+                session, agreement, created_by=approving_user.id, source="ApproveChangeRequest"
+            )
+            link_blis_to_action(session, agreement, action, BudgetLineItemStatus.IN_EXECUTION)
+
+    return True
+
+
+@click.command()
+@click.option("--env", required=True, help="The environment to use (dev, local, azure).")
+@click.option("--approving-user-email", required=True, help="Email of the user authorizing this out-of-band approval.")
+@click.option(
+    "--change-request-id",
+    "change_request_ids",
+    multiple=True,
+    type=int,
+    help="ChangeRequest id to approve. Repeatable.",
+)
+@click.option("--reviewer-notes", default=None, help="Optional note to prepend to reviewer_notes.")
+def main(env: str, approving_user_email: str, change_request_ids: tuple[int, ...], reviewer_notes: str | None):
+    """Approve one or more ChangeRequests out-of-band, on behalf of the assigned reviewer."""
+    if not change_request_ids:
+        logger.error("At least one --change-request-id is required.")
+        sys.exit(1)
+
+    script_config = get_config(env)
+    db_engine, _ = init_db_from_config(script_config)
+
+    if db_engine is None:
+        logger.error("Failed to initialize the database engine.")
+        sys.exit(1)
+
+    with db_engine.connect() as conn:
+        conn.execute(text("SELECT 1"))
+        logger.info("Successfully connected to the database.")
+
+    session_factory = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=db_engine))
+
+    with session_factory() as session:
+        sys_user = get_or_create_sys_user(session)
+        setup_triggers(session, sys_user)
+
+        approving_user = session.execute(
+            select(User).where(func.lower(User.email) == approving_user_email.lower())
+        ).scalar_one_or_none()
+        if approving_user is None:
+            logger.error(f"No user found with email {approving_user_email!r}. Aborting.")
+            sys.exit(1)
+
+        approved_count = 0
+        skipped_count = 0
+        for cr_id in change_request_ids:
+            try:
+                if approve_change_request(session, cr_id, approving_user, sys_user, reviewer_notes):
+                    commit_or_rollback(session)
+                    approved_count += 1
+                    logger.info(f"Approved ChangeRequest {cr_id}.")
+                else:
+                    session.rollback()
+                    skipped_count += 1
+            except Exception:
+                logger.exception(f"Error approving ChangeRequest {cr_id}.")
+                session.rollback()
+                skipped_count += 1
+
+    verb = "Would approve" if os.getenv("DRY_RUN") else "Approved"
+    logger.info(f"{verb} {approved_count} change request(s). Skipped {skipped_count}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/data_tools/src/approve_change_requests.py
+++ b/backend/data_tools/src/approve_change_requests.py
@@ -242,6 +242,7 @@ def approve_change_request(
                 f"ChangeRequest {change_request_id} — skipping."
             )
             return False
+        target.acting_change_request_id = change_request.id
         apply_change_request_data(target, change_request.requested_change_data)
     else:  # AGREEMENT_CHANGE_REQUEST
         target = session.get(Agreement, change_request.agreement_id)
@@ -251,6 +252,7 @@ def approve_change_request(
                 f"{change_request_id} — skipping."
             )
             return False
+        target.acting_change_request_id = change_request.id
         apply_change_request_data(target, change_request.requested_change_data)
 
     session.flush()

--- a/backend/data_tools/tests/approve_change_requests/test_approve_change_requests.py
+++ b/backend/data_tools/tests/approve_change_requests/test_approve_change_requests.py
@@ -1,0 +1,816 @@
+from datetime import datetime
+
+import pytest
+from click.testing import CliRunner
+from loguru import logger
+from sqlalchemy import func, select, text
+
+from data_tools.src.approve_change_requests import approve_change_request, main, warn_if_not_division_director
+from data_tools.src.common.utils import commit_or_rollback, get_or_create_sys_user
+from models import *  # noqa: F403, F401
+from models.change_requests import ChangeRequestStatus, ChangeRequestType
+
+
+@pytest.fixture()
+def db_with_change_requests(loaded_db):
+    """Set up a Division/Portfolio/CAN/Agreement/BLI plus three ChangeRequest shapes
+    (status-change, budget-change, procurement-shop-change) for out-of-band approval tests.
+    """
+    sys_user = get_or_create_sys_user(loaded_db)
+    loaded_db.add(sys_user)
+    loaded_db.commit()
+    uid = sys_user.id
+
+    # ---- Users ----
+    # Director of the managing division — NOT the approving user in tests, so tests
+    # can verify the warn-only behavior when the approving user isn't the director.
+    director = User(id=90001, email="oob.director@example.com", first_name="Dana", last_name="Director")
+    # Requestor — created_by on the change requests below.
+    requestor = User(id=90002, email="oob.requestor@example.com", first_name="Remy", last_name="Requestor")
+    # Approving user passed into approve_change_request in tests — distinct from the director.
+    approving_user = User(id=90003, email="oob.approver@example.com", first_name="Ana", last_name="Approver")
+    loaded_db.add_all([director, requestor, approving_user])
+    loaded_db.commit()
+
+    # ---- Division / Portfolio / CAN ----
+    division = Division(
+        id=9100,
+        name="OOB Test Division",
+        abbreviation="OOBTD",
+        division_director_id=director.id,
+        created_by=uid,
+    )
+    loaded_db.add(division)
+    loaded_db.commit()
+
+    portfolio = Portfolio(
+        id=9100,
+        name="OOB Test Portfolio",
+        abbreviation="OOBTP",
+        division_id=division.id,
+        created_by=uid,
+    )
+    loaded_db.add(portfolio)
+    loaded_db.commit()
+
+    can = CAN(
+        id=9100,
+        number="OOBTEST001",
+        portfolio_id=portfolio.id,
+        created_by=uid,
+    )
+    loaded_db.add(can)
+    loaded_db.commit()
+
+    # ---- Procurement shops: a "first" shop (unused by the agreement, present just so a
+    # second, distinct shop id is available) and the "new" shop the change request targets.
+    # The agreement's awarding_entity_id starts as None to match this fixture's
+    # requested_change_diff old value below (old=None, new=<proc_shop_new.id>).
+    proc_shop_old = ProcurementShop(id=9100, name="OOB Test PSC Old", abbr="OOBOLD", created_by=uid)
+    proc_shop_new = ProcurementShop(id=9101, name="OOB Test PSC New", abbr="OOBNEW", created_by=uid)
+    loaded_db.add_all([proc_shop_old, proc_shop_new])
+    loaded_db.commit()
+
+    # ---- Project / Agreement / BLI ----
+    project = ResearchProject(id=9100, title="OOB Approval Test Project", short_title="OOBP")
+    loaded_db.add(project)
+    loaded_db.commit()
+
+    agreement = ContractAgreement(
+        id=9101,
+        name="OOB Approval Test Contract",
+        project_id=project.id,
+        awarding_entity_id=None,
+        created_by=uid,
+        updated_by=uid,
+    )
+    loaded_db.add(agreement)
+    loaded_db.commit()
+
+    bli = ContractBudgetLineItem(
+        id=91001,
+        agreement_id=agreement.id,
+        can_id=can.id,
+        amount=1000,
+        status=BudgetLineItemStatus.PLANNED,
+        created_by=uid,
+    )
+    loaded_db.add(bli)
+    loaded_db.commit()
+
+    # ---- Change requests: one per shape ----
+    # 1. BLI status-change CR
+    cr_status = BudgetLineItemChangeRequest(
+        id=91101,
+        change_request_type=ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+        status=ChangeRequestStatus.IN_REVIEW,
+        agreement_id=agreement.id,
+        budget_line_item_id=bli.id,
+        managing_division_id=division.id,
+        created_by=requestor.id,
+        requested_change_data={"status": "IN_EXECUTION"},
+        requested_change_diff={"status": {"old": "PLANNED", "new": "IN_EXECUTION"}},
+    )
+    # 2. BLI budget (amount)-change CR
+    cr_amount = BudgetLineItemChangeRequest(
+        id=91102,
+        change_request_type=ChangeRequestType.BUDGET_LINE_ITEM_CHANGE_REQUEST,
+        status=ChangeRequestStatus.IN_REVIEW,
+        agreement_id=agreement.id,
+        budget_line_item_id=bli.id,
+        managing_division_id=division.id,
+        created_by=requestor.id,
+        requested_change_data={"amount": 5000.0},
+        requested_change_diff={"amount": {"old": 1000.0, "new": 5000.0}},
+    )
+    # 3. Agreement procurement-shop-change CR
+    cr_proc_shop = AgreementChangeRequest(
+        id=91103,
+        change_request_type=ChangeRequestType.AGREEMENT_CHANGE_REQUEST,
+        status=ChangeRequestStatus.IN_REVIEW,
+        agreement_id=agreement.id,
+        managing_division_id=division.id,
+        created_by=requestor.id,
+        requested_change_data={"awarding_entity_id": proc_shop_new.id},
+        requested_change_diff={"awarding_entity_id": {"old": None, "new": proc_shop_new.id}},
+    )
+    loaded_db.add_all([cr_status, cr_amount, cr_proc_shop])
+    loaded_db.commit()
+
+    yield loaded_db
+
+    # Redundant with loaded_db's savepoint rollback today, but kept because Task 6+ may
+    # exercise the real CLI's own session/engine outside this savepoint — revisit if that
+    # never ends up happening.
+    loaded_db.rollback()
+    loaded_db.execute(text("DELETE FROM notification"))
+    loaded_db.execute(text("DELETE FROM notification_version"))
+    loaded_db.execute(text("DELETE FROM change_request"))
+    loaded_db.execute(text("DELETE FROM change_request_version"))
+    loaded_db.execute(text("DELETE FROM ops_event"))
+    loaded_db.execute(text("DELETE FROM ops_event_version"))
+    loaded_db.execute(text("DELETE FROM procurement_tracker_step"))
+    loaded_db.execute(text("DELETE FROM procurement_tracker_step_version"))
+    loaded_db.execute(text("DELETE FROM default_procurement_tracker"))
+    loaded_db.execute(text("DELETE FROM default_procurement_tracker_version"))
+    loaded_db.execute(text("DELETE FROM procurement_tracker"))
+    loaded_db.execute(text("DELETE FROM procurement_tracker_version"))
+    loaded_db.execute(text("DELETE FROM grant_budget_line_item"))
+    loaded_db.execute(text("DELETE FROM grant_budget_line_item_version"))
+    loaded_db.execute(text("DELETE FROM contract_budget_line_item"))
+    loaded_db.execute(text("DELETE FROM contract_budget_line_item_version"))
+    loaded_db.execute(text("DELETE FROM budget_line_item"))
+    loaded_db.execute(text("DELETE FROM budget_line_item_version"))
+    loaded_db.execute(text("DELETE FROM procurement_action"))
+    loaded_db.execute(text("DELETE FROM procurement_action_version"))
+    loaded_db.execute(text("DELETE FROM agreement_history"))
+    loaded_db.execute(text("DELETE FROM agreement_history_version"))
+    loaded_db.execute(text("DELETE FROM grant_agreement"))
+    loaded_db.execute(text("DELETE FROM grant_agreement_version"))
+    loaded_db.execute(text("DELETE FROM contract_agreement"))
+    loaded_db.execute(text("DELETE FROM contract_agreement_version"))
+    loaded_db.execute(text("DELETE FROM agreement"))
+    loaded_db.execute(text("DELETE FROM agreement_version"))
+    loaded_db.execute(text("DELETE FROM research_project"))
+    loaded_db.execute(text("DELETE FROM research_project_version"))
+    loaded_db.execute(text("DELETE FROM project"))
+    loaded_db.execute(text("DELETE FROM project_version"))
+    loaded_db.execute(text("DELETE FROM procurement_shop_fee"))
+    loaded_db.execute(text("DELETE FROM procurement_shop_fee_version"))
+    loaded_db.execute(text("DELETE FROM procurement_shop"))
+    loaded_db.execute(text("DELETE FROM procurement_shop_version"))
+    loaded_db.execute(text("DELETE FROM can"))
+    loaded_db.execute(text("DELETE FROM can_version"))
+    loaded_db.execute(text("DELETE FROM portfolio"))
+    loaded_db.execute(text("DELETE FROM portfolio_version"))
+    loaded_db.execute(text("DELETE FROM division"))
+    loaded_db.execute(text("DELETE FROM division_version"))
+    loaded_db.execute(
+        text("DELETE FROM ops_user_version WHERE id IN (:director_id, :requestor_id, :approving_user_id)"),
+        {
+            "director_id": director.id,
+            "requestor_id": requestor.id,
+            "approving_user_id": approving_user.id,
+        },
+    )
+    loaded_db.execute(
+        text("DELETE FROM ops_user WHERE id IN (:director_id, :requestor_id, :approving_user_id)"),
+        {
+            "director_id": director.id,
+            "requestor_id": requestor.id,
+            "approving_user_id": approving_user.id,
+        },
+    )
+    loaded_db.execute(text("DELETE FROM ops_db_history"))
+    loaded_db.execute(text("DELETE FROM ops_db_history_version"))
+    loaded_db.commit()
+
+
+def test_fixture_loads(db_with_change_requests):
+    # Guards against the sys user's id resolving to None (get_or_create_sys_user returns a
+    # transient object when no sys user exists yet; it must be session.add()-ed before
+    # commit for the id to populate) — a regression here would silently null out
+    # created_by/updated_by on every infra row the fixture builds.
+    division = db_with_change_requests.get(Division, 9100)
+    assert division.created_by is not None
+
+
+@pytest.fixture()
+def captured_log_messages():
+    """Loguru's own sink-capture pattern (there is no caplog<->loguru bridge configured
+    in this codebase): add a temporary sink that appends formatted records to a list,
+    yield the list, then remove the temporary sink in teardown so it can't leak into
+    other tests even if an assertion in the test body fails.
+    """
+    messages: list[str] = []
+    handler_id = logger.add(lambda message: messages.append(message.record["message"]), level="WARNING")
+    try:
+        yield messages
+    finally:
+        logger.remove(handler_id)
+
+
+def test_warn_if_not_division_director_bli_change_request_director_no_warning(
+    db_with_change_requests, captured_log_messages
+):
+    """The actual division director approving a BLI ChangeRequest should never trigger
+    a warning — the fixture's Division(id=9100).division_director_id is director.id."""
+    session = db_with_change_requests
+    director = session.get(User, 90001)
+    change_request = session.get(ChangeRequest, 91101)  # BLI status-change CR
+
+    warn_if_not_division_director(session, change_request, director)
+
+    assert captured_log_messages == []
+
+
+def test_warn_if_not_division_director_bli_change_request_non_director_warns(
+    db_with_change_requests, captured_log_messages
+):
+    """A non-director approving user should produce a warning (never raise, never
+    block) when approving a BudgetLineItemChangeRequest."""
+    session = db_with_change_requests
+    approving_user = session.get(User, 90003)
+    change_request = session.get(ChangeRequest, 91101)  # BLI status-change CR
+
+    # Calling this must not raise — if it did, the test would error out here, which is
+    # itself sufficient proof the function "never blocks".
+    warn_if_not_division_director(session, change_request, approving_user)
+
+    assert len(captured_log_messages) == 1
+    assert "not the division director" in captured_log_messages[0]
+    assert "ChangeRequest 91101" in captured_log_messages[0]
+
+
+def test_warn_if_not_division_director_agreement_change_request_director_no_warning(
+    db_with_change_requests, captured_log_messages
+):
+    """AgreementChangeRequest branch: walks agreement.budget_line_items -> can ->
+    portfolio -> division to collect director/deputy ids. The fixture's single BLI
+    (id=91001) is linked to CAN(id=9100) -> Portfolio(id=9100) -> Division(id=9100),
+    whose director is `director`, so no warning should be logged."""
+    session = db_with_change_requests
+    director = session.get(User, 90001)
+    change_request = session.get(ChangeRequest, 91103)  # AgreementChangeRequest (procurement shop)
+
+    warn_if_not_division_director(session, change_request, director)
+
+    assert captured_log_messages == []
+
+
+def test_warn_if_not_division_director_agreement_change_request_non_director_warns(
+    db_with_change_requests, captured_log_messages
+):
+    """AgreementChangeRequest branch with a non-director/non-deputy approving user
+    should warn, and must not raise."""
+    session = db_with_change_requests
+    approving_user = session.get(User, 90003)
+    change_request = session.get(ChangeRequest, 91103)  # AgreementChangeRequest (procurement shop)
+
+    warn_if_not_division_director(session, change_request, approving_user)
+
+    assert len(captured_log_messages) == 1
+    assert "not a division director" in captured_log_messages[0]
+    assert "ChangeRequest 91103" in captured_log_messages[0]
+
+
+def test_warn_if_not_division_director_agreement_change_request_missing_agreement_no_warning(
+    db_with_change_requests, captured_log_messages
+):
+    """Edge case: an AgreementChangeRequest whose agreement_id points at a non-existent
+    Agreement should just return silently (no warning, no crash) per the function's
+    early-return branch."""
+    session = db_with_change_requests
+    approving_user = session.get(User, 90003)
+    change_request = session.get(ChangeRequest, 91103)
+    change_request.agreement_id = 999999  # no such Agreement
+
+    warn_if_not_division_director(session, change_request, approving_user)
+
+    assert captured_log_messages == []
+
+
+def test_warn_if_not_division_director_bli_change_request_missing_managing_division_no_warning(
+    db_with_change_requests, captured_log_messages
+):
+    """Edge case: a BudgetLineItemChangeRequest with managing_division_id=None should
+    just return silently (no warning, no crash) per the function's early-return branch."""
+    session = db_with_change_requests
+    approving_user = session.get(User, 90003)
+    change_request = session.get(ChangeRequest, 91101)
+    change_request.managing_division_id = None
+
+    warn_if_not_division_director(session, change_request, approving_user)
+
+    assert captured_log_messages == []
+
+
+# Fixture ids, named for readability in the approve_change_request tests below.
+APPROVING_USER_ID = 90003
+REQUESTOR_USER_ID = 90002
+STATUS_CR_ID = 91101
+
+
+def test_approve_status_change_request_applies_change_and_creates_history(db_with_change_requests):
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    result = approve_change_request(session, STATUS_CR_ID, approving_user, sys_user)
+    session.commit()
+
+    assert result is True
+    cr = session.get(ChangeRequest, STATUS_CR_ID)
+    assert cr.status == ChangeRequestStatus.APPROVED
+    assert cr.reviewed_by_id == approving_user.id
+    assert cr.reviewed_on is not None
+    assert "[Approved via out-of-band script" in cr.reviewer_notes
+
+    bli = session.get(BudgetLineItem, 91001)
+    assert bli.status == BudgetLineItemStatus.IN_EXECUTION
+
+    history = (
+        session.execute(select(AgreementHistory).where(AgreementHistory.agreement_id_record == 9101)).scalars().all()
+    )
+    assert len(history) == 1
+    assert approving_user.full_name in history[0].history_message
+
+    notif = session.execute(
+        select(ChangeRequestNotification).where(ChangeRequestNotification.change_request_id == STATUS_CR_ID)
+    ).scalar_one()
+    assert notif.recipient_id == REQUESTOR_USER_ID
+
+
+AMOUNT_CR_ID = 91102
+PROC_SHOP_CR_ID = 91103
+AGREEMENT_ID = 9101
+BLI_ID = 91001
+
+
+def test_approve_status_change_request_creates_procurement_tracker_and_action(db_with_change_requests):
+    """Approving the status-change CR (new status IN_EXECUTION) on an agreement that is
+    not yet awarded and has no existing procurement tracker/action should create a
+    DefaultProcurementTracker + ProcurementAction (NEW_AWARD) for the agreement, and link
+    the BLI to that new action."""
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    agreement = session.get(Agreement, AGREEMENT_ID)
+    assert agreement.is_awarded is False
+
+    result = approve_change_request(session, STATUS_CR_ID, approving_user, sys_user)
+    session.commit()
+
+    assert result is True
+
+    tracker = session.execute(
+        select(DefaultProcurementTracker).where(DefaultProcurementTracker.agreement_id == AGREEMENT_ID)
+    ).scalar_one_or_none()
+    assert tracker is not None
+
+    action = session.execute(
+        select(ProcurementAction).where(ProcurementAction.agreement_id == AGREEMENT_ID)
+    ).scalar_one_or_none()
+    assert action is not None
+    assert action.award_type == AwardType.NEW_AWARD
+
+    bli = session.get(BudgetLineItem, BLI_ID)
+    assert bli.procurement_action_id == action.id
+
+
+def test_approve_amount_change_request_does_not_create_procurement_tracker_or_action(db_with_change_requests):
+    """The budget-field-change CR (amount only, no status key) must NOT trigger the
+    procurement tracker/action side effect."""
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    result = approve_change_request(session, AMOUNT_CR_ID, approving_user, sys_user)
+    session.commit()
+
+    assert result is True
+
+    tracker = session.execute(
+        select(DefaultProcurementTracker).where(DefaultProcurementTracker.agreement_id == AGREEMENT_ID)
+    ).scalar_one_or_none()
+    assert tracker is None
+
+    action = session.execute(
+        select(ProcurementAction).where(ProcurementAction.agreement_id == AGREEMENT_ID)
+    ).scalar_one_or_none()
+    assert action is None
+
+    bli = session.get(BudgetLineItem, BLI_ID)
+    assert bli.procurement_action_id is None
+
+
+def test_approve_amount_change_request_applies_change_and_creates_history(db_with_change_requests):
+    """The budget-field-change CR (amount only) should apply the new amount to the BLI,
+    create exactly one AgreementHistory row with the amount-change wording, and create
+    exactly one notification addressed to the requestor."""
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    result = approve_change_request(session, AMOUNT_CR_ID, approving_user, sys_user)
+    session.commit()
+
+    assert result is True
+
+    bli = session.get(BudgetLineItem, BLI_ID)
+    assert bli.amount == 5000.0
+
+    history = (
+        session.execute(select(AgreementHistory).where(AgreementHistory.agreement_id_record == AGREEMENT_ID))
+        .scalars()
+        .all()
+    )
+    assert len(history) == 1
+    assert history[0].history_title == "Budget Change to Amount Approved"
+    assert history[0].history_message == (
+        "Ana Approver approved the budget change on BL 91001 from $1,000.00 to $5,000.00 as requested by "
+        "Remy Requestor."
+    )
+
+    notif = session.execute(
+        select(ChangeRequestNotification).where(ChangeRequestNotification.change_request_id == AMOUNT_CR_ID)
+    ).scalar_one()
+    assert notif.recipient_id == REQUESTOR_USER_ID
+    assert notif.title == "Budget Change Request APPROVED"
+    assert notif.message == "Your budget change request has been approved."
+
+
+def test_approve_procurement_shop_change_request_applies_change_and_creates_history(db_with_change_requests):
+    """The AgreementChangeRequest (procurement-shop-change) CR should apply the new
+    awarding_entity_id to the Agreement, create exactly one AgreementHistory row with
+    the procurement-shop-change wording, and create exactly one notification addressed
+    to the requestor."""
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    result = approve_change_request(session, PROC_SHOP_CR_ID, approving_user, sys_user)
+    session.commit()
+
+    assert result is True
+
+    agreement = session.get(Agreement, AGREEMENT_ID)
+    assert agreement.awarding_entity_id == 9101
+
+    history = (
+        session.execute(select(AgreementHistory).where(AgreementHistory.agreement_id_record == AGREEMENT_ID))
+        .scalars()
+        .all()
+    )
+    assert len(history) == 1
+    assert history[0].history_title == "Change to Procurement Shop Approved"
+    assert history[0].history_message == (
+        "Ana Approver approved the change on the Procurement Shop from TBD to OOBNEW as requested by "
+        "Remy Requestor. This changes the fee rate from 0% to 0% and the fee total from $0.00 to $0.00."
+    )
+
+    notif = session.execute(
+        select(ChangeRequestNotification).where(ChangeRequestNotification.change_request_id == PROC_SHOP_CR_ID)
+    ).scalar_one()
+    assert notif.recipient_id == REQUESTOR_USER_ID
+    assert notif.title == "Procurement Shop Change Approved"
+    assert notif.message == "Your procurement shop change request has been approved."
+
+
+def test_approve_procurement_shop_change_request_does_not_create_procurement_tracker_or_action(
+    db_with_change_requests,
+):
+    """The AgreementChangeRequest (procurement-shop-change) CR is not a BLI change
+    request at all, and must NOT trigger the procurement tracker/action side effect."""
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    result = approve_change_request(session, PROC_SHOP_CR_ID, approving_user, sys_user)
+    session.commit()
+
+    assert result is True
+
+    tracker = session.execute(
+        select(DefaultProcurementTracker).where(DefaultProcurementTracker.agreement_id == AGREEMENT_ID)
+    ).scalar_one_or_none()
+    assert tracker is None
+
+    action = session.execute(
+        select(ProcurementAction).where(ProcurementAction.agreement_id == AGREEMENT_ID)
+    ).scalar_one_or_none()
+    assert action is None
+
+    bli = session.get(BudgetLineItem, BLI_ID)
+    assert bli.procurement_action_id is None
+
+
+def test_approve_change_request_returns_false_for_missing_id(db_with_change_requests):
+    """Step 1 guard in approve_change_request: session.get(ChangeRequest, id) returning
+    None must short-circuit with no mutation and no side-effect rows — the guard logic
+    itself is already implemented (Task 6); this is new coverage for it."""
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    history_count_before = session.execute(select(func.count()).select_from(AgreementHistory)).scalar()
+    notif_count_before = session.execute(select(func.count()).select_from(ChangeRequestNotification)).scalar()
+
+    result = approve_change_request(session, 999999999, approving_user, sys_user)  # nonexistent id
+
+    assert result is False
+
+    history_count_after = session.execute(select(func.count()).select_from(AgreementHistory)).scalar()
+    notif_count_after = session.execute(select(func.count()).select_from(ChangeRequestNotification)).scalar()
+    assert history_count_after == history_count_before
+    assert notif_count_after == notif_count_before
+
+
+def test_approve_change_request_returns_false_for_missing_budget_line_item_target(db_with_change_requests, monkeypatch):
+    """Step 7 guard in approve_change_request: if a BudgetLineItemChangeRequest's
+    budget_line_item_id points at a BLI that no longer exists, the function must skip
+    (return False) rather than raise — this is the exact failure mode the CLI's
+    per-record error isolation relies on surviving without aborting the whole batch.
+
+    change_request.budget_line_item_id has an ondelete=CASCADE FK, so a real BLI
+    deletion would cascade-delete the ChangeRequest too — this scenario can't be
+    constructed via a live FK value. We monkeypatch Session.get to simulate the
+    target genuinely being gone by the time this function looks it up, which is the
+    condition the guard defends against."""
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    real_get = session.get
+
+    def fake_get(model, ident, *args, **kwargs):
+        if model is BudgetLineItem and ident == BLI_ID:
+            return None
+        return real_get(model, ident, *args, **kwargs)
+
+    monkeypatch.setattr(session, "get", fake_get)
+
+    history_count_before = session.execute(select(func.count()).select_from(AgreementHistory)).scalar()
+    notif_count_before = session.execute(select(func.count()).select_from(ChangeRequestNotification)).scalar()
+
+    result = approve_change_request(session, STATUS_CR_ID, approving_user, sys_user)
+
+    assert result is False
+
+    history_count_after = session.execute(select(func.count()).select_from(AgreementHistory)).scalar()
+    notif_count_after = session.execute(select(func.count()).select_from(ChangeRequestNotification)).scalar()
+    assert history_count_after == history_count_before
+    assert notif_count_after == notif_count_before
+
+
+def test_approve_change_request_returns_false_for_missing_agreement_target(db_with_change_requests, monkeypatch):
+    """Step 7 guard in approve_change_request: if an AgreementChangeRequest's
+    agreement_id points at an Agreement that no longer exists, the function must skip
+    (return False) rather than raise. Same CASCADE-FK caveat as the missing-BLI test
+    above — simulated via monkeypatching Session.get rather than a live FK value."""
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    real_get = session.get
+
+    def fake_get(model, ident, *args, **kwargs):
+        if model is Agreement and ident == AGREEMENT_ID:
+            return None
+        return real_get(model, ident, *args, **kwargs)
+
+    monkeypatch.setattr(session, "get", fake_get)
+
+    history_count_before = session.execute(select(func.count()).select_from(AgreementHistory)).scalar()
+    notif_count_before = session.execute(select(func.count()).select_from(ChangeRequestNotification)).scalar()
+
+    result = approve_change_request(session, PROC_SHOP_CR_ID, approving_user, sys_user)
+
+    assert result is False
+
+    history_count_after = session.execute(select(func.count()).select_from(AgreementHistory)).scalar()
+    notif_count_after = session.execute(select(func.count()).select_from(ChangeRequestNotification)).scalar()
+    assert history_count_after == history_count_before
+    assert notif_count_after == notif_count_before
+
+
+def test_approve_change_request_returns_false_for_unsupported_change_request_type(db_with_change_requests):
+    """Step 3 guard in approve_change_request: a base ChangeRequest (neither a
+    BudgetLineItemChangeRequest nor an AgreementChangeRequest) must be skipped."""
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    unsupported_cr = ChangeRequest(
+        id=91199,
+        change_request_type=ChangeRequestType.CHANGE_REQUEST,
+        status=ChangeRequestStatus.IN_REVIEW,
+        created_by=REQUESTOR_USER_ID,
+        requested_change_data={"note": "unsupported shape"},
+    )
+    session.add(unsupported_cr)
+    session.flush()
+
+    result = approve_change_request(session, 91199, approving_user, sys_user)
+
+    assert result is False
+
+    session.refresh(unsupported_cr)
+    assert unsupported_cr.status == ChangeRequestStatus.IN_REVIEW
+    assert unsupported_cr.reviewed_by_id is None
+
+
+def test_approve_change_request_skips_already_approved(db_with_change_requests):
+    """Step 2 guard in approve_change_request: a ChangeRequest whose status is not
+    IN_REVIEW must be skipped before any mutation happens — proven here by manually
+    approving the status-change CR with disposition values that are obviously distinct
+    from what a fresh approval by `approving_user` would produce, then confirming those
+    exact values (not just "some" values) survive the call untouched."""
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    cr = session.get(ChangeRequest, STATUS_CR_ID)
+    original_reviewed_by_id = 90001  # director.id — distinct from approving_user.id (90003)
+    original_reviewed_on = datetime(2020, 1, 1, 12, 0, 0)
+    original_reviewer_notes = "Pre-existing approval, not touched by this call."
+    cr.status = ChangeRequestStatus.APPROVED
+    cr.reviewed_by_id = original_reviewed_by_id
+    cr.reviewed_on = original_reviewed_on
+    cr.reviewer_notes = original_reviewer_notes
+    session.flush()
+
+    result = approve_change_request(session, STATUS_CR_ID, approving_user, sys_user)
+
+    assert result is False
+
+    session.refresh(cr)
+    assert cr.status == ChangeRequestStatus.APPROVED
+    assert cr.reviewed_by_id == original_reviewed_by_id
+    assert cr.reviewed_by_id != approving_user.id
+    assert cr.reviewed_on == original_reviewed_on
+    assert cr.reviewer_notes == original_reviewer_notes
+
+    # The underlying BLI must also be untouched — proves the guard fired before the
+    # BLI-mutation step, not just before the reviewed_by_id/reviewed_on writes.
+    bli = session.get(BudgetLineItem, BLI_ID)
+    assert bli.status == BudgetLineItemStatus.PLANNED
+
+
+def test_approve_change_request_respects_dry_run(db_with_change_requests, monkeypatch):
+    """DRY_RUN is not part of approve_change_request itself — it's commit_or_rollback's
+    job (data_tools.src.common.utils), already used by other scripts in this codebase
+    (e.g. backfill_procurement_tracker.py's main()). approve_change_request should still
+    report success (it only mutates in-memory/flushed state); commit_or_rollback is what
+    decides whether that mutation is persisted or rolled back."""
+    monkeypatch.setenv("DRY_RUN", "1")
+    session = db_with_change_requests
+    sys_user = get_or_create_sys_user(session)
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    result = approve_change_request(session, STATUS_CR_ID, approving_user, sys_user)
+    assert result is True
+
+    # Sanity check the mutation actually happened in-session before the rollback, so the
+    # rollback assertion below is proof of an undo, not proof that nothing ever changed.
+    bli_before_rollback = session.get(BudgetLineItem, BLI_ID)
+    assert bli_before_rollback.status == BudgetLineItemStatus.IN_EXECUTION
+
+    # agreement_history_trigger_func is called with a static dry_run=True inside
+    # approve_change_request regardless of the DRY_RUN env var — that only suppresses
+    # its own internal session.commit(), not the AgreementHistory row itself, which
+    # add_history_events() stages via session.add() unconditionally. So the staged
+    # history row must already be visible in-session here, before commit_or_rollback
+    # runs, confirming the rollback below actually has something to undo.
+    history_before_rollback = (
+        session.execute(select(AgreementHistory).where(AgreementHistory.agreement_id_record == AGREEMENT_ID))
+        .scalars()
+        .all()
+    )
+    assert len(history_before_rollback) == 1
+
+    commit_or_rollback(session)  # DRY_RUN=1 -> rolls back instead of committing
+
+    cr = session.get(ChangeRequest, STATUS_CR_ID)
+    assert cr.status == ChangeRequestStatus.IN_REVIEW
+    assert cr.reviewed_by_id is None
+    assert cr.reviewed_on is None
+
+    bli = session.get(BudgetLineItem, BLI_ID)
+    assert bli.status == BudgetLineItemStatus.PLANNED
+
+    # The staged AgreementHistory row must not survive the rollback either — it's part
+    # of the same unit of work as the CR/BLI mutations, discarded by the same
+    # session.rollback() call inside commit_or_rollback.
+    history_after_rollback = (
+        session.execute(select(AgreementHistory).where(AgreementHistory.agreement_id_record == AGREEMENT_ID))
+        .scalars()
+        .all()
+    )
+    assert len(history_after_rollback) == 0
+
+
+@pytest.fixture()
+def cli_ready_db(db_with_change_requests, db_service, monkeypatch):
+    """Patch approve_change_requests' own init_db_from_config/setup_triggers/scoped_session
+    references (mirroring conftest.py's loaded_db pattern, which only patches load_data's
+    names) so a CliRunner invocation of this module's main() reuses the fixture's
+    SAVEPOINT-wrapped session instead of opening a brand-new DB connection."""
+    session = db_with_change_requests
+    _, engine = db_service
+
+    monkeypatch.setattr(
+        "data_tools.src.approve_change_requests.init_db_from_config",
+        lambda config: (engine, None),
+    )
+    monkeypatch.setattr(
+        "data_tools.src.approve_change_requests.setup_triggers",
+        lambda session, sys_user: None,
+    )
+
+    class _CliSessionProxy:
+        """Stand-in for scoped_session that yields the test session to CLI code."""
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __call__(self):
+            return self
+
+        def __enter__(self):
+            return session
+
+        def __exit__(self, *args):
+            pass
+
+        def __getattr__(self, name):
+            return getattr(session, name)
+
+    monkeypatch.setattr("data_tools.src.approve_change_requests.scoped_session", _CliSessionProxy)
+
+    return session
+
+
+def test_main_approves_and_skips_in_one_mixed_batch(cli_ready_db):
+    """Task 10.6 dispatch-loop coverage: a single invocation of main() with one valid,
+    approvable ChangeRequest id and one nonexistent id must approve the former, skip the
+    latter, log the right summary counts, and exit 0 without letting the nonexistent id's
+    False return (or any exception) propagate or abort the batch.
+
+    The summary is asserted via a temporary loguru sink (INFO level — captured_log_messages
+    is scoped to WARNING+ for the director-check tests above and would swallow this INFO
+    line) rather than result.output/result.stderr: the module's logger.add(sys.stderr, ...)
+    sink is bound at import time, before CliRunner.invoke() swaps sys.stderr, so Click's
+    output capture never sees it."""
+    session = cli_ready_db
+    approving_user = session.get(User, APPROVING_USER_ID)
+
+    info_messages: list[str] = []
+    handler_id = logger.add(lambda message: info_messages.append(message.record["message"]), level="INFO")
+    try:
+        result = CliRunner().invoke(
+            main,
+            [
+                "--env",
+                "pytest_data_tools",
+                "--approving-user-email",
+                approving_user.email,
+                "--change-request-id",
+                str(STATUS_CR_ID),
+                "--change-request-id",
+                "999999999",  # nonexistent — approve_change_request returns False
+            ],
+        )
+    finally:
+        logger.remove(handler_id)
+
+    assert result.exit_code == 0, result.output
+    assert any("Approved 1 change request(s). Skipped 1." in message for message in info_messages)
+
+    cr = session.get(ChangeRequest, STATUS_CR_ID)
+    assert cr.status == ChangeRequestStatus.APPROVED
+    assert cr.reviewed_by_id == approving_user.id
+
+    bli = session.get(BudgetLineItem, BLI_ID)
+    assert bli.status == BudgetLineItemStatus.IN_EXECUTION

--- a/backend/data_tools/tests/approve_change_requests/test_helpers.py
+++ b/backend/data_tools/tests/approve_change_requests/test_helpers.py
@@ -1,0 +1,270 @@
+def test_apply_change_request_data_sets_mapped_columns(loaded_db):
+    from data_tools.src.approve_change_requests import apply_change_request_data
+    from models import BudgetLineItemStatus, ContractBudgetLineItem
+
+    bli = ContractBudgetLineItem(amount=100, status=BudgetLineItemStatus.PLANNED)
+    apply_change_request_data(bli, {"amount": 500.0, "not_a_real_column": "ignored"})
+    assert bli.amount == 500.0
+    assert not hasattr(bli, "not_a_real_column") or getattr(bli, "not_a_real_column", None) != "ignored"
+
+
+def test_apply_change_request_data_coerces_status_string_to_enum(loaded_db):
+    from data_tools.src.approve_change_requests import apply_change_request_data
+    from models import BudgetLineItemStatus, ContractBudgetLineItem
+
+    bli = ContractBudgetLineItem(status=BudgetLineItemStatus.PLANNED)
+    apply_change_request_data(bli, {"status": "IN_EXECUTION"})
+    assert bli.status == BudgetLineItemStatus.IN_EXECUTION
+    assert isinstance(bli.status, BudgetLineItemStatus)
+
+
+def test_apply_change_request_data_coerces_date_needed_string_to_date(loaded_db):
+    import datetime
+
+    from data_tools.src.approve_change_requests import apply_change_request_data
+    from models import ContractBudgetLineItem
+
+    bli = ContractBudgetLineItem()
+    apply_change_request_data(bli, {"date_needed": "2043-02-02"})
+    assert bli.date_needed == datetime.date(2043, 2, 2)
+    assert isinstance(bli.date_needed, datetime.date)
+
+
+# ---------------------------------------------------------------------------
+# build_reviewer_notes
+# ---------------------------------------------------------------------------
+
+
+def test_build_reviewer_notes_with_operator_note():
+    from data_tools.src.approve_change_requests import build_reviewer_notes
+
+    assert (
+        build_reviewer_notes("Confirmed with COR via email")
+        == "Confirmed with COR via email [Approved via out-of-band script on behalf of assigned reviewer]"
+    )
+
+
+def test_build_reviewer_notes_with_none():
+    from data_tools.src.approve_change_requests import OUT_OF_BAND_MARKER, build_reviewer_notes
+
+    assert build_reviewer_notes(None) == OUT_OF_BAND_MARKER
+
+
+def test_build_reviewer_notes_with_empty_string():
+    from data_tools.src.approve_change_requests import OUT_OF_BAND_MARKER, build_reviewer_notes
+
+    assert build_reviewer_notes("") == OUT_OF_BAND_MARKER
+
+
+# ---------------------------------------------------------------------------
+# build_change_request_history_dict
+# ---------------------------------------------------------------------------
+
+
+def test_build_change_request_history_dict_budget_line_item_change_request(loaded_db):
+    from data_tools.src.approve_change_requests import build_change_request_history_dict
+    from models import BudgetLineItemChangeRequest, ChangeRequestStatus, User
+
+    requestor_user = User(first_name="Remy", last_name="Requestor", email="remy.requestor@example.com")
+    loaded_db.add(requestor_user)
+    loaded_db.flush()
+
+    change_request = BudgetLineItemChangeRequest(
+        id=1,
+        requested_change_data={"status": "IN_EXECUTION"},
+        requested_change_diff={"status": {"old": "PLANNED", "new": "IN_EXECUTION"}},
+        reviewed_by_id=42,
+        status=ChangeRequestStatus.APPROVED,
+        budget_line_item_id=91001,
+        agreement_id=9101,
+    )
+
+    result = build_change_request_history_dict(change_request, requestor_user)
+
+    assert set(result.keys()) == {
+        "id",
+        "requested_change_data",
+        "requested_change_diff",
+        "reviewed_by_id",
+        "status",
+        "budget_line_item_id",
+        "agreement_id",
+        "created_by_user",
+    }
+    assert result["id"] == 1
+    assert result["requested_change_data"] == {"status": "IN_EXECUTION"}
+    assert result["requested_change_diff"] == {"status": {"old": "PLANNED", "new": "IN_EXECUTION"}}
+    assert result["reviewed_by_id"] == 42
+    assert result["status"] == "APPROVED"
+    assert result["budget_line_item_id"] == 91001
+    assert result["agreement_id"] == 9101
+    assert result["created_by_user"] == {"full_name": "Remy Requestor"}
+
+
+def test_build_change_request_history_dict_agreement_change_request_has_no_bli_id():
+    from data_tools.src.approve_change_requests import build_change_request_history_dict
+    from models import AgreementChangeRequest, ChangeRequestStatus, User
+
+    requestor_user = User(first_name="Remy", last_name="Requestor")
+    change_request = AgreementChangeRequest(
+        id=2,
+        requested_change_data={"awarding_entity_id": 5},
+        requested_change_diff={"awarding_entity_id": {"old": 1, "new": 5}},
+        reviewed_by_id=42,
+        status=ChangeRequestStatus.APPROVED,
+        agreement_id=9101,
+    )
+
+    assert not hasattr(change_request, "budget_line_item_id")
+
+    result = build_change_request_history_dict(change_request, requestor_user)
+
+    assert result["budget_line_item_id"] is None
+    assert result["agreement_id"] == 9101
+
+
+def test_build_change_request_history_dict_no_requestor_user():
+    from data_tools.src.approve_change_requests import build_change_request_history_dict
+    from models import AgreementChangeRequest, ChangeRequestStatus
+
+    change_request = AgreementChangeRequest(
+        id=3,
+        requested_change_data={"awarding_entity_id": 5},
+        requested_change_diff={"awarding_entity_id": {"old": 1, "new": 5}},
+        reviewed_by_id=42,
+        status=ChangeRequestStatus.APPROVED,
+        agreement_id=9101,
+    )
+
+    result = build_change_request_history_dict(change_request, None)
+
+    assert result["created_by_user"] == {"full_name": "Unknown User"}
+
+
+# ---------------------------------------------------------------------------
+# convert_bli_status_to_pretty_string
+# ---------------------------------------------------------------------------
+
+
+def test_convert_bli_status_to_pretty_string_valid_status():
+    from data_tools.src.approve_change_requests import convert_bli_status_to_pretty_string
+
+    assert convert_bli_status_to_pretty_string("IN_EXECUTION") == "IN_EXECUTION"
+
+
+def test_convert_bli_status_to_pretty_string_none_falls_back_to_draft():
+    from data_tools.src.approve_change_requests import convert_bli_status_to_pretty_string
+
+    assert convert_bli_status_to_pretty_string(None) == "DRAFT"
+
+
+def test_convert_bli_status_to_pretty_string_unrecognized_falls_back_to_draft():
+    from data_tools.src.approve_change_requests import convert_bli_status_to_pretty_string
+
+    assert convert_bli_status_to_pretty_string("NOT_A_REAL_STATUS") == "DRAFT"
+
+
+# ---------------------------------------------------------------------------
+# build_review_outcome_notification
+# ---------------------------------------------------------------------------
+
+
+def test_build_review_outcome_notification_agreement_change_request():
+    from data_tools.src.approve_change_requests import build_review_outcome_notification
+    from models import AgreementChangeRequest, ChangeRequestStatus
+
+    change_request = AgreementChangeRequest(
+        requested_change_data={"awarding_entity_id": 5},
+        status=ChangeRequestStatus.APPROVED,
+        agreement_id=9101,
+    )
+
+    title, message = build_review_outcome_notification(change_request)
+
+    assert title == "Procurement Shop Change Approved"
+    assert message == "Your procurement shop change request has been approved."
+
+
+def test_build_review_outcome_notification_bli_status_change():
+    from data_tools.src.approve_change_requests import build_review_outcome_notification
+    from models import BudgetLineItemChangeRequest, ChangeRequestStatus
+
+    change_request = BudgetLineItemChangeRequest(
+        requested_change_data={"status": "IN_EXECUTION"},
+        requested_change_diff={"status": {"old": "PLANNED", "new": "IN_EXECUTION"}},
+        status=ChangeRequestStatus.APPROVED,
+        budget_line_item_id=91001,
+        agreement_id=9101,
+    )
+
+    title, message = build_review_outcome_notification(change_request)
+
+    assert title == "Budget Lines Approved from PLANNED to IN_EXECUTION Status"
+    assert message == "The status change you submitted was approved: PLANNED → IN_EXECUTION."
+
+
+def test_build_review_outcome_notification_bli_amount_change():
+    from data_tools.src.approve_change_requests import build_review_outcome_notification
+    from models import BudgetLineItemChangeRequest, ChangeRequestStatus
+
+    change_request = BudgetLineItemChangeRequest(
+        requested_change_data={"amount": 5000.0},
+        status=ChangeRequestStatus.APPROVED,
+        budget_line_item_id=91001,
+        agreement_id=9101,
+    )
+
+    title, message = build_review_outcome_notification(change_request)
+
+    assert title == "Budget Change Request APPROVED"
+    assert message == "Your budget change request has been approved."
+
+
+def test_build_review_outcome_notification_bli_can_id_change():
+    from data_tools.src.approve_change_requests import build_review_outcome_notification
+    from models import BudgetLineItemChangeRequest, ChangeRequestStatus
+
+    change_request = BudgetLineItemChangeRequest(
+        requested_change_data={"can_id": 123},
+        status=ChangeRequestStatus.APPROVED,
+        budget_line_item_id=91001,
+        agreement_id=9101,
+    )
+
+    title, message = build_review_outcome_notification(change_request)
+
+    assert title == "Budget Change Request APPROVED"
+    assert message == "Your budget change request has been approved."
+
+
+def test_build_review_outcome_notification_bli_date_needed_change():
+    from data_tools.src.approve_change_requests import build_review_outcome_notification
+    from models import BudgetLineItemChangeRequest, ChangeRequestStatus
+
+    change_request = BudgetLineItemChangeRequest(
+        requested_change_data={"date_needed": "2043-02-02"},
+        status=ChangeRequestStatus.APPROVED,
+        budget_line_item_id=91001,
+        agreement_id=9101,
+    )
+
+    title, message = build_review_outcome_notification(change_request)
+
+    assert title == "Budget Change Request APPROVED"
+    assert message == "Your budget change request has been approved."
+
+
+def test_build_review_outcome_notification_bli_unmatched_returns_none_none():
+    from data_tools.src.approve_change_requests import build_review_outcome_notification
+    from models import BudgetLineItemChangeRequest, ChangeRequestStatus
+
+    change_request = BudgetLineItemChangeRequest(
+        requested_change_data={},
+        status=ChangeRequestStatus.APPROVED,
+        budget_line_item_id=91001,
+        agreement_id=9101,
+    )
+
+    title, message = build_review_outcome_notification(change_request)
+
+    assert (title, message) == (None, None)

--- a/backend/data_tools/tests/load_aas/test_load_aas.py
+++ b/backend/data_tools/tests/load_aas/test_load_aas.py
@@ -452,7 +452,11 @@ def test_existing_agreement_handling(db_for_aas):
 
     # Verify budget lines were created
     budget_lines = (
-        db_for_aas.execute(select(AABudgetLineItem).where(AABudgetLineItem.agreement_id == new_agreement.id))
+        db_for_aas.execute(
+            select(AABudgetLineItem)
+            .where(AABudgetLineItem.agreement_id == new_agreement.id)
+            .order_by(AABudgetLineItem.id)
+        )
         .scalars()
         .all()
     )


### PR DESCRIPTION
## What changed

Adds a standalone, one-off `data_tools` script (`backend/data_tools/src/approve_change_requests.py`) that approves `ChangeRequest` records on behalf of an assigned reviewer, for cases where legitimately-created records are stuck `IN_REVIEW` and no one with the right division-director authority is available to click "Approve" in the UI.

The script reproduces exactly what a real UI "Approve" click does — without any dependency on Flask/`ops_api` (the `data_tools` package's virtualenv doesn't have those installed, so all approval logic had to be locally ported rather than imported from `backend/ops_api/`):

- Sets the `ChangeRequest`'s disposition fields (`status=APPROVED`, `reviewed_by_id`, `reviewed_on`, `reviewer_notes` — always suffixed with an out-of-band marker).
- Applies the requested field change to the underlying `BudgetLineItem` or `Agreement`, including the one non-obvious type coercion the real approval path performs (`status`/`date_needed` come back from `requested_change_data` as plain JSON strings and need to be coerced to real enum/date values before `setattr`).
- Creates the matching `AgreementHistory` audit row via the shared `agreement_history_trigger_func`, attributed to the real approving user's name.
- Creates a `ChangeRequestNotification` for the original requestor, with title/message wording ported from `ops_api`'s `build_review_outcome_title_and_message`.
- If the approved change is a BLI status transition to `IN_EXECUTION`, also creates/links the `DefaultProcurementTracker`/`ProcurementAction` records exactly like a real approval would (reusing the shared `models.procurement_workflow` helpers).
- Warns (but never blocks) if the approving user isn't the actual division director/deputy for that change request.
- Supports the existing `DRY_RUN=1` convention and does per-record error isolation (one bad id logs an error and moves to the next; it doesn't abort the whole batch).

Supports the two real-world `ChangeRequest` shapes that exist in this codebase: `BudgetLineItemChangeRequest` (status changes and budget-field changes) and `AgreementChangeRequest` (procurement-shop changes). It never rejects — approve-only, by design.

**Files:**
- `backend/data_tools/src/approve_change_requests.py` — the script (CLI + orchestration + helpers), following `backfill_procurement_tracker.py`'s established shape (single file, one `click.command()`, not registered in `load_data.py`).
- `backend/data_tools/tests/approve_change_requests/` — new test package: `test_approve_change_requests.py` (DB-backed tests for the orchestration functions, using a dedicated fixture) and `test_helpers.py` (pure-function tests, no DB).
- `backend/data_tools/tests/load_aas/test_load_aas.py` — incidental one-line fix for a pre-existing flaky test (`test_existing_agreement_handling` asserted a specific row order from a query with no `ORDER BY`; Postgres doesn't guarantee row order without one, and this new test suite's added DB churn was enough to occasionally flip the query plan and expose it). Unrelated to this script's logic, but needed for the full suite to be reliably green.

## Design notes for reviewers

- **Why `dry_run=True` is hardcoded in the call to `agreement_history_trigger_func`, not tied to the `DRY_RUN` env var:** that parameter only controls whether the trigger function calls `session.commit()` *internally* — it stages the `AgreementHistory` row unconditionally either way. This script (like the existing `load_agreement_missing_data/utils.py::update_agreement()` precedent it's modeled on) builds one atomic unit of work per change request — CR mutation, target mutation, `OpsEvent`, history row, notification, tracker/action — and wants exactly one commit/rollback decision for the whole unit, made by the caller (`main()`'s loop, via `commit_or_rollback`). If the trigger function committed on its own mid-function, a later failure in the same record's processing could leave a permanently-committed partial mutation with no way to roll it back.
- **Why disposition fields are mutated before the target-existence check:** this mirrors the real `ChangeRequestService`'s own behavior (it sets disposition fields, then can fail later) and relies on the caller rolling back on any `False`/exception outcome — which `main()`'s loop does for every record, not just the happy path.
- **Single-table inheritance:** `ChangeRequest`/`AgreementChangeRequest`/`BudgetLineItemChangeRequest` all share one table, discriminated by `change_request_type`. The code branches on that enum rather than `isinstance()`, and uses `getattr(change_request, "budget_line_item_id", None)` defensively where `AgreementChangeRequest` instances genuinely lack that attribute.
- **One deliberate wording deviation from the real service:** the real `build_review_outcome_title_and_message`'s AGREEMENT_CHANGE_REQUEST branch hardcodes "Procurement Shop Change..." wording regardless of which agreement field actually changed — this port matches that exactly (not a bug, verified against the live source).

## Issue

https://github.com/HHS/OPRE-OPS/issues/6045

## How to test

I've already tested this on my own in local dev and in the azure dev environment.

Automated:
```bash
cd backend/data_tools
pipenv run pytest tests/approve_change_requests/ -v   # this script's own tests
pipenv run pytest tests/                                # full data_tools suite, confirm no regressions
pipenv run nox -s format_check
pipenv run nox -s lint
```

Manual (against a local dev DB, `docker compose up db data-import --build` first):
```bash
cd backend
python data_tools/src/approve_change_requests.py --env dev \
    --approving-user-email <a real user's email> --change-request-id <a real IN_REVIEW CR id>
```
Confirm the CR shows `APPROVED`, the underlying BLI/Agreement field changed, an `AgreementHistory` entry appears on the agreement's history tab, and a notification appears for the requestor. Re-run the exact same command a second time and confirm it logs "not IN_REVIEW" and skips cleanly rather than double-applying anything. Try `DRY_RUN=1` first to confirm nothing persists.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] No UI component changes in this PR

## Screenshots

N/A — backend-only, no UI changes.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [x] Form validations updated

## Links

N/A