### PR TITLE
add useBlocker regression-test and issue-video Claude skills

### DIFF
--- a/.claude/skills/useblocker-bypass-regression-test/SKILL.md
+++ b/.claude/skills/useblocker-bypass-regression-test/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: useblocker-bypass-regression-test
+description: Use when writing a Vitest test for a react-router useBlocker unsaved-changes guard in this repo — specifically an intentional-navigation handler (Edit / Submit / Cancel) that uses flushSync(() => setIsNavigating(true)) before navigate() to bypass the blocker. A test that reads the blocker predicate after act() passes even when flushSync is removed, so it does not guard the fix. Trigger on any test touching isNavigating, useBlocker, flushSync, or a *.hooks.js navigation-blocker handler.
+---
+
+# useBlocker Bypass Regression Test
+
+## Overview
+
+Several `*.hooks.js` files in this repo (`RequestPreAwardApproval`, `ApprovePreAwardApproval`, `ReviewBudgetTeamRequisition`, award-approval siblings) register a react-router `useBlocker` unsaved-changes guard:
+
+```js
+const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+        !isNavigating && hasChanged && currentLocation.pathname !== nextLocation.pathname
+);
+```
+
+An *intentional* navigation (Edit / Submit / Cancel) must slip past this guard. The pattern is always:
+
+```js
+flushSync(() => { setIsNavigating(true); });   // <-- load-bearing
+navigate(`/somewhere`);
+```
+
+**Core principle:** `flushSync` is the load-bearing line, and the obvious unit test does not guard it. react-router evaluates the blocker predicate **synchronously** at the instant `navigate()` fires on a forward push. A plain `setIsNavigating(true)` batches the state update, so the predicate that runs during `navigate()` is still closed over `isNavigating === false` and blocks — reintroducing the bug. `flushSync` forces the commit (and blocker re-registration) *before* `navigate()`. A test must therefore assert the predicate's value **at navigate-time**, not after `act()` settles.
+
+## The trap (why the obvious test is false confidence)
+
+The natural test reads the captured predicate *after* the handler runs:
+
+```js
+act(() => { result.current.handleEdit(); });
+expect(capturedCb(nav)).toBe(false);   // ❌ passes with OR without flushSync
+```
+
+This passes even against a mutant where `flushSync(...)` is replaced by a plain `setIsNavigating(true)`. Two reasons, both verified by mutation testing in this repo:
+
+1. **`useBlocker` is mocked.** The mock just captures the predicate; react-router's real synchronous re-check during a forward push — the exact thing `flushSync` protects — never runs.
+2. **`act()` masks the timing.** `act()` flushes all pending state before returning, so by the time you call `capturedCb(nav)` the batched `setIsNavigating(true)` has already committed. The stale-vs-fresh distinction is gone.
+
+Result: dropping `flushSync` reintroduces the production bug with a fully green suite. The regression test for the bug does not protect the line the fix is made of.
+
+## The technique: evaluate the predicate at navigate-time
+
+Reproduce react-router's synchronous behavior by evaluating the currently-registered predicate **inside the `navigate` mock** — the moment `navigate()` is called:
+
+```js
+it("does not block at the instant navigate() fires (guards flushSync)", async () => {
+    let capturedCb;
+    // mockImplementation re-captures the predicate on EVERY render, so capturedCb
+    // always points at the latest closure over isNavigating.
+    mockUseBlocker.mockImplementation((cb) => {
+        capturedCb = cb;
+        return { state: "unblocked", proceed: mockProceed, reset: mockReset };
+    });
+    const { result } = setup(buildAgreement());
+    await waitFor(() => expect(result.current).toBeDefined());
+
+    // Dirty the form so the guard WOULD fire on navigation.
+    act(() => { result.current.setNotes("some note"); });
+
+    const nav = {
+        currentLocation: { pathname: "/agreements/1/pre-award-approval" },
+        nextLocation: { pathname: "/agreements/review/1/edit" }
+    };
+    await waitFor(() => expect(capturedCb(nav)).toBe(true)); // sanity: blocks before edit
+
+    // Capture the predicate's value at the exact moment navigate() runs — this is
+    // what react-router does synchronously on a real forward push.
+    let blockedAtNavigateTime;
+    navigateMock.mockImplementation(() => {
+        blockedAtNavigateTime = capturedCb(nav);
+    });
+
+    act(() => { result.current.handleEdit(); });
+
+    // With flushSync -> false (bypass committed before navigate). Without -> true (bug).
+    expect(blockedAtNavigateTime).toBe(false);
+    expect(navigateMock).toHaveBeenCalledWith(
+        "/agreements/review/1/edit?returnTo=%2Fagreements%2F1%2Fpre-award-approval"
+    );
+});
+```
+
+Requires a **module-level stable `navigateMock`** (not `useNavigate: () => vi.fn()`, which returns a throwaway) so `mockImplementation` and URL assertions work. `beforeEach` must `vi.clearAllMocks()`.
+
+## Verify it actually guards (mutation test)
+
+A bypass test that you have not mutation-tested is presumed to be the trap above. Confirm it fails against the mutant:
+
+1. In the handler, replace `flushSync(() => { setIsNavigating(true); });` with a plain `setIsNavigating(true);`.
+2. Run the test — it MUST fail (`expected true to be false` at `blockedAtNavigateTime`).
+3. Run the existing hook suite — it will still pass (that is the coverage gap this test closes).
+4. Restore the handler (`git checkout` the file).
+
+If the test still passes against the mutant, it is the after-`act()` trap — rewrite it to evaluate inside the `navigate` mock.
+
+## Quick Reference
+
+| Assertion site | Catches `flushSync` removal? |
+|---|---|
+| `capturedCb(nav)` after `act()` | ❌ No — `act()` already flushed the batched setState |
+| `capturedCb(nav)` inside `navigateMock.mockImplementation` | ✅ Yes — reads the predicate at navigate-time |
+| `navigate` called with encoded URL | ❌ No (guards the URL, not the timing) |
+| bypass-flag exists at all (remove `setIsNavigating` → fail) | Partial — guards the flag, not `flushSync` |
+
+## Scope and honest limits
+
+- This is the strongest guard achievable at the **hook-unit** layer, where `useBlocker`/`navigate` are mocked. It models — does not exercise — a real react-router transition.
+- A fully faithful guarantee needs an integration test with a real `MemoryRouter`/`createMemoryRouter`, a real blocker, and real routes. **There is no such test in this repo** — every blocker test mocks `useBlocker` (see `src/hooks/useNavigationBlocker.test.js`, `useUnsavedChangesBlocker.test.js`). Don't introduce that machinery for one line unless asked; the navigate-time unit test is the idiomatic choice here.
+- If you keep only the after-`act()` assertion (e.g. matching a sibling test's style), add a one-line comment stating it guards the bypass-flag contract and URL but **not** the `flushSync` timing — so the next reader isn't misled. Don't write a comment claiming it verifies `flushSync` when it doesn't.
+
+## Common Mistakes
+
+- **Asserting `capturedCb(nav) === false` after `act()` and calling it done.** That is the trap — mutation-test it and watch it pass against the mutant.
+- **Using `useNavigate: () => vi.fn()`.** Returns a fresh mock each call; you can't attach `mockImplementation` or assert the URL. Hoist a module-level `navigateMock`.
+- **Comment claims flushSync is verified when it isn't.** A comment saying "flips the bypass (flushSync)" on an after-`act()` test overstates coverage. State what the test actually guards.
+- **Reaching for a full real-router harness by default.** Non-idiomatic here and heavy for one line. Only do it if explicitly asked.
+
+## Real-World Impact
+
+On issue 6061 (Edit button wrongly showing the cancel modal), the fix added `handleEdit` with `flushSync(() => setIsNavigating(true))`. Adversarial review mutation-tested the new hook test: replacing `flushSync` with a plain `setIsNavigating(true)` left all 14 hook tests green — the regression test for the bug did not protect the fix's load-bearing line. The navigate-time technique above fails against that mutant, closing the gap. See [dead-code-after-removal-sweep](../dead-code-after-removal-sweep/SKILL.md) for the sibling "verify with a mutation" discipline applied to deletions.

--- a/.claude/skills/useblocker-bypass-regression-test/SKILL.md
+++ b/.claude/skills/useblocker-bypass-regression-test/SKILL.md
@@ -108,7 +108,7 @@ If the test still passes against the mutant, it is the after-`act()` trap — re
 ## Scope and honest limits
 
 - This is the strongest guard achievable at the **hook-unit** layer, where `useBlocker`/`navigate` are mocked. It models — does not exercise — a real react-router transition.
-- A fully faithful guarantee needs an integration test with a real `MemoryRouter`/`createMemoryRouter`, a real blocker, and real routes. **There is no such test in this repo** — every blocker test mocks `useBlocker` (see `src/hooks/useNavigationBlocker.test.js`, `useUnsavedChangesBlocker.test.js`). Don't introduce that machinery for one line unless asked; the navigate-time unit test is the idiomatic choice here.
+- A fully faithful guarantee needs an integration test with a real `MemoryRouter`/`createMemoryRouter`, a real blocker, and real routes. **There is no such test in this repo** — every blocker test mocks `useBlocker` (see `frontend/src/hooks/useNavigationBlocker.test.js`, `frontend/src/hooks/useUnsavedChangesBlocker.test.js`). Don't introduce that machinery for one line unless asked; the navigate-time unit test is the idiomatic choice here.
 - If you keep only the after-`act()` assertion (e.g. matching a sibling test's style), add a one-line comment stating it guards the bypass-flag contract and URL but **not** the `flushSync` timing — so the next reader isn't misled. Don't write a comment claiming it verifies `flushSync` when it doesn't.
 
 ## Common Mistakes

--- a/.claude/skills/watching-issue-video-recordings/SKILL.md
+++ b/.claude/skills/watching-issue-video-recordings/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: watching-issue-video-recordings
+description: Use when a GitHub issue, PR, or bug report links a screen-recording video (github.com/user-attachments/assets/... .mov/.mp4/.webm) and you need to know what it shows. You cannot view video in context — this extracts still frames to a temp dir so you can Read them as images. Trigger whenever a task references a video/screen recording/attachment demonstrating a bug, or when text says "see the recording"/"linked video".
+---
+
+# Watching Issue Video Recordings
+
+## Overview
+
+Issues often attach a screen recording as the clearest record of a bug. You cannot watch video in context, but you can Read image frames. This skill extracts frames from a video (a GitHub attachment URL or local file) into a temp workspace, then reads them.
+
+**Core principle:** Do it autonomously and without polluting the repo, then interpret the frames *against the issue's written words* — never from the frames alone. Sparse frames drop the causal step (a click and the UI it triggers land between samples), so a frames-only reading is a guess. The written repro steps are ground truth for what action was taken; the frames show the result.
+
+## Workflow
+
+Copy this checklist and track progress:
+
+```
+- [ ] 1. Read the issue text FIRST (title, body, repro steps, expected vs actual)
+- [ ] 2. Extract frames with the script (2 fps whole-clip pass)
+- [ ] 3. Read the frames; map each to a repro step
+- [ ] 4. If a transition is ambiguous, zoom-extract that window (10 fps)
+- [ ] 5. Reconcile: does my reading match the written repro? If not, resolve before concluding
+- [ ] 6. Report frame-by-frame; clean up the temp workspace
+```
+
+**Step 1 — Read the issue text first.** Get the title, body, numbered repro steps, and expected-vs-actual. This tells you what page and what action to expect. Do NOT skip this — it is what keeps step 5 honest.
+
+**Step 2 — Extract frames.** Run the bundled script (it installs ffmpeg if missing on macOS, downloads to a `mktemp -d` dir OUTSIDE the repo, prompts for nothing):
+
+```bash
+.claude/skills/watching-issue-video-recordings/scripts/extract-frames.sh <url-or-path> [fps] [start] [duration]
+```
+
+For a GitHub attachment, pass the `github.com/user-attachments/assets/<uuid>` URL verbatim. Default 2 fps is right for a first pass. The script prints `WORKSPACE=`, `META:`, `FRAMES=`, then one absolute frame path per line.
+
+**Step 3 — Read the frames.** Read the printed frame paths as images (batch several Read calls). Note the URL bar, visible controls, form field contents, cursor position, and any modal.
+
+**Step 4 — Zoom on ambiguity.** If you can't tell *which control was clicked* or *what triggered a modal*, re-run over just that window at high fps — e.g. `... 10 1.5 1.5` samples 10 fps from 1.5s for 1.5s. The click and its effect are usually 1–2 frames apart; 2 fps can merge them.
+
+**Step 5 — Reconcile with the text (the load-bearing step).** State what you think happened, then check it against the repro steps from step 1. If the recording seems to show something the text doesn't describe (e.g. "the button does nothing" when the issue says "clicking X shows the wrong modal"), you are probably misreading a merged transition — zoom in (step 4) before concluding. A confident frames-only narrative that contradicts the written steps is the most common failure of this task.
+
+**Step 6 — Report and clean up.** Give a concise frame-by-frame account tied to timestamps/steps. Then remove the workspace by its literal path: `rm -rf <the WORKSPACE path the script printed>`. Do not glob-delete other temp dirs — unrelated `issue-video.*` dirs from other sessions may exist; leave any you did not create.
+
+## Hard constraints
+
+- **Never write into the repo working directory.** The script uses `mktemp -d` under the system temp dir. If you extract manually, do the same — a downloaded `.mov` or a `frames/` dir committed to the repo is a defect.
+- **Fully autonomous.** No prompts, no "where should I save this?", no auth. GitHub user-attachment URLs are public and need no token; `curl -L` follows the redirect to blob storage.
+- **Verify the repo stayed clean** with `git status --porcelain` before reporting done.
+
+## Quick Reference
+
+| Need | Command |
+|---|---|
+| First pass, whole clip | `extract-frames.sh <url> ` (2 fps default) |
+| Zoom a transition (2s–3.5s) | `extract-frames.sh <url> 10 2 1.5` |
+| Local file instead of URL | `extract-frames.sh /path/to/clip.mov` |
+| Clean up | `rm -rf <WORKSPACE printed by the script>` |
+
+## Common Mistakes
+
+- **Concluding from frames alone.** The frames show state; the issue text says what action produced it. Read the text first (step 1) and reconcile (step 5). This is the failure that produced a confidently-wrong bug interpretation in baseline testing.
+- **Sampling too sparsely and merging a click with its result.** At 2 fps a click and the modal it opens can be adjacent frames or the click frame is skipped entirely — so it looks like the modal "just appeared" or the click "did nothing." Zoom to 10 fps on the transition.
+- **Downloading into the repo.** Polluting the working tree. Always use the temp workspace; the script enforces it.
+- **Stopping to ask where to save / for credentials.** Not needed — public attachment, temp dir. Run to completion.
+- **Trusting the modal's copy over the trigger.** A dialog reading "Are you sure you want to cancel?" does not prove the user clicked *Cancel* — a nav guard can raise the same modal on *any* blocked navigation (e.g. an Edit button). Identify the clicked control from the cursor + zoom, then cross-check the repro steps.
+
+## Real-World Impact
+
+On issue 6061, the attached recording was the key to the diagnosis: a frame showed the Notes field already contained text (`asdfasdfasdfasdf`) before "Edit" was clicked — the precondition (`hasChanged`) that made the navigation guard fire. A baseline agent working from a sparse 1 fps pass, without reading the issue text, concluded the bug was "'Yes, Cancel' does nothing" — the opposite of the real Edit→wrong-modal bug — because the click→modal transition fell between samples. Reading the text first and zooming on the transition (steps 1, 4, 5) prevents that.

--- a/.claude/skills/watching-issue-video-recordings/SKILL.md
+++ b/.claude/skills/watching-issue-video-recordings/SKILL.md
@@ -52,7 +52,7 @@ For a GitHub attachment, pass the `github.com/user-attachments/assets/<uuid>` UR
 
 | Need | Command |
 |---|---|
-| First pass, whole clip | `extract-frames.sh <url> ` (2 fps default) |
+| First pass, whole clip | `extract-frames.sh <url>` (2 fps default) |
 | Zoom a transition (2s–3.5s) | `extract-frames.sh <url> 10 2 1.5` |
 | Local file instead of URL | `extract-frames.sh /path/to/clip.mov` |
 | Clean up | `rm -rf <WORKSPACE printed by the script>` |

--- a/.claude/skills/watching-issue-video-recordings/scripts/extract-frames.sh
+++ b/.claude/skills/watching-issue-video-recordings/scripts/extract-frames.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Extract still frames from a video (GitHub issue attachment URL or local file) into a
+# temp workspace OUTSIDE the repo, so an agent can Read the frames as images.
+#
+# Fully autonomous: never writes to the current working directory, never prompts.
+# All output goes to a fresh `mktemp -d` directory under the system temp dir.
+#
+# Usage:
+#   extract-frames.sh <url-or-path> [fps] [start] [duration]
+#     url-or-path : GitHub user-attachment URL, any http(s) video URL, or a local file
+#     fps         : frames per second to sample        (default 2)
+#     start       : optional start offset in seconds    (for a zoom pass on a transition)
+#     duration    : optional length in seconds from start
+#
+# Examples:
+#   extract-frames.sh https://github.com/user-attachments/assets/<uuid>        # 2 fps over whole clip
+#   extract-frames.sh https://github.com/user-attachments/assets/<uuid> 10 2 3 # 10 fps, 2s..5s zoom
+#
+# On success prints, on stdout:
+#   WORKSPACE=<dir>            the temp dir holding video + frames (rm -rf when done)
+#   VIDEO=<path>              the downloaded/copied source
+#   META: <ffprobe summary>
+#   then one absolute frame path per line (sorted) for the agent to Read.
+
+set -euo pipefail
+
+SRC="${1:-}"
+FPS="${2:-2}"          # 2 fps default: dense enough to separate a click from the UI it triggers,
+                       # without flooding context. Bump to 10+ for a short zoom pass on a transition.
+START="${3:-}"
+DURATION="${4:-}"
+
+if [[ -z "$SRC" ]]; then
+    echo "ERROR: no video url-or-path given" >&2
+    echo "usage: extract-frames.sh <url-or-path> [fps] [start] [duration]" >&2
+    exit 2
+fi
+
+# --- ensure ffmpeg/ffprobe exist (install once on macOS; guide otherwise) -------------
+ensure_ffmpeg() {
+    if command -v ffmpeg >/dev/null 2>&1 && command -v ffprobe >/dev/null 2>&1; then
+        return 0
+    fi
+    if [[ "$(uname)" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then
+        echo "ffmpeg not found; installing via Homebrew (non-interactive)..." >&2
+        HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_ENV_HINTS=1 brew install ffmpeg >&2
+        return 0
+    fi
+    echo "ERROR: ffmpeg/ffprobe required but not installed, and no supported installer found." >&2
+    echo "Install ffmpeg (e.g. 'brew install ffmpeg' on macOS, 'apt-get install ffmpeg' on Debian) and retry." >&2
+    exit 3
+}
+ensure_ffmpeg
+
+# --- workspace OUTSIDE the repo (system temp dir) -------------------------------------
+WORKSPACE="$(mktemp -d "${TMPDIR:-/tmp}/issue-video.XXXXXX")"
+FRAMES_DIR="$WORKSPACE/frames"
+mkdir -p "$FRAMES_DIR"
+
+# --- obtain the video into the workspace ----------------------------------------------
+VIDEO="$WORKSPACE/source"
+if [[ "$SRC" == http://* || "$SRC" == https://* ]]; then
+    # -L follows GitHub's redirect to blob storage; attachments need no auth.
+    curl -fsSL "$SRC" -o "$VIDEO"
+elif [[ -f "$SRC" ]]; then
+    cp "$SRC" "$VIDEO"
+else
+    echo "ERROR: '$SRC' is neither an http(s) URL nor an existing file" >&2
+    exit 4
+fi
+
+# --- metadata -------------------------------------------------------------------------
+META="$(ffprobe -v error -select_streams v:0 \
+    -show_entries format=duration:stream=width,height,r_frame_rate \
+    -of default=noprint_wrappers=1 "$VIDEO" 2>/dev/null || true)"
+
+# --- build ffmpeg args: optional zoom window, then fps sampling -----------------------
+# -ss before -i seeks fast; scale caps very large frames (even dims via -2) to keep the
+# image readable without upscaling small clips.
+declare -a WINDOW=()
+[[ -n "$START" ]] && WINDOW+=(-ss "$START")
+[[ -n "$DURATION" ]] && WINDOW+=(-t "$DURATION")
+
+ffmpeg -hide_banner -loglevel error "${WINDOW[@]+"${WINDOW[@]}"}" -i "$VIDEO" \
+    -vf "fps=${FPS},scale='min(1600,iw)':-2" -q:v 2 \
+    "$FRAMES_DIR/frame_%03d.png"
+
+# --- report ---------------------------------------------------------------------------
+echo "WORKSPACE=$WORKSPACE"
+echo "VIDEO=$VIDEO"
+echo "META: $(echo "$META" | tr '\n' ' ')"
+echo "FPS=$FPS${START:+ START=$START}${DURATION:+ DURATION=$DURATION}"
+count=$(find "$FRAMES_DIR" -name 'frame_*.png' | wc -l | tr -d ' ')
+echo "FRAMES=$count"
+find "$FRAMES_DIR" -name 'frame_*.png' | sort

--- a/.claude/skills/watching-issue-video-recordings/scripts/extract-frames.sh
+++ b/.claude/skills/watching-issue-video-recordings/scripts/extract-frames.sh
@@ -44,7 +44,12 @@ ensure_ffmpeg() {
     if [[ "$(uname)" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then
         echo "ffmpeg not found; installing via Homebrew (non-interactive)..." >&2
         HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_ENV_HINTS=1 brew install ffmpeg >&2
-        return 0
+        if command -v ffmpeg >/dev/null 2>&1 && command -v ffprobe >/dev/null 2>&1; then
+            return 0
+        fi
+        echo "ERROR: ffmpeg installed but not on PATH (Homebrew prefix may be missing from \$PATH)." >&2
+        echo "Add Homebrew's bin dir to PATH (e.g. '$(brew --prefix)/bin') and retry." >&2
+        exit 3
     fi
     echo "ERROR: ffmpeg/ffprobe required but not installed, and no supported installer found." >&2
     echo "Install ffmpeg (e.g. 'brew install ffmpeg' on macOS, 'apt-get install ffmpeg' on Debian) and retry." >&2


### PR DESCRIPTION
## What changed

Adds two project-local Claude Code skills under `.claude/skills/`, both built and verified via the writing-skills TDD cycle (baseline failure observed → skill written → re-verified with a fresh subagent). Neither touches application code.

**`.claude/skills/useblocker-bypass-regression-test/`** — a technique skill for writing Vitest tests that guard the repo's react-router `useBlocker` unsaved-changes pattern, where an intentional navigation (Edit/Submit/Cancel) uses `flushSync(() => setIsNavigating(true))` before `navigate()` to bypass the blocker. It documents that the obvious test (reading the blocker predicate after `act()`) passes even when `flushSync` is removed, and prescribes evaluating the predicate at navigate-time (inside the `navigate` mock) plus a required mutation check. This is the exact coverage gap surfaced while fixing issue 6061.

**`.claude/skills/watching-issue-video-recordings/`** — a skill for inspecting screen-recording attachments on GitHub issues/PRs (which can't be viewed in-context). Includes `scripts/extract-frames.sh`, which installs ffmpeg if missing (macOS), downloads the video to a `mktemp -d` workspace **outside the repo**, and extracts still frames to Read as images — fully autonomously, with no repo writes and no interactive prompts. The SKILL.md's load-bearing step is reconciling the frames against the issue's written repro steps, addressing a baseline failure where sparse sampling led to a confidently-wrong interpretation.

## Issue

No OPS ticket — this is a `docs/`-scoped tooling change. Related context: https://github.com/HHS/OPRE-OPS/issues/6061 (the skills were distilled from that investigation; this PR does not close it).

## How to test

No application code changes, so the app/test suites are unaffected. To verify the skills themselves:

1. **Read both SKILL.md files** and confirm the frontmatter/description and guidance are clear:
   - `.claude/skills/useblocker-bypass-regression-test/SKILL.md`
   - `.claude/skills/watching-issue-video-recordings/SKILL.md`
2. **Exercise the frame-extraction script** against any public GitHub attachment URL (or a local video):
   ```bash
   .claude/skills/watching-issue-video-recordings/scripts/extract-frames.sh \
     https://github.com/user-attachments/assets/e257a570-444c-42e8-9382-427b858c5922 2
   ```
   Confirm it prints a `WORKSPACE=` path under the system temp dir, `FRAMES=<n>`, and one frame path per line — and that `git status --porcelain` shows **nothing added to the repo** (no downloads/frames in the working tree). Clean up with `rm -rf <the printed WORKSPACE path>`.
3. **Confirm the regression-test technique** by reading the `useblocker-bypass-regression-test` "Verify it actually guards (mutation test)" section — the navigate-time assertion fails when `flushSync` is swapped for a plain `setIsNavigating(true)`, while the existing hook suite stays green.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — no UI changes (documentation/tooling only).

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [x] Form validations updated

_Not applicable: this PR adds Claude-tooling markdown + a shell helper under `.claude/skills/`; there is no repo test suite covering these, and no application/UI/form/dependency code changed._

## Links

N/A