### PR TITLE
Show services component description in accordion header

### DIFF
--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
@@ -17,7 +17,7 @@ import StepIndicator from "../../UI/StepIndicator/StepIndicator";
 import BudgetLinesForm from "../BudgetLinesForm";
 import BudgetLinesTable from "../BudgetLinesTable";
 import useCreateBLIsAndSCs from "./CreateBLIsAndSCs.hooks";
-import { findIfOptional } from "../../../helpers/servicesComponent.helpers";
+import { findDescription, findIfOptional } from "../../../helpers/servicesComponent.helpers";
 import { cleanBudgetLineItemForApi } from "../../../helpers/agreement.helpers";
 import { useEditAgreement } from "../../Agreements/AgreementEditor/AgreementEditorContext.hooks";
 
@@ -561,6 +561,7 @@ export const CreateBLIsAndSCs = ({
                             serviceComponentGroupingLabel={group.serviceComponentGroupingLabel}
                             serviceRequirementType={selectedAgreement.service_requirement_type}
                             optional={findIfOptional(servicesComponents, budgetLineScGroupingLabel)}
+                            description={findDescription(servicesComponents, budgetLineScGroupingLabel)}
                         >
                             <BudgetLinesTable
                                 budgetLines={group.budgetLines}

--- a/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.jsx
+++ b/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.jsx
@@ -1,6 +1,7 @@
 import Accordion from "../../UI/Accordion";
 import ServicesComponentMetadata from "../ServicesComponentMetadata";
 import { formatServiceComponent } from "../ServicesComponents.helpers";
+import styles from "./ServicesComponentAccordion.module.css";
 
 /**
  * @component ServicesComponentAccordion is a component that wraps its children in an Accordion UI component.
@@ -38,9 +39,20 @@ function ServicesComponentAccordion({
                   serviceComponentGroupingLabel
               );
 
+    const showDescriptionInHeader = !withMetadata && !!description?.trim();
+
+    const heading = showDescriptionInHeader ? (
+        <span className={styles.header}>
+            <span className={styles.name}>{servicesComponentDisplayTitle}</span>
+            <span className={styles.description}>: {description}</span>
+        </span>
+    ) : (
+        servicesComponentDisplayTitle
+    );
+
     return (
         <Accordion
-            heading={servicesComponentDisplayTitle}
+            heading={heading}
             level={3}
         >
             {withMetadata && (

--- a/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.jsx
+++ b/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.jsx
@@ -44,7 +44,7 @@ function ServicesComponentAccordion({
     const heading = showDescriptionInHeader ? (
         <span className={styles.header}>
             <span className={styles.name}>{servicesComponentDisplayTitle}</span>
-            <span className={styles.description}>: {description}</span>
+            <span className={styles.description}>: {description.trim()}</span>
         </span>
     ) : (
         servicesComponentDisplayTitle

--- a/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.module.css
+++ b/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.module.css
@@ -1,0 +1,18 @@
+.header {
+    display: flex;
+    align-items: center;
+    width: 100%;
+}
+
+.name {
+    flex: 0 0 auto;
+}
+
+.description {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: normal;
+}

--- a/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.test.jsx
+++ b/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.test.jsx
@@ -1,0 +1,190 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ServicesComponentAccordion from "./ServicesComponentAccordion";
+import styles from "./ServicesComponentAccordion.module.css";
+
+/* eslint-disable testing-library/no-container, testing-library/no-node-access */
+// Note: Using container.querySelector is necessary for testing className changes
+// on the description span, which doesn't have accessible queries available
+
+const baseProps = {
+    servicesComponentNumber: 3,
+    serviceRequirementType: "NON_SEVERABLE",
+    optional: true
+};
+
+describe("ServicesComponentAccordion header description", () => {
+    it("shows the description in the header when there is no in-body metadata", () => {
+        const { container } = render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={false}
+                description="Phase 2 data collection and analysis"
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const button = screen.getByRole("button", { name: /Optional Services Component 3/ });
+        expect(button).toHaveTextContent("Optional Services Component 3: Phase 2 data collection and analysis");
+        const descriptionSpan = container.querySelector(`.${styles.description}`);
+        expect(descriptionSpan).toHaveClass(styles.description);
+    });
+
+    it("shows only the name (no colon) when the description is empty", () => {
+        const { container } = render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={false}
+                description=""
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const button = screen.getByRole("button", { name: /Optional Services Component 3/ });
+        expect(button.textContent.trim()).toBe("Optional Services Component 3");
+        const descriptionSpan = container.querySelector(`.${styles.description}`);
+        expect(descriptionSpan).not.toBeInTheDocument();
+    });
+
+    it("shows only the name (no colon) when the description is null", () => {
+        const { container } = render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={false}
+                description={null}
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const button = screen.getByRole("button", { name: /Optional Services Component 3/ });
+        expect(button.textContent.trim()).toBe("Optional Services Component 3");
+        const descriptionSpan = container.querySelector(`.${styles.description}`);
+        expect(descriptionSpan).not.toBeInTheDocument();
+    });
+
+    it("does NOT show the description in the header when metadata is displayed in the body (no-op)", () => {
+        render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={true}
+                description="Phase 2 data collection and analysis"
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const button = screen.getByRole("button", { name: /Optional Services Component 3/ });
+        expect(button).not.toHaveTextContent("Phase 2 data collection and analysis");
+    });
+
+    it("still toggles open/closed (regression)", async () => {
+        const user = userEvent.setup();
+        render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={false}
+                description="Phase 2 data collection and analysis"
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const button = screen.getByRole("button", { name: /Optional Services Component 3/ });
+        expect(button).toHaveAttribute("aria-expanded", "true");
+        await user.click(button);
+        expect(button).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("shows only the name (no colon) when the description is whitespace only", () => {
+        const { container } = render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={false}
+                description="   "
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const button = screen.getByRole("button", { name: /Optional Services Component 3/ });
+        expect(button.textContent.trim()).toBe("Optional Services Component 3");
+        const descriptionSpan = container.querySelector(`.${styles.description}`);
+        expect(descriptionSpan).not.toBeInTheDocument();
+    });
+});
+
+describe("ServicesComponentAccordion metadata rendering", () => {
+    it("renders ServicesComponentMetadata in the body when withMetadata is true", () => {
+        render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={true}
+                description="Phase 2 data collection and analysis"
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        expect(screen.getByText("Description")).toBeInTheDocument();
+    });
+
+    it("does not render ServicesComponentMetadata in the body when withMetadata is false", () => {
+        render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={false}
+                description="Phase 2 data collection and analysis"
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        expect(screen.queryByText("Description")).not.toBeInTheDocument();
+    });
+});
+
+describe("ServicesComponentAccordion class assignments", () => {
+    it("assigns correct classes to name and description spans", () => {
+        const { container } = render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={false}
+                description="Phase 2 data collection and analysis"
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const nameSpan = container.querySelector(`.${styles.name}`);
+        const descriptionSpan = container.querySelector(`.${styles.description}`);
+
+        expect(nameSpan).toHaveTextContent("Optional Services Component 3");
+        expect(nameSpan).not.toHaveClass(styles.description);
+        expect(descriptionSpan).not.toHaveClass(styles.name);
+    });
+});
+
+describe("ServicesComponentAccordion special cases", () => {
+    it("displays the correct text when servicesComponentNumber is 0", () => {
+        render(
+            <ServicesComponentAccordion
+                servicesComponentNumber={0}
+                serviceRequirementType="NON_SEVERABLE"
+                optional={true}
+                withMetadata={false}
+                description=""
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const button = screen.getByRole("button", { name: /BLs not associated with a Services Component/ });
+        expect(button).toBeInTheDocument();
+    });
+
+    it("renders an h3 heading via Accordion level prop", () => {
+        render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={false}
+                description=""
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        expect(screen.getByRole("heading", { level: 3 })).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.test.jsx
+++ b/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.test.jsx
@@ -30,6 +30,20 @@ describe("ServicesComponentAccordion header description", () => {
         expect(descriptionSpan).toHaveClass(styles.description);
     });
 
+    it("trims leading and trailing whitespace from a rendered description", () => {
+        const { container } = render(
+            <ServicesComponentAccordion
+                {...baseProps}
+                withMetadata={false}
+                description="  Phase 2 data collection  "
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const descriptionSpan = container.querySelector(`.${styles.description}`);
+        expect(descriptionSpan.textContent).toBe(": Phase 2 data collection");
+    });
+
     it("shows only the name (no colon) when the description is empty", () => {
         const { container } = render(
             <ServicesComponentAccordion


### PR DESCRIPTION
## What changed

Adds the services component's description alongside its name in the Services Component accordion header, so users can identify a component by its description (not just its generated name) without expanding it.

Of the 7 places `ServicesComponentAccordion` is rendered, 6 already show the description inside the expanded body (via `ServicesComponentMetadata`, gated on `withMetadata={true}`). Exactly one — the agreement-details Edit-mode flow — showed the description nowhere. Rather than adding a new prop or a mode flag, the header now shows the description whenever the body isn't already showing it: `!withMetadata && description`. This makes the 6 existing call sites automatic no-ops and only changes behavior at the one call site that previously displayed no description at all.

**`ServicesComponentAccordion.jsx` / `ServicesComponentAccordion.module.css`**
- Builds a header node (bold name + `: description`) when `!withMetadata && description` is truthy; otherwise renders the plain name string as before.
- The description truncates with a single-line CSS ellipsis (`overflow: hidden; text-overflow: ellipsis; white-space: nowrap`) that adapts to any viewport width — chosen over a fixed character-count cutoff so it never wraps and never crowds the accordion's expand/collapse control, at any screen size. The name never truncates.
- Deliberately does not reuse the existing `TextClip` component, since it auto-adds a hover tooltip on overflow, which is explicitly out of scope for this feature.

**`CreateBLIsAndSCs.jsx`**
- Wires `description={findDescription(servicesComponents, budgetLineScGroupingLabel)}` into the one call site that previously passed neither `withMetadata` nor `description`.

**`ServicesComponentAccordion.test.jsx`** (new)
- 11 tests covering: description shown in header when no in-body metadata; empty/null/whitespace-only description shows name only with no dangling colon; description NOT shown in header when `withMetadata` is true (no-op, body renders it instead); accordion toggle regression; CSS class assignment on name vs. description spans; the `servicesComponentNumber === 0` special case; heading level semantics.

## Issue

https://github.com/HHS/OPRE-OPS/issues/6078

## How to test

Automated:
```
cd frontend
bun run test --watch=false src/components/ServicesComponents/ServicesComponentAccordion src/components/BudgetLineItems/CreateBLIsAndSCs
```

Manual (verified locally against a running dev stack):
1. Create/open an agreement, go to the "SCs & Budget Lines" tab, click Edit.
2. Add a services component with a description and at least one budget line. Confirm the accordion header shows `Name: description`, truncating with an ellipsis and never overlapping the expand/collapse icon — try narrowing the browser window.
3. Add a second services component with no description. Confirm its header shows only the name, with no colon or placeholder.
4. Click "Save & Exit", then view the same tab outside Edit mode. Confirm the header is unchanged (name only) — the description still appears in the expanded body next to the Period of Performance dates.
5. Confirm this holds for both the mandatory/base and an optional services component.

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Screenshots
Example of SCs with a description.  SCs without a description are unchanged from prior behavior. 
<img width="1002" height="412" alt="Screenshot 2026-08-11 at 00 02 06" src="https://github.com/user-attachments/assets/b910705b-3f33-4e30-94d7-7a36774a3866" />


## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated


## Links

N/A