### PR TITLE
Relax CAN funding validation on update, backfill funding_details history

### DIFF
--- a/.claude/skills/db-migrations/SKILL.md
+++ b/.claude/skills/db-migrations/SKILL.md
@@ -3,7 +3,7 @@ name: db-migrations
 description: Create, review, test, and rollback Alembic database migrations for OPRE OPS. Use this skill whenever the user mentions database migrations, alembic, schema changes, adding/modifying columns or tables, model changes that need migration, or "migrate the database". Also use when a model change has been made and the user needs to generate the corresponding migration.
 argument-hint: "[create <message> | review | upgrade | downgrade | status | history]"
 allowed-tools: Read, Grep, Glob, Bash, Edit, Write
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # Database Migration Manager

--- a/backend/alembic/versions/2026_08_07_0553-5bbc500dc6a1_add_can_funding_details_edited_history_.py
+++ b/backend/alembic/versions/2026_08_07_0553-5bbc500dc6a1_add_can_funding_details_edited_history_.py
@@ -1,0 +1,79 @@
+"""add can funding details edited history type
+
+Revision ID: 5bbc500dc6a1
+Revises: a7c3f1e9b2d4
+Create Date: 2026-08-07 05:53:26.415481+00:00
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from alembic_postgresql_enum import TableReference
+
+# revision identifiers, used by Alembic.
+revision: str = "5bbc500dc6a1"
+down_revision: Union[str, None] = "a7c3f1e9b2d4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.sync_enum_values(
+        enum_schema="ops",
+        enum_name="canhistorytype",
+        new_values=[
+            "CAN_DATA_IMPORT",
+            "CAN_NICKNAME_EDITED",
+            "CAN_DESCRIPTION_EDITED",
+            "CAN_FUNDING_CREATED",
+            "CAN_RECEIVED_CREATED",
+            "CAN_FUNDING_EDITED",
+            "CAN_RECEIVED_EDITED",
+            "CAN_FUNDING_DELETED",
+            "CAN_RECEIVED_DELETED",
+            "CAN_PORTFOLIO_CREATED",
+            "CAN_PORTFOLIO_DELETED",
+            "CAN_PORTFOLIO_EDITED",
+            "CAN_DIVISION_CREATED",
+            "CAN_DIVISION_DELETED",
+            "CAN_DIVISION_EDITED",
+            "CAN_CARRY_FORWARD_CALCULATED",
+            "CAN_FUNDING_DETAILS_EDITED",
+        ],
+        affected_columns=[
+            TableReference(table_schema="ops", table_name="can_history", column_name="history_type"),
+            TableReference(table_schema="ops", table_name="can_history_version", column_name="history_type"),
+        ],
+        enum_values_to_rename=[],
+    )
+
+
+def downgrade() -> None:
+    op.sync_enum_values(
+        enum_schema="ops",
+        enum_name="canhistorytype",
+        new_values=[
+            "CAN_DATA_IMPORT",
+            "CAN_NICKNAME_EDITED",
+            "CAN_DESCRIPTION_EDITED",
+            "CAN_FUNDING_CREATED",
+            "CAN_RECEIVED_CREATED",
+            "CAN_FUNDING_EDITED",
+            "CAN_RECEIVED_EDITED",
+            "CAN_FUNDING_DELETED",
+            "CAN_RECEIVED_DELETED",
+            "CAN_PORTFOLIO_CREATED",
+            "CAN_PORTFOLIO_DELETED",
+            "CAN_PORTFOLIO_EDITED",
+            "CAN_DIVISION_CREATED",
+            "CAN_DIVISION_DELETED",
+            "CAN_DIVISION_EDITED",
+            "CAN_CARRY_FORWARD_CALCULATED",
+        ],
+        affected_columns=[
+            TableReference(table_schema="ops", table_name="can_history", column_name="history_type"),
+            TableReference(table_schema="ops", table_name="can_history_version", column_name="history_type"),
+        ],
+        enum_values_to_rename=[],
+    )

--- a/backend/data_tools/data/ops_event.json5
+++ b/backend/data_tools/data/ops_event.json5
@@ -7427,6 +7427,29 @@
             },
             created_by: 521,
             created_on: "2026-04-03T16:35:45.789012Z",
+        },
+        {
+            // 75
+            event_type: "UPDATE_CAN",
+            event_status: "SUCCESS",
+            event_details: {
+                can_updates: {
+                    owner_id: 500,
+                    changes: {
+                        "funding_details.appropriation": {
+                            new_value: "75-2529-1512",
+                            old_value: "75-25-1512",
+                        },
+                        "funding_details.fiscal_year": {
+                            new_value: 2026,
+                            old_value: 2025,
+                        },
+                    },
+                    updated_by: 516,
+                },
+            },
+            created_by: 516,
+            created_on: "2026-08-07T04:20:00.000000Z",
         }
     ],
 }

--- a/backend/data_tools/src/backfill_can_funding_details_history.py
+++ b/backend/data_tools/src/backfill_can_funding_details_history.py
@@ -1,0 +1,144 @@
+"""
+Backfill CANHistory records for UPDATE_CAN OpsEvents whose "changes" dict contains
+funding_details.* keys, which were silently dropped by create_can_update_history_event
+before CANHistoryType.CAN_FUNDING_DETAILS_EDITED existed.
+
+Related to: production run of load_cans against a real dataset recorded OpsEvents with
+correct funding_details.* changes, but no corresponding CANHistory rows were created.
+This is intended as a one-time ad-hoc backfill.
+
+Usage (from backend/ directory):
+    python data_tools/src/backfill_can_funding_details_history.py --env dev
+
+Set DRY_RUN=1 to preview changes without committing:
+    DRY_RUN=1 python data_tools/src/backfill_can_funding_details_history.py --env dev
+"""
+
+import os
+import sys
+import time
+
+import click
+from dotenv import load_dotenv
+from loguru import logger
+from sqlalchemy import select, text
+from sqlalchemy.orm import Session, scoped_session, sessionmaker
+
+from data_tools.src.common.db import init_db_from_config, setup_triggers
+from data_tools.src.common.utils import get_config, get_or_create_sys_user
+from models import CANHistory, OpsEvent, OpsEventStatus, OpsEventType, User
+from models.can_history import can_history_trigger_func
+
+load_dotenv(os.getenv("ENV_FILE", ".env"))
+
+os.environ["TZ"] = "UTC"
+time.tzset()
+
+log_format = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+    "<level>{level: <8}</level> | "
+    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> | "
+    "<level>{message}</level>"
+)
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+logger.remove()
+logger.add(sys.stderr, format=log_format, level=LOG_LEVEL)
+
+
+def get_update_can_events_with_funding_details_changes(session: Session) -> list[OpsEvent]:
+    """
+    Find all successful UPDATE_CAN OpsEvents whose "changes" dict contains at least one
+    funding_details.* key.
+    """
+    events = (
+        session.execute(
+            select(OpsEvent)
+            .where(OpsEvent.event_type == OpsEventType.UPDATE_CAN)
+            .where(OpsEvent.event_status == OpsEventStatus.SUCCESS)
+            .order_by(OpsEvent.id)
+        )
+        .scalars()
+        .all()
+    )
+
+    return [
+        event
+        for event in events
+        if any(
+            key.startswith("funding_details.") for key in event.event_details.get("can_updates", {}).get("changes", {})
+        )
+    ]
+
+
+def backfill_can_funding_details_history(session: Session, sys_user: User) -> None:
+    """
+    Re-run can_history_trigger_func for every UPDATE_CAN OpsEvent with funding_details.*
+    changes. add_history_events already de-duplicates by (timestamp, history_type,
+    history_message, fiscal_year) against existing rows, so this is safe to re-run and
+    leaves previously-recorded nick_name/description/portfolio_id history untouched.
+    """
+    dry_run = os.getenv("DRY_RUN", "").lower() in ("1", "true")
+    if dry_run:
+        logger.info("DRY_RUN mode enabled — changes will be rolled back.")
+
+    events = get_update_can_events_with_funding_details_changes(session)
+    logger.info(f"Found {len(events)} UPDATE_CAN events with funding_details changes.")
+
+    created_history_count = 0
+    for event in events:
+        try:
+            before_count = len(
+                session.execute(select(CANHistory).where(CANHistory.ops_event_id == event.id)).scalars().all()
+            )
+            can_history_trigger_func(event, session, sys_user, dry_run=True)
+            session.flush()
+            after_count = len(
+                session.execute(select(CANHistory).where(CANHistory.ops_event_id == event.id)).scalars().all()
+            )
+            created_history_count += after_count - before_count
+
+            if dry_run:
+                logger.info(f"Dry run: rolling back changes for OpsEvent {event.id}.")
+                session.rollback()
+            else:
+                session.commit()
+
+        except Exception:
+            logger.exception(f"Error processing OpsEvent {event.id}")
+            session.rollback()
+            raise
+
+    verb = "Would create" if dry_run else "Created"
+    logger.info(f"Backfill complete. {verb} {created_history_count} CANHistory records.")
+
+
+@click.command()
+@click.option("--env", required=True, help="The environment to use (dev, local, azure).")
+def main(env: str):
+    """Backfill CANHistory records for UPDATE_CAN OpsEvents with funding_details.* changes."""
+    logger.info("Starting CAN funding details history backfill.")
+
+    script_config = get_config(env)
+    db_engine, _ = init_db_from_config(script_config)
+
+    if db_engine is None:
+        logger.error("Failed to initialize the database engine.")
+        sys.exit(1)
+
+    with db_engine.connect() as conn:
+        conn.execute(text("SELECT 1"))
+        logger.info("Successfully connected to the database.")
+
+    session_factory = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=db_engine))
+
+    with session_factory() as session:
+        sys_user = get_or_create_sys_user(session)
+        logger.info(f"Retrieved system user: {sys_user}")
+        setup_triggers(session, sys_user)
+        backfill_can_funding_details_history(session, sys_user)
+
+    logger.info("CAN funding details history backfill complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/data_tools/src/load_cans/utils.py
+++ b/backend/data_tools/src/load_cans/utils.py
@@ -85,16 +85,22 @@ def validate_data(data: CANData) -> bool:
     """
     Validate the data in a CanData instance.
 
+    A blank SYS_CAN_ID means this row can only create a brand-new CAN (no update fallback is
+    possible without a DB lookup), so PORTFOLIO must be present up front — mirroring the hard
+    requirement enforced later in _resolve_portfolio for new CANs — so a batch with a bad new-CAN
+    row fails atomically here rather than after some rows have already been committed.
+
     :param data: The CanData instance to validate.
 
     :return: True if the data is valid, False otherwise.
     """
-    return all(
-        [
-            data.FISCAL_YEAR is not None,
-            data.CAN_NBR is not None,
-        ]
-    )
+    checks = [
+        data.FISCAL_YEAR is not None,
+        data.CAN_NBR is not None,
+    ]
+    if data.SYS_CAN_ID is None:
+        checks.append(data.PORTFOLIO is not None)
+    return all(checks)
 
 
 def validate_all(data: List[CANData]) -> bool:
@@ -172,8 +178,12 @@ def _diff_values(pairs: dict, enum_keys: frozenset = frozenset()) -> dict:
 
 def _update_can_fields(can: CAN, data: CANData, portfolio: Optional[Portfolio], sys_user: User) -> dict:
     """
-    Update an existing CAN's attributes, leaving blank NICK_NAME/PORTFOLIO untouched, and return a
-    changes dict of whatever differs from before the update.
+    Update an existing CAN's attributes and return a changes dict of whatever differs from before
+    the update.
+
+    Blank NICK_NAME/PORTFOLIO leave the existing value untouched. CAN_DESCRIPTION is intentionally
+    full-replacement (not blank-preserving) — a description is expected to always be present in
+    the source data, so a blank value on an update is treated as a real change, not an omission.
 
     :param can: The existing CAN to update.
     :param data: The CANData instance to use.
@@ -344,6 +354,9 @@ def create_models(data: CANData, sys_user: User, session: Session) -> None:
             can.funding_details = get_or_create_funding_details(data, sys_user, can.funding_details)
             changes.update(_track_funding_details_changes(can, old_funding_details, is_new))
         except ValueError as e:
+            # Intentional: a new CAN with an invalid fund code, or missing required
+            # METHOD_OF_TRANSFER/FUNDING_SOURCE, still gets created with funding_details=None
+            # rather than failing the whole row. See test_create_models_new_can_blank_*.
             logger.warning(
                 f"Skipping creating funding details for {data} due to invalid or missing required funding data. {e}"
             )

--- a/backend/data_tools/src/load_cans/utils.py
+++ b/backend/data_tools/src/load_cans/utils.py
@@ -198,12 +198,16 @@ def _update_can_fields(can: CAN, data: CANData, portfolio: Optional[Portfolio], 
     can.updated_by = sys_user.id
     can.updated_on = datetime.now()
 
+    # can.portfolio_id isn't populated until flush, so diff against the resolved portfolio's id
+    # directly rather than reading the (still-stale) FK column back off `can`.
+    new_portfolio_id = portfolio.id if portfolio else old_values["portfolio_id"]
+
     return _diff_values(
         {
             "number": (old_values["number"], can.number),
             "description": (old_values["description"], can.description),
             "nick_name": (old_values["nick_name"], can.nick_name),
-            "portfolio_id": (old_values["portfolio_id"], can.portfolio_id),
+            "portfolio_id": (old_values["portfolio_id"], new_portfolio_id),
         }
     )
 

--- a/backend/data_tools/src/load_cans/utils.py
+++ b/backend/data_tools/src/load_cans/utils.py
@@ -93,9 +93,6 @@ def validate_data(data: CANData) -> bool:
         [
             data.FISCAL_YEAR is not None,
             data.CAN_NBR is not None,
-            data.PORTFOLIO is not None,
-            data.FUNDING_SOURCE is not None,
-            data.METHOD_OF_TRANSFER is not None,
         ]
     )
 
@@ -111,6 +108,195 @@ def validate_all(data: List[CANData]) -> bool:
     return sum(1 for d in data if validate_data(d)) == len(data)
 
 
+def _find_existing_can(data: CANData, session: Session) -> Optional[CAN]:
+    """
+    Look up an existing CAN by SYS_CAN_ID, falling back to a lookup by CAN_NBR.
+
+    :param data: The CANData instance to use.
+    :param session: The database session to use.
+
+    :return: The existing CAN, or None if not found.
+    """
+    can = session.get(CAN, data.SYS_CAN_ID) if data.SYS_CAN_ID else None
+    if not can:
+        can = session.execute(select(CAN).where(CAN.number == data.CAN_NBR)).scalar_one_or_none()
+        if can:
+            logger.info(f"*** found existing CAN by number {can.number} instead of ID")
+    return can
+
+
+def _resolve_portfolio(data: CANData, is_new: bool, session: Session) -> Optional[Portfolio]:
+    """
+    Resolve PORTFOLIO to a Portfolio. Required when creating a new CAN; a blank PORTFOLIO on an
+    update returns None so the caller can leave the CAN's existing portfolio alone.
+
+    :param data: The CANData instance to use.
+    :param is_new: Whether this row is creating a brand-new CAN.
+    :param session: The database session to use.
+
+    :return: The resolved Portfolio, or None if PORTFOLIO was blank on an update.
+    :raises ValueError: If PORTFOLIO is blank on a new CAN, or doesn't match a known Portfolio.
+    """
+    if not data.PORTFOLIO:
+        if is_new:
+            raise ValueError("PORTFOLIO is required when creating a new CAN.")
+        return None
+    portfolio = session.execute(select(Portfolio).where(Portfolio.abbreviation == data.PORTFOLIO)).scalar_one_or_none()
+    if not portfolio:
+        raise ValueError(f"Portfolio not found for {data.PORTFOLIO}")
+    return portfolio
+
+
+def _diff_values(pairs: dict, enum_keys: frozenset = frozenset()) -> dict:
+    """
+    Compare old/new value pairs and build a changes dict for any that differ.
+
+    :param pairs: mapping of change-key -> (old_value, new_value) tuples.
+    :param enum_keys: keys whose values are enums and should be serialized via their `.name`.
+
+    :return: {key: {"old_value": ..., "new_value": ...}} for values that differ.
+    """
+    changes = {}
+    for key, (old_value, new_value) in pairs.items():
+        if old_value == new_value:
+            continue
+        if key in enum_keys:
+            changes[key] = {
+                "old_value": old_value.name if old_value else None,
+                "new_value": new_value.name if new_value else None,
+            }
+        else:
+            changes[key] = {"old_value": old_value, "new_value": new_value}
+    return changes
+
+
+def _update_can_fields(can: CAN, data: CANData, portfolio: Optional[Portfolio], sys_user: User) -> dict:
+    """
+    Update an existing CAN's attributes, leaving blank NICK_NAME/PORTFOLIO untouched, and return a
+    changes dict of whatever differs from before the update.
+
+    :param can: The existing CAN to update.
+    :param data: The CANData instance to use.
+    :param portfolio: The resolved Portfolio, or None to leave the CAN's portfolio alone.
+    :param sys_user: The system user to use.
+
+    :return: {field: {"old_value": ..., "new_value": ...}} for fields that changed.
+    """
+    old_values = {
+        "number": can.number,
+        "description": can.description,
+        "nick_name": can.nick_name,
+        "portfolio_id": can.portfolio_id,
+    }
+
+    can.number = data.CAN_NBR
+    can.description = data.CAN_DESCRIPTION
+    if data.NICK_NAME:
+        can.nick_name = data.NICK_NAME
+    if portfolio:
+        can.portfolio = portfolio
+    can.updated_by = sys_user.id
+    can.updated_on = datetime.now()
+
+    return _diff_values(
+        {
+            "number": (old_values["number"], can.number),
+            "description": (old_values["description"], can.description),
+            "nick_name": (old_values["nick_name"], can.nick_name),
+            "portfolio_id": (old_values["portfolio_id"], can.portfolio_id),
+        }
+    )
+
+
+_FUNDING_DETAILS_FIELDS = (
+    "fiscal_year",
+    "fund_code",
+    "allowance",
+    "sub_allowance",
+    "allotment",
+    "appropriation",
+    "method_of_transfer",
+    "funding_source",
+    "funding_partner",
+)
+_FUNDING_DETAILS_ENUM_FIELDS = frozenset({"method_of_transfer", "funding_source"})
+
+
+def _capture_funding_details_values(funding_details: Optional[CANFundingDetails]) -> dict:
+    """
+    Snapshot a CANFundingDetails' comparable fields, or all-None if there is none.
+
+    :param funding_details: The CANFundingDetails to snapshot, or None.
+
+    :return: {field: value} for each of _FUNDING_DETAILS_FIELDS.
+    """
+    if not funding_details:
+        return {field_name: None for field_name in _FUNDING_DETAILS_FIELDS}
+    return {field_name: getattr(funding_details, field_name) for field_name in _FUNDING_DETAILS_FIELDS}
+
+
+def _track_funding_details_changes(can: CAN, old_funding_details: dict, is_new: bool) -> dict:
+    """
+    Diff a CAN's current funding_details against a prior snapshot, keyed as `funding_details.<field>`.
+    When the CAN had no funding_details before (old_funding_details is empty), every field is treated
+    as a None -> new_value change, so the first-ever funding_details record for an existing CAN always
+    produces an UPDATE_CAN history event.
+
+    :param can: The CAN whose funding_details was just created/updated.
+    :param old_funding_details: A snapshot from _capture_funding_details_values, or {} if there was none.
+    :param is_new: Whether this row is creating a brand-new CAN.
+
+    :return: {field: {"old_value": ..., "new_value": ...}} for funding_details fields that changed.
+    """
+    if is_new or not can.funding_details:
+        return {}
+    if not old_funding_details:
+        old_funding_details = _capture_funding_details_values(None)
+
+    fd = can.funding_details
+    return _diff_values(
+        {
+            f"funding_details.{field_name}": (old_funding_details[field_name], getattr(fd, field_name))
+            for field_name in _FUNDING_DETAILS_FIELDS
+        },
+        enum_keys=frozenset(f"funding_details.{field_name}" for field_name in _FUNDING_DETAILS_ENUM_FIELDS),
+    )
+
+
+def _record_can_event(can: CAN, sys_user: User, session: Session, is_new: bool, changes: dict) -> None:
+    """
+    Create and commit the OpsEvent (CREATE_NEW_CAN or UPDATE_CAN) and fire the history trigger. No
+    event is created for an update with no actual changes.
+
+    :param can: The CAN that was just created/updated.
+    :param sys_user: The system user to use.
+    :param session: The database session to use.
+    :param is_new: Whether this row created a brand-new CAN.
+    :param changes: The changes dict from updating the CAN and its funding_details.
+    """
+    if not is_new and not changes:
+        logger.info(f"No changes detected for CAN with id {can.id} and number {can.number}, skipping event creation")
+        return
+
+    event = OpsEvent(event_status=OpsEventStatus.SUCCESS, created_by=sys_user.id)
+    if is_new:
+        event.event_type = OpsEventType.CREATE_NEW_CAN
+        event.event_details = {"new_can": can.to_dict()}
+        session.add(event)
+        session.commit()
+        logger.info(f"Created Ops Event for new CAN with id {can.id} and number {can.number}")
+    else:
+        event.event_type = OpsEventType.UPDATE_CAN
+        event.event_details = {"can_updates": {"owner_id": can.id, "changes": changes}}
+        session.add(event)
+        session.commit()
+        logger.info(
+            f"Created Ops Event for existing CAN with id {can.id} and number {can.number} with {len(changes)} changes"
+        )
+
+    can_history_trigger_func(event, session, sys_user)
+
+
 def create_models(data: CANData, sys_user: User, session: Session) -> None:
     """
     Upsert a CAN and its associated CANFundingDetails.
@@ -122,28 +308,21 @@ def create_models(data: CANData, sys_user: User, session: Session) -> None:
     logger.debug(f"Creating models for {data}")
 
     try:
-        portfolio = session.execute(
-            select(Portfolio).where(Portfolio.abbreviation == data.PORTFOLIO)
-        ).scalar_one_or_none()
-        if not portfolio:
-            raise ValueError(f"Portfolio not found for {data.PORTFOLIO}")
-
         base_date = datetime(data.FISCAL_YEAR - 1, 10, 1)
-        is_new = False
 
-        can = session.get(CAN, data.SYS_CAN_ID) if data.SYS_CAN_ID else None
-        if not can:
-            can = session.execute(select(CAN).where(CAN.number == data.CAN_NBR)).scalar_one_or_none()
+        can = _find_existing_can(data, session)
+        is_new = can is None
+
+        portfolio = _resolve_portfolio(data, is_new, session)
+
+        changes = {}
+        old_funding_details = {}
 
         if can:
-            can.number = data.CAN_NBR
-            can.description = data.CAN_DESCRIPTION
-            can.nick_name = data.NICK_NAME
-            can.portfolio = portfolio
-            can.updated_by = sys_user.id
-            can.updated_on = datetime.now()
+            if can.funding_details:
+                old_funding_details = _capture_funding_details_values(can.funding_details)
+            changes = _update_can_fields(can, data, portfolio, sys_user)
         else:
-            is_new = True
             can = CAN(
                 id=data.SYS_CAN_ID if data.SYS_CAN_ID else None,
                 number=data.CAN_NBR,
@@ -159,8 +338,11 @@ def create_models(data: CANData, sys_user: User, session: Session) -> None:
         try:
             validate_fund_code(data)
             can.funding_details = get_or_create_funding_details(data, sys_user, can.funding_details)
+            changes.update(_track_funding_details_changes(can, old_funding_details, is_new))
         except ValueError as e:
-            logger.info(f"Skipping creating funding details for {data} due to invalid fund code. {e}")
+            logger.warning(
+                f"Skipping creating funding details for {data} due to invalid or missing required funding data. {e}"
+            )
 
         if is_new:
             session.add(can)
@@ -171,18 +353,7 @@ def create_models(data: CANData, sys_user: User, session: Session) -> None:
         else:
             session.commit()
             logger.info(f"Upserted CAN {can.number} with id {can.id}")
-
-            event = OpsEvent(
-                event_type=OpsEventType.CREATE_NEW_CAN,
-                event_status=OpsEventStatus.SUCCESS,
-                event_details={"new_can": can.to_dict()},
-                created_by=sys_user.id,
-            )
-            session.add(event)
-            session.commit()
-            logger.info(f"Created Ops Event for CAN with id {can.id} and number {can.number}")
-
-            can_history_trigger_func(event, session, sys_user)
+            _record_can_event(can, sys_user, session, is_new, changes)
 
     except Exception as e:
         session.rollback()
@@ -215,11 +386,27 @@ def get_or_create_funding_details(
 
     appropriation = "-".join([data.APPROP_PREFIX or "", data.APPROP_YEAR or "", data.APPROP_POSTFIX or ""])
 
-    method_of_transfer = CANMethodOfTransfer[data.METHOD_OF_TRANSFER]
-    funding_source = (
-        CANFundingSource[data.FUNDING_SOURCE] if data.FUNDING_SOURCE != "ACF - MOU" else CANFundingSource.ACF_MOU
-    )
-    funding_partner = data.FUNDING_PARTNER
+    if existing:
+        # Blank METHOD_OF_TRANSFER/FUNDING_SOURCE leave the existing value alone.
+        method_of_transfer = (
+            CANMethodOfTransfer[data.METHOD_OF_TRANSFER] if data.METHOD_OF_TRANSFER else existing.method_of_transfer
+        )
+        funding_source = (
+            (CANFundingSource[data.FUNDING_SOURCE] if data.FUNDING_SOURCE != "ACF - MOU" else CANFundingSource.ACF_MOU)
+            if data.FUNDING_SOURCE
+            else existing.funding_source
+        )
+    else:
+        if not data.METHOD_OF_TRANSFER:
+            raise ValueError("METHOD_OF_TRANSFER is required to create funding details.")
+        if not data.FUNDING_SOURCE:
+            raise ValueError("FUNDING_SOURCE is required to create funding details.")
+        method_of_transfer = CANMethodOfTransfer[data.METHOD_OF_TRANSFER]
+        funding_source = (
+            CANFundingSource[data.FUNDING_SOURCE] if data.FUNDING_SOURCE != "ACF - MOU" else CANFundingSource.ACF_MOU
+        )
+    # Blank FUNDING_PARTNER leaves the existing value alone; it's never required.
+    funding_partner = data.FUNDING_PARTNER if data.FUNDING_PARTNER else (existing.funding_partner if existing else None)
 
     if existing:
         existing.fiscal_year = fiscal_year
@@ -270,6 +457,7 @@ def validate_fund_code(data: CANData) -> None:
     length_of_appropriation = data.FUND[10]
     if length_of_appropriation not in ["0", "1", "2", "5", "3", "8"]:
         raise ValueError(f"Invalid length of appropriation {length_of_appropriation}")
+
     direct_or_reimbursable = data.FUND[11]
     if direct_or_reimbursable not in ["D", "R"]:
         raise ValueError(f"Invalid direct or reimbursable {direct_or_reimbursable}")

--- a/backend/data_tools/tests/backfill_can_funding_details_history/test_backfill_can_funding_details_history.py
+++ b/backend/data_tools/tests/backfill_can_funding_details_history/test_backfill_can_funding_details_history.py
@@ -1,0 +1,172 @@
+import pytest
+from sqlalchemy import select, text
+
+from data_tools.src.backfill_can_funding_details_history import (
+    backfill_can_funding_details_history,
+    get_update_can_events_with_funding_details_changes,
+)
+from data_tools.src.common.utils import get_or_create_sys_user
+from data_tools.src.load_cans.utils import CANData, create_models
+from models import *  # noqa: F403, F401
+
+
+def _make_can_data(**overrides):
+    """Build a fully-populated CANData, with any field overridden by kwargs."""
+    defaults = dict(
+        FISCAL_YEAR=2023,
+        SYS_CAN_ID=500,
+        CAN_NBR="G99HRF2",
+        CAN_DESCRIPTION="Healthy Marriages Responsible Fatherhood - OPRE",
+        FUND="AAXXXX20231DAD",
+        ALLOWANCE="0000000001",
+        ALLOTMENT_ORG="YZC6S1JUGUN",
+        SUB_ALLOWANCE="9KRZ2ND",
+        APPROP_PREFIX="XX",
+        APPROP_POSTFIX="XXXX",
+        APPROP_YEAR="23",
+        PORTFOLIO="HMRF",
+        FUNDING_SOURCE="OPRE",
+        METHOD_OF_TRANSFER="DIRECT",
+        NICK_NAME="HMRF-OPRE",
+        FUNDING_PARTNER="partner 1",
+    )
+    defaults.update(overrides)
+    return CANData(**defaults)
+
+
+@pytest.fixture()
+def db_with_missing_history(loaded_db):
+    """Build two UPDATE_CAN OpsEvents via the real create_models path: one with funding_details.*
+    changes (whose CANHistory rows are then deleted to simulate events recorded before
+    CAN_FUNDING_DETAILS_EDITED existed), and one control event with only a nick_name change, whose
+    history the backfill must leave untouched."""
+    division = Division(id=999, name="Fake Division", abbreviation="FD")
+    loaded_db.merge(division)
+    loaded_db.commit()
+
+    if not loaded_db.get(Portfolio, 1):
+        loaded_db.add(
+            Portfolio(id=1, abbreviation="HMRF", name="Healthy Marriages Responsible Fatherhood", division_id=999)
+        )
+    loaded_db.commit()
+
+    sys_user = get_or_create_sys_user(loaded_db)
+    if sys_user.id is None:
+        loaded_db.add(sys_user)
+        loaded_db.commit()
+
+    create_models(_make_can_data(), sys_user, loaded_db)
+    create_models(_make_can_data(METHOD_OF_TRANSFER="IAA"), sys_user, loaded_db)
+    funding_details_event = (
+        loaded_db.execute(select(OpsEvent).where(OpsEvent.event_type == OpsEventType.UPDATE_CAN)).scalars().one()
+    )
+
+    # Simulate the pre-fix production bug: this event's CANHistory rows were never created.
+    loaded_db.execute(text("DELETE FROM can_history WHERE ops_event_id = :id"), {"id": funding_details_event.id})
+    loaded_db.commit()
+
+    create_models(_make_can_data(SYS_CAN_ID=600, CAN_NBR="G99NEW1"), sys_user, loaded_db)
+    create_models(_make_can_data(SYS_CAN_ID=600, CAN_NBR="G99NEW1", NICK_NAME="Renamed"), sys_user, loaded_db)
+    control_event = (
+        loaded_db.execute(
+            select(OpsEvent).where(
+                OpsEvent.event_type == OpsEventType.UPDATE_CAN,
+                OpsEvent.id != funding_details_event.id,
+            )
+        )
+        .scalars()
+        .one()
+    )
+
+    yield loaded_db, funding_details_event.id, control_event.id, sys_user
+
+    loaded_db.execute(text("DELETE FROM can_history"))
+    loaded_db.execute(text("DELETE FROM can_history_version"))
+    loaded_db.execute(text("DELETE FROM ops_event"))
+    loaded_db.execute(text("DELETE FROM ops_event_version"))
+    loaded_db.execute(text("DELETE FROM can"))
+    loaded_db.execute(text("DELETE FROM can_version"))
+    loaded_db.execute(text("DELETE FROM can_funding_details"))
+    loaded_db.execute(text("DELETE FROM can_funding_details_version"))
+    loaded_db.execute(text("DELETE FROM ops_db_history"))
+    loaded_db.execute(text("DELETE FROM ops_db_history_version"))
+    loaded_db.commit()
+
+
+def test_get_events_finds_only_funding_details_events(db_with_missing_history):
+    """The query should return only the UPDATE_CAN event with funding_details.* changes, not the
+    control event whose changes are limited to nick_name."""
+    session, funding_details_event_id, control_event_id, _ = db_with_missing_history
+
+    events = get_update_can_events_with_funding_details_changes(session)
+    event_ids = {e.id for e in events}
+
+    assert funding_details_event_id in event_ids
+    assert control_event_id not in event_ids
+
+
+def test_backfill_creates_missing_history_rows(db_with_missing_history):
+    """Running the backfill against an event whose CANHistory rows were deleted should recreate a
+    CAN_FUNDING_DETAILS_EDITED row for it."""
+    session, funding_details_event_id, _, sys_user = db_with_missing_history
+
+    before = (
+        session.execute(select(CANHistory).where(CANHistory.ops_event_id == funding_details_event_id)).scalars().all()
+    )
+    assert len(before) == 0
+
+    backfill_can_funding_details_history(session, sys_user)
+
+    after = (
+        session.execute(select(CANHistory).where(CANHistory.ops_event_id == funding_details_event_id)).scalars().all()
+    )
+    assert len(after) == 1
+    assert after[0].history_type == CANHistoryType.CAN_FUNDING_DETAILS_EDITED
+
+
+def test_backfill_is_idempotent(db_with_missing_history):
+    """Running the backfill twice should not create duplicate CANHistory rows, since
+    add_history_events already de-duplicates against existing rows."""
+    session, funding_details_event_id, _, sys_user = db_with_missing_history
+
+    backfill_can_funding_details_history(session, sys_user)
+    first_run = (
+        session.execute(select(CANHistory).where(CANHistory.ops_event_id == funding_details_event_id)).scalars().all()
+    )
+
+    backfill_can_funding_details_history(session, sys_user)
+    second_run = (
+        session.execute(select(CANHistory).where(CANHistory.ops_event_id == funding_details_event_id)).scalars().all()
+    )
+
+    assert len(first_run) == 1
+    assert len(second_run) == 1
+
+
+def test_backfill_does_not_touch_unrelated_history(db_with_missing_history):
+    """The control event's existing nick_name history should be untouched by the backfill."""
+    session, _, control_event_id, sys_user = db_with_missing_history
+
+    before = session.execute(select(CANHistory).where(CANHistory.ops_event_id == control_event_id)).scalars().all()
+    assert len(before) == 1
+    assert before[0].history_type == CANHistoryType.CAN_NICKNAME_EDITED
+
+    backfill_can_funding_details_history(session, sys_user)
+
+    after = session.execute(select(CANHistory).where(CANHistory.ops_event_id == control_event_id)).scalars().all()
+    assert len(after) == 1
+    assert after[0].id == before[0].id
+
+
+def test_backfill_dry_run_creates_nothing(db_with_missing_history, monkeypatch):
+    """With DRY_RUN set, the backfill should compute what it would create but roll back, leaving
+    no CANHistory rows behind."""
+    session, funding_details_event_id, _, sys_user = db_with_missing_history
+    monkeypatch.setenv("DRY_RUN", "1")
+
+    backfill_can_funding_details_history(session, sys_user)
+
+    after = (
+        session.execute(select(CANHistory).where(CANHistory.ops_event_id == funding_details_event_id)).scalars().all()
+    )
+    assert len(after) == 0

--- a/backend/data_tools/tests/load_cans/test_load_cans.py
+++ b/backend/data_tools/tests/load_cans/test_load_cans.py
@@ -70,6 +70,13 @@ def db_with_portfolios(db_with_divisions):
 
     db_with_divisions.commit()
 
+    # Persist the system user so it has a real id — CANHistory event recording needs to look
+    # it up by id, which fails on a transient (unpersisted) User.
+    sys_user = get_or_create_sys_user(db_with_divisions)
+    if sys_user.id is None:
+        db_with_divisions.add(sys_user)
+        db_with_divisions.commit()
+
     yield db_with_divisions
 
     # Cleanup
@@ -116,14 +123,14 @@ def test_validate_data():
     test_data = list(csv.DictReader(open("test_csv/can_invalid.tsv"), dialect="excel-tab"))
     assert len(test_data) == 17
     count = sum(1 for data in test_data if validate_data(create_can_data(data)))
-    assert count == 10
+    assert count == 17
 
 
 def test_validate_all():
     test_data = list(csv.DictReader(open("test_csv/can_invalid.tsv"), dialect="excel-tab"))
     assert len(test_data) == 17
     can_data = [create_can_data(data) for data in test_data]
-    assert validate_all(can_data) is False
+    assert validate_all(can_data) is True
 
 
 def test_create_models_no_can_nbr():
@@ -827,6 +834,227 @@ def test_create_models_fallback_lookup_by_number(db_with_portfolios):
 
     all_cans = db_with_portfolios.execute(select(CAN).where(CAN.number == "G99HRF2")).scalars().all()
     assert len(all_cans) == 1
+
+
+def _make_can_data(**overrides):
+    """Build a fully-populated CANData, with any field overridden by kwargs."""
+    defaults = dict(
+        FISCAL_YEAR=2023,
+        SYS_CAN_ID=500,
+        CAN_NBR="G99HRF2",
+        CAN_DESCRIPTION="Healthy Marriages Responsible Fatherhood - OPRE",
+        FUND="AAXXXX20231DAD",
+        ALLOWANCE="0000000001",
+        ALLOTMENT_ORG="YZC6S1JUGUN",
+        SUB_ALLOWANCE="9KRZ2ND",
+        CURRENT_FY_FUNDING_YTD=880000.0,
+        APPROP_PREFIX="XX",
+        APPROP_POSTFIX="XXXX",
+        APPROP_YEAR="23",
+        PORTFOLIO="HMRF",
+        FUNDING_SOURCE="OPRE",
+        METHOD_OF_TRANSFER="DIRECT",
+        NICK_NAME="HMRF-OPRE",
+        FUNDING_PARTNER="partner 1",
+    )
+    defaults.update(overrides)
+    return CANData(**defaults)
+
+
+def test_create_models_update_preserves_blank_nick_name_and_portfolio(db_with_portfolios):
+    """Blank NICK_NAME/PORTFOLIO on an update leave the existing values untouched."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    create_models(_make_can_data(), sys_user, db_with_portfolios)
+    can = db_with_portfolios.get(CAN, 500)
+    assert can.nick_name == "HMRF-OPRE"
+    original_portfolio_id = can.portfolio_id
+
+    create_models(_make_can_data(NICK_NAME="", PORTFOLIO=""), sys_user, db_with_portfolios)
+    can = db_with_portfolios.get(CAN, 500)
+    assert can.nick_name == "HMRF-OPRE"
+    assert can.portfolio_id == original_portfolio_id
+
+
+def test_create_models_update_preserves_blank_method_of_transfer_and_funding_source(db_with_portfolios):
+    """Blank METHOD_OF_TRANSFER/FUNDING_SOURCE on an update leave the existing funding_details values untouched."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    create_models(_make_can_data(), sys_user, db_with_portfolios)
+
+    create_models(
+        _make_can_data(METHOD_OF_TRANSFER="", FUNDING_SOURCE=""),
+        sys_user,
+        db_with_portfolios,
+    )
+
+    can = db_with_portfolios.get(CAN, 500)
+    assert can.funding_details.method_of_transfer == CANMethodOfTransfer.DIRECT
+    assert can.funding_details.funding_source == CANFundingSource.OPRE
+
+
+def test_create_models_update_preserves_blank_funding_partner(db_with_portfolios):
+    """Blank FUNDING_PARTNER on an update leaves the existing funding_details value untouched."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    create_models(_make_can_data(), sys_user, db_with_portfolios)
+
+    create_models(_make_can_data(FUNDING_PARTNER=""), sys_user, db_with_portfolios)
+
+    can = db_with_portfolios.get(CAN, 500)
+    assert can.funding_details.funding_partner == "partner 1"
+
+
+def test_create_models_new_can_blank_funding_partner_creates_funding_details(db_with_portfolios):
+    """FUNDING_PARTNER is never required — a blank value on a brand-new CAN still creates
+    funding_details, unlike METHOD_OF_TRANSFER/FUNDING_SOURCE."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    create_models(
+        _make_can_data(SYS_CAN_ID=600, CAN_NBR="G99NEW1", FUNDING_PARTNER=""),
+        sys_user,
+        db_with_portfolios,
+    )
+
+    can = db_with_portfolios.get(CAN, 600)
+    assert can is not None
+    assert can.funding_details is not None
+    assert can.funding_details.funding_partner is None
+
+
+def test_create_models_new_can_blank_portfolio_raises(db_with_portfolios):
+    """Creating a brand-new CAN with a blank PORTFOLIO is a hard failure."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    with pytest.raises(ValueError, match="PORTFOLIO is required"):
+        create_models(
+            _make_can_data(SYS_CAN_ID=600, CAN_NBR="G99NEW1", PORTFOLIO=""),
+            sys_user,
+            db_with_portfolios,
+        )
+
+
+def test_create_models_new_can_blank_method_of_transfer_skips_funding_details(db_with_portfolios):
+    """Creating a brand-new CAN with blank METHOD_OF_TRANSFER still creates the CAN, but skips funding_details."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    create_models(
+        _make_can_data(SYS_CAN_ID=600, CAN_NBR="G99NEW1", METHOD_OF_TRANSFER=""),
+        sys_user,
+        db_with_portfolios,
+    )
+
+    can = db_with_portfolios.get(CAN, 600)
+    assert can is not None
+    assert can.number == "G99NEW1"
+    assert can.funding_details is None
+
+
+def test_create_models_new_can_blank_funding_source_skips_funding_details(db_with_portfolios):
+    """Creating a brand-new CAN with blank FUNDING_SOURCE still creates the CAN, but skips funding_details."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    create_models(
+        _make_can_data(SYS_CAN_ID=600, CAN_NBR="G99NEW1", FUNDING_SOURCE=""),
+        sys_user,
+        db_with_portfolios,
+    )
+
+    can = db_with_portfolios.get(CAN, 600)
+    assert can is not None
+    assert can.number == "G99NEW1"
+    assert can.funding_details is None
+
+
+def test_create_models_existing_can_first_funding_details_blank_required_field_skips(db_with_portfolios):
+    """An existing CAN with no prior funding_details still requires METHOD_OF_TRANSFER/FUNDING_SOURCE
+    for its first funding_details record; if blank, funding_details creation is skipped but the CAN
+    itself still updates normally."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+    portfolio = db_with_portfolios.execute(select(Portfolio).where(Portfolio.abbreviation == "HMRF")).scalar()
+
+    bare_can = CAN(
+        id=700,
+        number="G99BARE1",
+        description="Original description",
+        portfolio=portfolio,
+        created_by=sys_user.id,
+        updated_by=sys_user.id,
+    )
+    db_with_portfolios.add(bare_can)
+    db_with_portfolios.commit()
+
+    create_models(
+        _make_can_data(
+            SYS_CAN_ID=700,
+            CAN_NBR="G99BARE1",
+            CAN_DESCRIPTION="Updated description",
+            METHOD_OF_TRANSFER="",
+        ),
+        sys_user,
+        db_with_portfolios,
+    )
+
+    can = db_with_portfolios.get(CAN, 700)
+    assert can.description == "Updated description"
+    assert can.funding_details is None
+
+
+def test_create_models_existing_can_first_funding_details_forces_history_event(db_with_portfolios):
+    """When an existing CAN gets its first-ever funding_details record and no other CAN column
+    changes, an UPDATE_CAN OpsEvent is still recorded."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+    portfolio = db_with_portfolios.execute(select(Portfolio).where(Portfolio.abbreviation == "HMRF")).scalar()
+
+    bare_can = CAN(
+        id=700,
+        number="G99BARE1",
+        description="Healthy Marriages Responsible Fatherhood - OPRE",
+        nick_name="HMRF-OPRE",
+        portfolio=portfolio,
+        created_by=sys_user.id,
+        updated_by=sys_user.id,
+    )
+    db_with_portfolios.add(bare_can)
+    db_with_portfolios.commit()
+
+    create_models(
+        _make_can_data(SYS_CAN_ID=700, CAN_NBR="G99BARE1"),
+        sys_user,
+        db_with_portfolios,
+    )
+
+    can = db_with_portfolios.get(CAN, 700)
+    assert can.funding_details is not None
+
+    update_events = (
+        db_with_portfolios.execute(select(OpsEvent).where(OpsEvent.event_type == OpsEventType.UPDATE_CAN))
+        .scalars()
+        .all()
+    )
+    assert len(update_events) == 1
+    assert update_events[0].event_details["can_updates"]["owner_id"] == 700
+    assert "funding_details.fund_code" in update_events[0].event_details["can_updates"]["changes"]
+
+
+def test_create_models_update_bad_portfolio_hard_fails(db_with_portfolios):
+    """A mistyped PORTFOLIO abbreviation on an update still hard-fails the batch."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    create_models(_make_can_data(), sys_user, db_with_portfolios)
+
+    with pytest.raises(ValueError, match="Portfolio not found"):
+        create_models(_make_can_data(PORTFOLIO="BOGUS"), sys_user, db_with_portfolios)
+
+
+def test_create_models_update_bad_method_of_transfer_hard_fails(db_with_portfolios):
+    """A mistyped METHOD_OF_TRANSFER on an update still hard-fails the batch."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    create_models(_make_can_data(), sys_user, db_with_portfolios)
+
+    with pytest.raises(KeyError):
+        create_models(_make_can_data(METHOD_OF_TRANSFER="BOGUS"), sys_user, db_with_portfolios)
 
 
 @pytest.mark.skip(reason="Need to update the test data")

--- a/backend/data_tools/tests/load_cans/test_load_cans.py
+++ b/backend/data_tools/tests/load_cans/test_load_cans.py
@@ -133,6 +133,21 @@ def test_validate_all():
     assert validate_all(can_data) is True
 
 
+def test_validate_data_requires_portfolio_when_sys_can_id_blank():
+    """A row with no SYS_CAN_ID can only create a brand-new CAN, so PORTFOLIO must be present at
+    validation time — a batch with such a row should fail atomically before any row is processed,
+    rather than partway through after preceding rows have already been committed."""
+    data = CANData(FISCAL_YEAR=2023, CAN_NBR="G99NEW1", FUND="AAXXXX20231DAD", PORTFOLIO=None)
+    assert validate_data(data) is False
+
+
+def test_validate_data_allows_blank_portfolio_when_sys_can_id_present():
+    """A row with a SYS_CAN_ID may be updating an existing CAN, where a blank PORTFOLIO is
+    legitimate (the existing portfolio is left untouched) — validate_data should not reject it."""
+    data = CANData(FISCAL_YEAR=2023, SYS_CAN_ID=500, CAN_NBR="G99HRF2", FUND="AAXXXX20231DAD", PORTFOLIO=None)
+    assert validate_data(data) is True
+
+
 def test_create_models_no_can_nbr():
     with pytest.raises(ValueError):
         CANData(

--- a/backend/data_tools/tests/load_cans/test_load_cans.py
+++ b/backend/data_tools/tests/load_cans/test_load_cans.py
@@ -876,6 +876,40 @@ def test_create_models_update_preserves_blank_nick_name_and_portfolio(db_with_po
     assert can.portfolio_id == original_portfolio_id
 
 
+def test_create_models_update_portfolio_change_records_history(db_with_portfolios):
+    """Changing PORTFOLIO on an update persists the new portfolio and records a matching
+    OpsEvent/CANHistory row — the diff must not read the CAN's portfolio_id FK before flush,
+    which would still show the old value and silently drop the change from the event."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    create_models(_make_can_data(), sys_user, db_with_portfolios)
+    can = db_with_portfolios.get(CAN, 500)
+    original_portfolio_id = can.portfolio_id
+
+    create_models(_make_can_data(PORTFOLIO="CC"), sys_user, db_with_portfolios)
+
+    can = db_with_portfolios.get(CAN, 500)
+    new_portfolio = db_with_portfolios.execute(select(Portfolio).where(Portfolio.abbreviation == "CC")).scalar()
+    assert can.portfolio_id == new_portfolio.id
+    assert can.portfolio_id != original_portfolio_id
+
+    update_events = (
+        db_with_portfolios.execute(select(OpsEvent).where(OpsEvent.event_type == OpsEventType.UPDATE_CAN))
+        .scalars()
+        .all()
+    )
+    assert len(update_events) == 1
+    changes = update_events[0].event_details["can_updates"]["changes"]
+    assert changes["portfolio_id"] == {"old_value": original_portfolio_id, "new_value": new_portfolio.id}
+
+    history_events = (
+        db_with_portfolios.execute(select(CANHistory).where(CANHistory.ops_event_id == update_events[0].id))
+        .scalars()
+        .all()
+    )
+    assert any(e.history_type == CANHistoryType.CAN_PORTFOLIO_EDITED for e in history_events)
+
+
 def test_create_models_update_preserves_blank_method_of_transfer_and_funding_source(db_with_portfolios):
     """Blank METHOD_OF_TRANSFER/FUNDING_SOURCE on an update leave the existing funding_details values untouched."""
     sys_user = get_or_create_sys_user(db_with_portfolios)
@@ -1035,6 +1069,44 @@ def test_create_models_existing_can_first_funding_details_forces_history_event(d
     assert len(update_events) == 1
     assert update_events[0].event_details["can_updates"]["owner_id"] == 700
     assert "funding_details.fund_code" in update_events[0].event_details["can_updates"]["changes"]
+
+
+def test_create_models_update_method_of_transfer_and_funding_source_records_history(db_with_portfolios):
+    """Changing METHOD_OF_TRANSFER/FUNDING_SOURCE on an update stores the new/old enum values as
+    their `.name` strings (not enum reprs) in the OpsEvent, and produces a matching CANHistory row."""
+    sys_user = get_or_create_sys_user(db_with_portfolios)
+
+    create_models(_make_can_data(), sys_user, db_with_portfolios)
+
+    create_models(
+        _make_can_data(METHOD_OF_TRANSFER="IAA", FUNDING_SOURCE="ACF"),
+        sys_user,
+        db_with_portfolios,
+    )
+
+    can = db_with_portfolios.get(CAN, 500)
+    assert can.funding_details.method_of_transfer == CANMethodOfTransfer.IAA
+    assert can.funding_details.funding_source == CANFundingSource.ACF
+
+    update_events = (
+        db_with_portfolios.execute(select(OpsEvent).where(OpsEvent.event_type == OpsEventType.UPDATE_CAN))
+        .scalars()
+        .all()
+    )
+    assert len(update_events) == 1
+    changes = update_events[0].event_details["can_updates"]["changes"]
+    assert changes["funding_details.method_of_transfer"] == {"old_value": "DIRECT", "new_value": "IAA"}
+    assert changes["funding_details.funding_source"] == {"old_value": "OPRE", "new_value": "ACF"}
+
+    history_events = (
+        db_with_portfolios.execute(select(CANHistory).where(CANHistory.ops_event_id == update_events[0].id))
+        .scalars()
+        .all()
+    )
+    method_event = next(e for e in history_events if "method of transfer" in e.history_message)
+    assert method_event.history_type == CANHistoryType.CAN_FUNDING_DETAILS_EDITED
+    assert "DIRECT" in method_event.history_message
+    assert "IAA" in method_event.history_message
 
 
 def test_create_models_update_bad_portfolio_hard_fails(db_with_portfolios):

--- a/backend/models/can_history.py
+++ b/backend/models/can_history.py
@@ -30,6 +30,7 @@ class CANHistoryType(Enum):
     CAN_DIVISION_DELETED = auto()
     CAN_DIVISION_EDITED = auto()
     CAN_CARRY_FORWARD_CALCULATED = auto()
+    CAN_FUNDING_DETAILS_EDITED = auto()  # CANFundingDetails
 
 
 class CANHistory(BaseModel):
@@ -41,9 +42,7 @@ class CANHistory(BaseModel):
     history_title: Mapped[str]
     history_message: Mapped[str] = mapped_column(Text)
     timestamp: Mapped[str]
-    history_type: Mapped[CANHistoryType] = mapped_column(
-        ENUM(CANHistoryType), nullable=True
-    )
+    history_type: Mapped[CANHistoryType] = mapped_column(ENUM(CANHistoryType), nullable=True)
     fiscal_year: Mapped[int]
 
 
@@ -72,7 +71,7 @@ def can_history_trigger_func(
                 history_message=f"FY {current_fiscal_year} CAN Funding Information imported from CANBACs",
                 timestamp=event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 history_type=CANHistoryType.CAN_DATA_IMPORT,
-                fiscal_year = current_fiscal_year
+                fiscal_year=current_fiscal_year,
             )
             history_events.append(history_event)
         case OpsEventType.UPDATE_CAN:
@@ -88,7 +87,7 @@ def can_history_trigger_func(
                     event.event_details["can_updates"]["owner_id"],
                     event.id,
                     session,
-                    system_user
+                    system_user,
                 )
                 history_events.extend(history_items)
         case OpsEventType.CREATE_CAN_FUNDING_BUDGET:
@@ -102,7 +101,7 @@ def can_history_trigger_func(
                 history_message=f"{creator_name} entered a FY {current_fiscal_year} budget of {budget}",
                 timestamp=event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 history_type=CANHistoryType.CAN_FUNDING_CREATED,
-                fiscal_year=current_fiscal_year
+                fiscal_year=current_fiscal_year,
             )
             history_events.append(history_event)
         case OpsEventType.UPDATE_CAN_FUNDING_BUDGET:
@@ -120,7 +119,7 @@ def can_history_trigger_func(
                     history_message=f"{event_user.full_name} edited the FY {current_fiscal_year} budget from {old_budget} to {new_budget}",
                     timestamp=event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     history_type=CANHistoryType.CAN_FUNDING_EDITED,
-                    fiscal_year=current_fiscal_year
+                    fiscal_year=current_fiscal_year,
                 )
                 history_events.append(history_event)
         case OpsEventType.CREATE_CAN_FUNDING_RECEIVED:
@@ -134,7 +133,7 @@ def can_history_trigger_func(
                 history_message=f"{creator_name} added funding received to funding ID {event.event_details['new_can_funding_received']['id']} in the amount of {funding}",
                 timestamp=event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 history_type=CANHistoryType.CAN_RECEIVED_CREATED,
-                fiscal_year=current_fiscal_year
+                fiscal_year=current_fiscal_year,
             )
             history_events.append(history_event)
         case OpsEventType.UPDATE_CAN_FUNDING_RECEIVED:
@@ -151,7 +150,7 @@ def can_history_trigger_func(
                     history_message=f"{event_user.full_name} edited funding received for funding ID {event.event_details['funding_received_updates']['funding_id']} from {old_funding} to {new_funding}",
                     timestamp=event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     history_type=CANHistoryType.CAN_RECEIVED_EDITED,
-                    fiscal_year=current_fiscal_year
+                    fiscal_year=current_fiscal_year,
                 )
                 history_events.append(history_event)
         case OpsEventType.DELETE_CAN_FUNDING_RECEIVED:
@@ -165,7 +164,7 @@ def can_history_trigger_func(
                 history_message=f"{creator_name} deleted funding received for funding ID {event.event_details['deleted_can_funding_received']['id']} in the amount of {funding}",
                 timestamp=event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                 history_type=CANHistoryType.CAN_RECEIVED_DELETED,
-                fiscal_year=current_fiscal_year
+                fiscal_year=current_fiscal_year,
             )
             history_events.append(history_event)
     add_history_events(history_events, session)
@@ -203,67 +202,112 @@ def create_can_update_history_event(
     event_history = []
     match property_name:
         case "nick_name":
-            event_history.append(CANHistory(
-                can_id=can_id,
-                ops_event_id=ops_event_id,
-                history_title="Nickname Edited",
-                history_message=f"Nickname changed from {old_value} to {new_value} during FY {current_fiscal_year} data import" if updated_by_sys_user else f"{updated_by_user.full_name} edited the nickname from {old_value} to {new_value}",
-                timestamp=updated_on,
-                history_type=CANHistoryType.CAN_NICKNAME_EDITED,
-                fiscal_year=current_fiscal_year
-            ))
+            event_history.append(
+                CANHistory(
+                    can_id=can_id,
+                    ops_event_id=ops_event_id,
+                    history_title="Nickname Edited",
+                    history_message=(
+                        f"Nickname changed from {old_value} to {new_value} during FY {current_fiscal_year} data import"
+                        if updated_by_sys_user
+                        else f"{updated_by_user.full_name} edited the nickname from {old_value} to {new_value}"
+                    ),
+                    timestamp=updated_on,
+                    history_type=CANHistoryType.CAN_NICKNAME_EDITED,
+                    fiscal_year=current_fiscal_year,
+                )
+            )
         case "description":
-            event_history.append(CANHistory(
-                can_id=can_id,
-                ops_event_id=ops_event_id,
-                history_title="Description Edited",
-                history_message=f"{updated_by_user.full_name} edited the description",
-                timestamp=updated_on,
-                history_type=CANHistoryType.CAN_DESCRIPTION_EDITED,
-                fiscal_year=current_fiscal_year
-            ))
+            event_history.append(
+                CANHistory(
+                    can_id=can_id,
+                    ops_event_id=ops_event_id,
+                    history_title="Description Edited",
+                    history_message=f"{updated_by_user.full_name} edited the description",
+                    timestamp=updated_on,
+                    history_type=CANHistoryType.CAN_DESCRIPTION_EDITED,
+                    fiscal_year=current_fiscal_year,
+                )
+            )
         case "portfolio_id":
             old_portfolio = session.get(Portfolio, old_value)
             new_portfolio = session.get(Portfolio, new_value)
-            event_history.append(CANHistory(
-                can_id=can_id,
-                ops_event_id=ops_event_id,
-                history_title="CAN Portfolio Edited",
-                history_message=f"CAN portfolio changed from {old_portfolio.name} to {new_portfolio.name} during FY {current_fiscal_year} data import" if updated_by_sys_user else f"{updated_by_user.full_name} changed the portfolio from {old_portfolio.name} to {new_portfolio.name}",
-                timestamp=updated_on,
-                history_type=CANHistoryType.CAN_PORTFOLIO_EDITED,
-                fiscal_year=current_fiscal_year
-            ))
+            event_history.append(
+                CANHistory(
+                    can_id=can_id,
+                    ops_event_id=ops_event_id,
+                    history_title="CAN Portfolio Edited",
+                    history_message=(
+                        f"CAN portfolio changed from {old_portfolio.name} to {new_portfolio.name} during FY {current_fiscal_year} data import"
+                        if updated_by_sys_user
+                        else f"{updated_by_user.full_name} changed the portfolio from {old_portfolio.name} to {new_portfolio.name}"
+                    ),
+                    timestamp=updated_on,
+                    history_type=CANHistoryType.CAN_PORTFOLIO_EDITED,
+                    fiscal_year=current_fiscal_year,
+                )
+            )
             if old_portfolio.division_id != new_portfolio.division_id:
-                event_history.append(CANHistory(
-                can_id=can_id,
-                ops_event_id=ops_event_id,
-                history_title="CAN Division Edited",
-                history_message=f"CAN division changed from {old_portfolio.division.name} to {new_portfolio.division.name} during FY {current_fiscal_year} data import" if updated_by_sys_user else f"{updated_by_user.full_name} changed the division from {old_portfolio.division.name} to {new_portfolio.division.name}",
-                timestamp=updated_on,
-                history_type=CANHistoryType.CAN_DIVISION_EDITED,
-                fiscal_year=current_fiscal_year
-            ))
+                event_history.append(
+                    CANHistory(
+                        can_id=can_id,
+                        ops_event_id=ops_event_id,
+                        history_title="CAN Division Edited",
+                        history_message=(
+                            f"CAN division changed from {old_portfolio.division.name} to {new_portfolio.division.name} during FY {current_fiscal_year} data import"
+                            if updated_by_sys_user
+                            else f"{updated_by_user.full_name} changed the division from {old_portfolio.division.name} to {new_portfolio.division.name}"
+                        ),
+                        timestamp=updated_on,
+                        history_type=CANHistoryType.CAN_DIVISION_EDITED,
+                        fiscal_year=current_fiscal_year,
+                    )
+                )
+        case str() as name if name.startswith("funding_details."):
+            field_label = name.removeprefix("funding_details.").replace("_", " ")
+            event_history.append(
+                CANHistory(
+                    can_id=can_id,
+                    ops_event_id=ops_event_id,
+                    history_title="Funding Details Edited",
+                    history_message=(
+                        f"Funding details {field_label} changed from {old_value} to {new_value} during FY {current_fiscal_year} data import"
+                        if updated_by_sys_user
+                        else f"{updated_by_user.full_name} edited the funding details {field_label} from {old_value} to {new_value}"
+                    ),
+                    timestamp=updated_on,
+                    history_type=CANHistoryType.CAN_FUNDING_DETAILS_EDITED,
+                    fiscal_year=current_fiscal_year,
+                )
+            )
         case _:
             logger.info(f"{property_name} edited by {updated_by_user.full_name} from {old_value} to {new_value}")
 
     return event_history
 
+
 def add_history_events(events: List[CANHistory], session):
-    '''Add a list of CANHistory events to the database session. First check that there are not any matching events already in the database to prevent duplicates.'''
+    """Add a list of CANHistory events to the database session. First check that there are not any matching events already in the database to prevent duplicates."""
     for event in events:
         # Query the database for existing events
         can_history_items = session.query(CANHistory).where(CANHistory.ops_event_id == event.ops_event_id).all()
 
         # Also check pending objects in the session that haven't been flushed yet
-        pending_items = [obj for obj in session.new if isinstance(obj, CANHistory) and obj.ops_event_id == event.ops_event_id]
+        pending_items = [
+            obj for obj in session.new if isinstance(obj, CANHistory) and obj.ops_event_id == event.ops_event_id
+        ]
 
         # Combine both database and pending items
         all_items = can_history_items + pending_items
 
         duplicate_found = False
         for item in all_items:
-            if item.timestamp == event.timestamp and item.history_type == event.history_type and item.history_message == event.history_message and item.fiscal_year == event.fiscal_year:
+            if (
+                item.timestamp == event.timestamp
+                and item.history_type == event.history_type
+                and item.history_message == event.history_message
+                and item.fiscal_year == event.fiscal_year
+            ):
                 # enough fields match that we're willing to say this is a duplicate.
                 duplicate_found = True
                 break

--- a/backend/ops_api/tests/ops/can_history/test_can_history.py
+++ b/backend/ops_api/tests/ops/can_history/test_can_history.py
@@ -334,6 +334,31 @@ def test_update_can_can_history(loaded_db, app_ctx):
     assert description_can_history_event.fiscal_year == 2025
 
 
+def test_update_can_funding_details_can_history(loaded_db, app_ctx):
+    update_can_event = loaded_db.get(OpsEvent, 75)
+    can_history_trigger(update_can_event, loaded_db)
+    loaded_db.flush()  # Ensure items are visible to queries
+    can_update_history_events = (
+        loaded_db.execute(select(CANHistory).where(CANHistory.ops_event_id == 75)).scalars().all()
+    )
+    assert len(can_update_history_events) == 2
+
+    appropriation_event = next(e for e in can_update_history_events if "appropriation" in e.history_message)
+    assert appropriation_event.history_title == "Funding Details Edited"
+    assert (
+        appropriation_event.history_message
+        == "Steve Tekell edited the funding details appropriation from 75-25-1512 to 75-2529-1512"
+    )
+    assert appropriation_event.history_type == CANHistoryType.CAN_FUNDING_DETAILS_EDITED
+    assert appropriation_event.fiscal_year == 2026
+
+    fiscal_year_event = next(e for e in can_update_history_events if "fiscal year" in e.history_message)
+    assert fiscal_year_event.history_title == "Funding Details Edited"
+    assert fiscal_year_event.history_message == "Steve Tekell edited the funding details fiscal year from 2025 to 2026"
+    assert fiscal_year_event.history_type == CANHistoryType.CAN_FUNDING_DETAILS_EDITED
+    assert fiscal_year_event.fiscal_year == 2026
+
+
 def test_update_can_funding_budget_can_history(loaded_db, app_ctx):
     update_can_event = loaded_db.get(OpsEvent, 22)
     can_history_trigger(update_can_event, loaded_db)


### PR DESCRIPTION
## What changed

This PR fixes two related gaps in CAN loading/history for the CANBACs re-import of existing CANs: overly strict validation was rejecting update rows that legitimately omit fields, and funding_details changes weren't generating audit history at all. These changes essentially allow for more freedom to use the same script on the larger CANBACs file that updates existing OPS rows (although at run time you still have to exclude it from creating new ones) as well as a smaller file that the BT will provide that has extra OPS-specific attributes for creating new CANs. 🥫 🦄 


**`backend/data_tools/src/load_cans/utils.py`** — refactored `create_models`/`get_or_create_funding_details` so `PORTFOLIO`, `METHOD_OF_TRANSFER`, and `FUNDING_SOURCE` are only hard-required when creating a brand-new CAN. On an update, a blank value for any of these (plus `NICK_NAME`/`FUNDING_PARTNER`) now leaves the CAN's existing value untouched instead of failing the row. `validate_data`/`validate_all` no longer duplicate this at the row-validation layer, since the requirement is now conditional on create-vs-update rather than universal. Split the function into focused helpers (`_find_existing_can`, `_resolve_portfolio`, `_diff_values`, `_update_can_fields`, `_capture_funding_details_values`, `_track_funding_details_changes`, `_record_can_event`) to keep the create/update/diff logic readable. Also fixes a bug (caught during review) where a portfolio/division change was persisted to the CAN but silently dropped from the change-tracking dict — because the diff read `can.portfolio_id` (unpopulated until flush) instead of the resolved `Portfolio.id` — so portfolio moves produced no `OpsEvent`/`CANHistory` audit trail.

**`backend/models/can_history.py`** — adds `CANHistoryType.CAN_FUNDING_DETAILS_EDITED` and a new match-case branch in `create_can_update_history_event` so `funding_details.*` change keys (fiscal_year, fund_code, allowance, appropriation, method_of_transfer, funding_source, etc.) actually generate a `CANHistory` row instead of being silently logged and dropped. Includes the corresponding Alembic migration to add the enum value.

**`backend/data_tools/src/backfill_can_funding_details_history.py`** (new) — a one-time script to backfill `CANHistory` rows for `UPDATE_CAN` `OpsEvent`s that already have correct `funding_details.*` changes recorded (from a prior production load) but no matching history row, because `CAN_FUNDING_DETAILS_EDITED` didn't exist yet. Supports `DRY_RUN=1` to preview without committing. Safe to re-run — relies on `add_history_events`'s existing de-dup logic.

**Tests** — added coverage in `backend/data_tools/tests/load_cans/test_load_cans.py` for the full blank/required-field matrix on create vs. update (including the portfolio-diff fix and enum serialization of `method_of_transfer`/`funding_source` in the resulting `OpsEvent`), a new `test_update_can_funding_details_can_history` in `backend/ops_api/tests/ops/can_history/test_can_history.py`, and a new `backend/data_tools/tests/backfill_can_funding_details_history/` suite covering the backfill script's query filter, idempotency, non-interference with unrelated history, and `DRY_RUN` behavior.

I'm also suggesting the `db-migration` repo CC skill be enabled for the model to auto-invoke it, particularly since the description of the skill implies it should be so and because I can't think of a reason not to. 😃 

## Issue

#6052

## How to test

Backend/data-tools only — no UI changes.

```bash
cd backend/data_tools
pipenv run pytest tests/load_cans/ tests/backfill_can_funding_details_history/ -v

cd backend/ops_api
pipenv run pytest tests/ops/can_history/ -v
```

Also run the full suites to confirm no regressions:

```bash
cd backend/data_tools && pipenv run pytest
cd backend/ops_api && pipenv run pytest
```

The new `backfill_can_funding_details_history.py` script itself is a one-time operational cleanup for existing production data (not part of the normal load path) — it doesn't need to be run as part of this review; its behavior is covered by the new test suite.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] No UI component changes in this PR

## Screenshots

N/A — backend changes only

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
~- [ ] Form validations updated~

## Links

N/A