### PR TITLE
fix: enable budget line row icons after duplicating

### DIFF
--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
@@ -869,7 +869,11 @@ const useCreateBLIsAndSCs = (
             date_needed,
             proc_shop_fee_percentage,
             status: BLI_STATUS.DRAFT,
-            created_by: loggedInUserFullName
+            created_by: loggedInUserFullName,
+            // Mirror handleAddBLI: a duplicated draft BLI must be editable so its
+            // edit/delete/duplicate icons stay enabled. Without this the row reads
+            // _meta?.isEditable as undefined and renders the disabled icons. (issue #6020)
+            _meta: { isEditable: true }
         };
         setTempBudgetLines([...tempBudgetLines, payload]);
         resetForm();

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
@@ -273,6 +273,35 @@ describe("useCreateBLIsAndSCs", () => {
         );
     });
 
+    it("marks a duplicated budget line editable so its row icons stay enabled (issue #6020)", () => {
+        const { result } = renderSubject();
+
+        // Seed a budget line to duplicate.
+        act(() => {
+            result.current.setServicesComponentNumber(1);
+            result.current.setSelectedCan({ id: 22, display_name: "CAN 22" });
+            result.current.setEnteredAmount(1000);
+            result.current.setNeedByDate("01/01/2026");
+            result.current.setEnteredDescription("Original budget line");
+        });
+        act(() => {
+            result.current.handleAddBLI({ preventDefault: vi.fn() });
+        });
+
+        const original = result.current.tempBudgetLines[0];
+
+        act(() => {
+            result.current.handleDuplicateBudgetLine(original.id);
+        });
+
+        expect(result.current.tempBudgetLines).toHaveLength(2);
+        const duplicate = result.current.tempBudgetLines[1];
+        // Without _meta.isEditable the row renders the disabled edit/delete/duplicate icons.
+        expect(duplicate._meta).toEqual({ isEditable: true });
+        expect(duplicate.id).not.toBe(original.id);
+        expect(duplicate.amount).toBe(original.amount);
+    });
+
     it("opens cancel modal and navigates to budget lines on confirm", () => {
         const { result } = renderSubject();
 


### PR DESCRIPTION
## What changed

The edit/delete/duplicate icons in a budget line table row were disabled after duplicating that budget line. The duplicate handler (`handleDuplicateBudgetLine` in `CreateBLIsAndSCs.hooks.js`) built the new BLI payload without the `_meta: { isEditable: true }` flag that the add handler (`handleAddBLI`) sets. `BLIRow` reads `budgetLine._meta?.isEditable` to gate the icons, so a duplicated row got `undefined` and rendered the disabled icon variant.

This adds `_meta: { isEditable: true }` to the duplicate payload, mirroring `handleAddBLI`, so duplicated draft budget lines stay editable. Affects both the Create Agreement wizard and editing existing budget lines (both share this hook).

## Issue

https://github.com/HHS/OPRE-OPS/issues/6020

## How to test

1. In the create agreement wizard, fill in and move to step 3 to add a budget line.
2. Duplicate the budget line with the duplicate icon in the table row.
3. Verify the edit/delete/duplicate icons on the new duplicated row are enabled (not greyed out).
4. Repeat when editing an existing agreement's budget lines.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated
