### PR TITLE
feat: add division director and deputy director to portfolio page

### DIFF
--- a/backend/models/portfolios.py
+++ b/backend/models/portfolios.py
@@ -27,6 +27,7 @@ class Division(BaseModel):
     division_director_id = Column(Integer, ForeignKey("ops_user.id"))
     deputy_division_director_id = Column(Integer, ForeignKey("ops_user.id"))
     division_director = relationship("User", foreign_keys=[division_director_id], viewonly=True)
+    deputy_division_director = relationship("User", foreign_keys=[deputy_division_director_id], viewonly=True)
 
     __table_args__ = (
         Index("ix_division_division_director_id", "division_director_id"),
@@ -42,6 +43,10 @@ class Division(BaseModel):
 
         return self.division_director.full_name if self.division_director else None
 
+    @property
+    def deputy_division_director_full_name(self):
+
+        return self.deputy_division_director.full_name if self.deputy_division_director else None
 
 
 class PortfolioUrl(BaseModel):
@@ -62,9 +67,7 @@ class PortfolioUrl(BaseModel):
 class SharedPortfolioCANs(BaseModel):
     __tablename__ = "shared_portfolio_cans"
 
-    portfolio_id: Mapped[int] = mapped_column(
-        ForeignKey("portfolio.id"), primary_key=True
-    )
+    portfolio_id: Mapped[int] = mapped_column(ForeignKey("portfolio.id"), primary_key=True)
     can_id: Mapped[int] = mapped_column(ForeignKey("can.id"), primary_key=True)
 
     @BaseModel.display_name.getter
@@ -75,12 +78,8 @@ class SharedPortfolioCANs(BaseModel):
 class PortfolioTeamLeaders(BaseModel):
     __tablename__ = "portfolio_team_leaders"
 
-    portfolio_id: Mapped[int] = mapped_column(
-        ForeignKey("portfolio.id"), primary_key=True
-    )
-    team_lead_id: Mapped[int] = mapped_column(
-        ForeignKey("ops_user.id"), primary_key=True
-    )
+    portfolio_id: Mapped[int] = mapped_column(ForeignKey("portfolio.id"), primary_key=True)
+    team_lead_id: Mapped[int] = mapped_column(ForeignKey("ops_user.id"), primary_key=True)
 
     @BaseModel.display_name.getter
     def display_name(self):
@@ -117,3 +116,15 @@ class Portfolio(BaseModel):
     @BaseModel.display_name.getter
     def display_name(self):
         return self.name
+
+    @property
+    def division_director(self):
+        """SafeUser dict ({id, full_name}) for this portfolio's division's director, or None."""
+        user = self.division.division_director if self.division else None
+        return {"id": user.id, "full_name": user.full_name} if user else None
+
+    @property
+    def deputy_division_director(self):
+        """SafeUser dict ({id, full_name}) for this portfolio's division's deputy director, or None."""
+        user = self.division.deputy_division_director if self.division else None
+        return {"id": user.id, "full_name": user.full_name} if user else None

--- a/backend/ops_api/ops/resources/portfolios.py
+++ b/backend/ops_api/ops/resources/portfolios.py
@@ -29,6 +29,7 @@ class PortfolioItemAPI(BaseItemAPI):
                 selectinload(Portfolio.team_leaders),
                 selectinload(Portfolio.urls),
                 selectinload(Portfolio.division).selectinload(Division.division_director),
+                selectinload(Portfolio.division).selectinload(Division.deputy_division_director),
             )
         )
         item = current_app.db_session.scalar(stmt)
@@ -58,6 +59,7 @@ class PortfolioListAPI(BaseListAPI):
             selectinload(Portfolio.team_leaders),  # Many-to-many: portfolio -> users
             selectinload(Portfolio.urls),  # One-to-many: portfolio -> urls
             selectinload(Portfolio.division).selectinload(Division.division_director),  # Many-to-one with nested
+            selectinload(Portfolio.division).selectinload(Division.deputy_division_director),
         )
 
         if project_id is not None:
@@ -97,4 +99,6 @@ def add_additional_fields_to_portfolio_response(
     return {
         "team_leaders": [tm.to_dict() for tm in portfolio.team_leaders],
         "division": portfolio.division.to_dict() if portfolio.division else None,
+        "division_director": portfolio.division_director,
+        "deputy_division_director": portfolio.deputy_division_director,
     }

--- a/backend/ops_api/tests/ops/portfolio/test_portfolio_directors.py
+++ b/backend/ops_api/tests/ops/portfolio/test_portfolio_directors.py
@@ -1,0 +1,116 @@
+from models import Division, Portfolio, User, UserStatus
+from ops_api.ops.resources.portfolios import add_additional_fields_to_portfolio_response
+
+
+def _make_user(loaded_db, first_name, last_name, email):
+    user = User(first_name=first_name, last_name=last_name, email=email, status=UserStatus.ACTIVE)
+    loaded_db.add(user)
+    loaded_db.flush()  # assign user.id
+    return user
+
+
+def test_portfolio_division_director_and_deputy(loaded_db, app_ctx):
+    director = _make_user(loaded_db, "Dana", "Director", "dana.director@example.com")
+    deputy = _make_user(loaded_db, "Dez", "Deputy", "dez.deputy@example.com")
+
+    division = Division(
+        name="Test Division With Both",
+        abbreviation="TDWB",
+        division_director_id=director.id,
+        deputy_division_director_id=deputy.id,
+    )
+    loaded_db.add(division)
+    loaded_db.flush()
+
+    portfolio = Portfolio(name="Test Portfolio", abbreviation="TP", division_id=division.id)
+    loaded_db.add(portfolio)
+    loaded_db.flush()
+
+    assert portfolio.division_director == {"id": director.id, "full_name": "Dana Director"}
+    assert portfolio.deputy_division_director == {"id": deputy.id, "full_name": "Dez Deputy"}
+
+
+def test_portfolio_division_director_missing_deputy(loaded_db, app_ctx):
+    director = _make_user(loaded_db, "Only", "Director", "only.director@example.com")
+
+    division = Division(
+        name="Test Division Director Only",
+        abbreviation="TDDO",
+        division_director_id=director.id,
+        # deputy_division_director_id intentionally omitted
+    )
+    loaded_db.add(division)
+    loaded_db.flush()
+
+    portfolio = Portfolio(name="Test Portfolio No Deputy", abbreviation="TPND", division_id=division.id)
+    loaded_db.add(portfolio)
+    loaded_db.flush()
+
+    assert portfolio.division_director == {"id": director.id, "full_name": "Only Director"}
+    assert portfolio.deputy_division_director is None
+
+
+def test_portfolio_division_director_and_deputy_both_unset(loaded_db, app_ctx):
+    division = Division(name="Test Division Neither", abbreviation="TDN")
+    loaded_db.add(division)
+    loaded_db.flush()
+
+    portfolio = Portfolio(name="Test Portfolio Neither", abbreviation="TPN", division_id=division.id)
+    loaded_db.add(portfolio)
+    loaded_db.flush()
+
+    assert portfolio.division_director is None
+    assert portfolio.deputy_division_director is None
+
+
+def test_portfolio_directors_none_when_division_not_assigned():
+    # No division relationship loaded/assigned at all — division is None.
+    portfolio = Portfolio(name="No Division Portfolio", abbreviation="NDP")
+
+    assert portfolio.division_director is None
+    assert portfolio.deputy_division_director is None
+
+
+def test_add_additional_fields_includes_division_directors(loaded_db, app_ctx):
+    director = _make_user(loaded_db, "Response", "Director", "response.director@example.com")
+    deputy = _make_user(loaded_db, "Response", "Deputy", "response.deputy@example.com")
+
+    division = Division(
+        name="Response Division",
+        abbreviation="RESD",
+        division_director_id=director.id,
+        deputy_division_director_id=deputy.id,
+    )
+    loaded_db.add(division)
+    loaded_db.flush()
+
+    portfolio = Portfolio(name="Response Portfolio", abbreviation="RESP", division_id=division.id)
+    loaded_db.add(portfolio)
+    loaded_db.flush()
+
+    additional_fields = add_additional_fields_to_portfolio_response(portfolio)
+
+    assert additional_fields["division_director"] == {"id": director.id, "full_name": "Response Director"}
+    assert additional_fields["deputy_division_director"] == {"id": deputy.id, "full_name": "Response Deputy"}
+
+
+def test_portfolio_get_by_id_includes_director_fields(auth_client, loaded_db, app_ctx):
+    director = _make_user(loaded_db, "Api", "Director", "api.director@example.com")
+
+    division = Division(
+        name="Api Division",
+        abbreviation="APID",
+        division_director_id=director.id,
+    )
+    loaded_db.add(division)
+    loaded_db.flush()
+
+    portfolio = Portfolio(name="Api Portfolio", abbreviation="APIP", division_id=division.id)
+    loaded_db.add(portfolio)
+    loaded_db.commit()
+
+    response = auth_client.get(f"/api/v1/portfolios/{portfolio.id}")
+
+    assert response.status_code == 200
+    assert response.json["division_director"] == {"id": director.id, "full_name": "Api Director"}
+    assert response.json["deputy_division_director"] is None

--- a/frontend/src/components/Portfolios/PortfolioHero/PortfolioHero.jsx
+++ b/frontend/src/components/Portfolios/PortfolioHero/PortfolioHero.jsx
@@ -1,5 +1,7 @@
 import Hero from "../../UI/Hero";
 import TeamLeaders from "../../UI/TeamLeaders/TeamLeaders";
+import TermTag from "../../UI/Term/TermTag";
+import { formatUserName } from "../../../helpers/users.helpers";
 import HeroDescription from "./HeroDescription";
 
 /**
@@ -7,6 +9,8 @@ import HeroDescription from "./HeroDescription";
     @property {string} entityName
     @property {string} divisionName
     @property {import("../../../types/UserTypes").SafeUser} teamLeaders
+    @property {import("../../../types/UserTypes").SafeUser | null} divisionDirector
+    @property {import("../../../types/UserTypes").SafeUser | null} deputyDivisionDirector
     @property {string} label
     @property {string} description
     @property {string} url
@@ -17,11 +21,39 @@ import HeroDescription from "./HeroDescription";
  * @param {HeroProps} props
  * @returns {React.ReactElement}
  */
-const PortfolioHero = ({ entityName, description, divisionName, label, teamLeaders, url, children }) => {
+const PortfolioHero = ({
+    entityName,
+    description,
+    divisionName,
+    label,
+    teamLeaders,
+    divisionDirector,
+    deputyDivisionDirector,
+    url,
+    children
+}) => {
     return (
         <Hero entityName={entityName}>
             <h2 className={`font-sans-3xs text-normal margin-top-1 margin-bottom-2`}>{divisionName}</h2>
-            <TeamLeaders teamLeaders={teamLeaders} />
+            <div className="display-flex flex-align-start">
+                <div className="margin-right-4">
+                    <TeamLeaders teamLeaders={teamLeaders} />
+                </div>
+                <dl className="margin-0 margin-right-4 font-12px">
+                    <TermTag
+                        term="Division Director"
+                        description={formatUserName(divisionDirector?.display_name ?? divisionDirector?.full_name)}
+                    />
+                </dl>
+                <dl className="margin-0 font-12px">
+                    <TermTag
+                        term="Deputy Division Director"
+                        description={formatUserName(
+                            deputyDivisionDirector?.display_name ?? deputyDivisionDirector?.full_name
+                        )}
+                    />
+                </dl>
+            </div>
             <HeroDescription
                 label={label}
                 description={description}

--- a/frontend/src/components/Portfolios/PortfolioHero/PortfolioHero.test.jsx
+++ b/frontend/src/components/Portfolios/PortfolioHero/PortfolioHero.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import PortfolioHero from "./PortfolioHero";
+
+describe("PortfolioHero", () => {
+    it("renders the division director and deputy division director", () => {
+        render(
+            <PortfolioHero
+                entityName="Test Portfolio"
+                divisionName="Test Division"
+                teamLeaders={[]}
+                divisionDirector={{ id: 1, full_name: "JANE SMITH" }}
+                deputyDivisionDirector={{ id: 2, full_name: "JOHN DOE" }}
+            />
+        );
+
+        expect(screen.getByText("Division Director")).toBeInTheDocument();
+        expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+        expect(screen.getByText("Deputy Division Director")).toBeInTheDocument();
+        expect(screen.getByText("John Doe")).toBeInTheDocument();
+    });
+
+    it("renders TBD when the division director or deputy is missing", () => {
+        render(
+            <PortfolioHero
+                entityName="Test Portfolio"
+                divisionName="Test Division"
+                teamLeaders={[]}
+                divisionDirector={null}
+                deputyDivisionDirector={null}
+            />
+        );
+
+        const tbds = screen.getAllByText("TBD");
+        expect(tbds).toHaveLength(3);
+    });
+});

--- a/frontend/src/helpers/users.helpers.js
+++ b/frontend/src/helpers/users.helpers.js
@@ -176,7 +176,9 @@ export const normalizePortfolioUsers = (portfolio) => {
     if (!portfolio || typeof portfolio !== "object") return portfolio;
     return {
         ...portfolio,
-        team_leaders: normalizeUsers(portfolio.team_leaders)
+        team_leaders: normalizeUsers(portfolio.team_leaders),
+        division_director: normalizeUser(portfolio.division_director),
+        deputy_division_director: normalizeUser(portfolio.deputy_division_director)
     };
 };
 

--- a/frontend/src/helpers/users.helpers.test.js
+++ b/frontend/src/helpers/users.helpers.test.js
@@ -190,6 +190,44 @@ describe("embedded payload normalizers", () => {
         });
     });
 
+    it("normalizes portfolio division director and deputy division director", () => {
+        expect(
+            normalizePortfolioUsers({
+                id: 1,
+                division_director: { id: 1, full_name: "JANE SMITH", email: "jane@example.com" },
+                deputy_division_director: { id: 2, full_name: "JOHN DOE", email: "john@example.com" }
+            })
+        ).toEqual({
+            id: 1,
+            division_director: {
+                id: 1,
+                full_name: "JANE SMITH",
+                email: "jane@example.com",
+                display_name: "Jane Smith"
+            },
+            deputy_division_director: {
+                id: 2,
+                full_name: "JOHN DOE",
+                email: "john@example.com",
+                display_name: "John Doe"
+            }
+        });
+    });
+
+    it("leaves division director and deputy division director null when absent", () => {
+        expect(
+            normalizePortfolioUsers({
+                id: 1,
+                division_director: null,
+                deputy_division_director: null
+            })
+        ).toEqual({
+            id: 1,
+            division_director: null,
+            deputy_division_director: null
+        });
+    });
+
     it("normalizes nested portfolio team leaders on CAN payloads", () => {
         expect(
             normalizeCanUsers({

--- a/frontend/src/pages/portfolios/detail/PortfolioDetail.jsx
+++ b/frontend/src/pages/portfolios/detail/PortfolioDetail.jsx
@@ -54,6 +54,8 @@ const PortfolioDetail = () => {
                     label="Portfolio Description"
                     description={portfolio?.description}
                     teamLeaders={portfolio?.team_leaders}
+                    divisionDirector={portfolio?.division_director}
+                    deputyDivisionDirector={portfolio?.deputy_division_director}
                     url={portfolioUrl?.url}
                 />
                 <section className="display-flex flex-justify margin-top-3">

--- a/frontend/src/types/PortfolioTypes.d.ts
+++ b/frontend/src/types/PortfolioTypes.d.ts
@@ -23,6 +23,8 @@ export type Portfolio = {
     division: Division;
     urls?: URL[];
     team_leaders?: SafeUser[];
+    division_director?: SafeUser | null;
+    deputy_division_director?: SafeUser | null;
     created_by?: any;
     created_by_user?: any;
     created_on?: any;


### PR DESCRIPTION
## What changed

Surfaces the Division Director and Deputy Division Director on the Portfolio detail page, matching the existing "Team Leader" display pattern.

**Backend** (`backend/models/portfolios.py`, `backend/ops_api/ops/resources/portfolios.py`)
- Added `Division.deputy_division_director` relationship and `deputy_division_director_full_name` property, mirroring the existing `division_director`.
- Added `Portfolio.division_director` / `Portfolio.deputy_division_director` properties returning a safe `{id, full_name}` dict (or `None`).
- Eager-load both relationships in the Portfolio list/item API and include them in the response payload.

**Frontend**
- `PortfolioHero.jsx` now renders "Division Director" and "Deputy Division Director" as tag pills next to "Team Leader", using the existing `TermTag` component for visual consistency. Shows "TBD" when either is unset.
- `users.helpers.js`: `normalizePortfolioUsers` now normalizes the two new user fields (adds `display_name`, title-cases all-caps names from AMS).
- `PortfolioTypes.d.ts`: added the two new optional fields to the `Portfolio` type.
- `PortfolioDetail.jsx`: passes the new fields into `PortfolioHero`.
- Fixed a layout bug found during manual verification: the hero's flex container used `gap-4`, which isn't a valid USWDS utility outside `.grid-row`, so the labels had no spacing between them. Replaced with `margin-right-4`.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5983

## How to test

1. Backend: `cd backend/ops_api && pipenv run pytest tests/ops/portfolio/test_portfolio_directors.py`
2. Frontend: `cd frontend && bun run test --watch=false src/components/Portfolios/PortfolioHero src/helpers/users.helpers.test.js`
3. Manual: `docker compose up --build`, log in, navigate to a Portfolio detail page (e.g. `/portfolios/1/spending`) and confirm "Division Director" and "Deputy Division Director" tags render next to "Team Leader", with "TBD" shown when a division has no deputy director set.

## A11y impact

- [ ] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Screenshots

<img width="1016" height="427" alt="Screenshot 2026-08-12 at 12 48 46 PM" src="https://github.com/user-attachments/assets/16f0e890-290f-4887-88cc-c74b72eada5d" />


## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A