### PR TITLE
fix: correct cancel modal copy and nav blocker on award approval review

### DIFF
--- a/frontend/src/pages/agreements/award-approval/ApproveAwardApproval.hooks.js
+++ b/frontend/src/pages/agreements/award-approval/ApproveAwardApproval.hooks.js
@@ -1,9 +1,10 @@
-import React, { useState, useMemo, useEffect } from "react";
+import React, { useState, useMemo } from "react";
 import { flushSync } from "react-dom";
-import { useNavigate, useBlocker } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useSelector, shallowEqual } from "react-redux";
 import { useUpdateProcurementTrackerStepMutation } from "../../../api/opsAPI";
 import useAlert from "../../../hooks/use-alert.hooks";
+import useUnsavedChangesBlocker from "../../../hooks/useUnsavedChangesBlocker.hooks";
 import usePreAwardApprovalData from "../pre-award-approval/usePreAwardApprovalData";
 import DatePicker from "../../../components/UI/USWDS/DatePicker";
 import { formatDateForApi } from "../../../helpers/utils";
@@ -65,39 +66,22 @@ export default function useApproveAwardApproval(agreementId) {
     }, [userRoles]);
 
     /**
-     * Track unsaved changes
+     * Track unsaved changes — obligated date is the only editable field
      */
-    const hasChanged = useMemo(() => obligatedDate !== "", [obligatedDate]);
+    const hasChanged = useMemo(() => !isNavigating && obligatedDate !== "", [isNavigating, obligatedDate]);
 
     /**
-     * Navigation blocker — prevents accidental navigation when form has unsaved changes
+     * Navigation blocker — "Save changes before leaving?" pattern, no draft save option.
+     * Primary: "Go back" (stay). Secondary: "Leave without saving" (discard + proceed).
      */
-    const blocker = useBlocker(
-        ({ currentLocation, nextLocation }) =>
-            !isNavigating && hasChanged && currentLocation.pathname !== nextLocation.pathname
-    );
-
-    useEffect(() => {
-        if (blocker.state === "blocked") {
-            setShowModal(true);
-            setModalProps({
-                heading: "Are you sure you want to cancel this task? Your input will not be saved.",
-                actionButtonText: "Yes, Cancel Task",
-                secondaryButtonText: "Continue Editing",
-                handleConfirm: () => {
-                    setShowModal(false);
-                    flushSync(() => {
-                        setIsNavigating(true);
-                    });
-                    blocker.proceed?.();
-                },
-                closeModal: () => {
-                    setShowModal(false);
-                    blocker.reset?.();
-                }
-            });
-        }
-    }, [blocker.state, blocker]);
+    const { showBlockerModal, setShowBlockerModal, blockerModalProps } = useUnsavedChangesBlocker({
+        hasChanged,
+        heading: "Save changes before leaving?",
+        description:
+            "You have unsaved changes in this award approval review. If you leave without completing this review, these changes will be lost.",
+        actionButtonText: "Go back",
+        secondaryButtonText: "Leave without saving"
+    });
 
     /**
      * Approve handler — opens confirmation modal, then PATCHes step 6
@@ -147,14 +131,15 @@ export default function useApproveAwardApproval(agreementId) {
     };
 
     /**
-     * Cancel handler
+     * Cancel handler — explicit user-initiated cancel from the page Cancel button
      */
     const handleCancel = () => {
         setShowModal(true);
         setModalProps({
-            heading: "Are you sure you want to cancel this task? Your input will not be saved.",
-            actionButtonText: "Yes, Cancel Task",
-            secondaryButtonText: "Continue Editing",
+            heading:
+                "Are you sure you want to cancel? This will exit the review process and you can come back to it later.",
+            actionButtonText: "Cancel",
+            secondaryButtonText: "Continue Reviewing",
             handleConfirm: () => {
                 flushSync(() => {
                     setIsNavigating(true);
@@ -186,6 +171,9 @@ export default function useApproveAwardApproval(agreementId) {
         showModal,
         setShowModal,
         modalProps,
+        showBlockerModal,
+        setShowBlockerModal,
+        blockerModalProps,
         isSubmitting,
         submitError,
         handleApprove,

--- a/frontend/src/pages/agreements/award-approval/ApproveAwardApproval.hooks.test.js
+++ b/frontend/src/pages/agreements/award-approval/ApproveAwardApproval.hooks.test.js
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { setupStore } from "../../../store";
+import useApproveAwardApproval from "./ApproveAwardApproval.hooks";
+
+// Mock API hooks
+vi.mock("../../../api/opsAPI", () => ({
+    useGetAgreementByIdQuery: vi.fn(),
+    useGetServicesComponentsListQuery: vi.fn(),
+    useGetGrantNumbersListQuery: vi.fn(),
+    useUpdateProcurementTrackerStepMutation: vi.fn(),
+    useGetDocumentsByAgreementIdQuery: vi.fn(),
+    useGetProcurementTrackersByAgreementIdQuery: vi.fn()
+}));
+
+vi.mock("../../../hooks/user.hooks", () => ({
+    default: vi.fn()
+}));
+
+vi.mock("../../../hooks/use-alert.hooks", () => ({
+    default: vi.fn()
+}));
+
+vi.mock("../../../helpers/budgetLines.helpers", () => ({
+    groupByServicesComponent: vi.fn(),
+    groupByGrantNumber: vi.fn(),
+    budgetLinesTotal: vi.fn()
+}));
+
+const mockNavigate = vi.fn();
+const mockUseBlocker = vi.fn(() => ({ state: "unblocked", proceed: vi.fn(), reset: vi.fn() }));
+
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual("react-router-dom");
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+        useBlocker: (...args) => mockUseBlocker(...args)
+    };
+});
+
+import {
+    useGetAgreementByIdQuery,
+    useGetServicesComponentsListQuery,
+    useGetGrantNumbersListQuery,
+    useUpdateProcurementTrackerStepMutation,
+    useGetDocumentsByAgreementIdQuery,
+    useGetProcurementTrackersByAgreementIdQuery
+} from "../../../api/opsAPI";
+import useGetUserFullNameFromId from "../../../hooks/user.hooks";
+import useAlert from "../../../hooks/use-alert.hooks";
+import { groupByServicesComponent, groupByGrantNumber, budgetLinesTotal } from "../../../helpers/budgetLines.helpers";
+
+const mockStep6 = {
+    id: 6,
+    step_number: 6,
+    requestor_notes: "Please review",
+    approval_status: null
+};
+
+const mockTrackerData = {
+    data: [{ status: "ACTIVE", steps: [mockStep6] }]
+};
+
+const createWrapper = (store) => {
+    const Wrapper = ({ children }) => (
+        <Provider store={store}>
+            <MemoryRouter>{children}</MemoryRouter>
+        </Provider>
+    );
+    Wrapper.displayName = "TestWrapper";
+    return Wrapper;
+};
+
+const setup = () => {
+    const store = setupStore({ auth: { activeUser: { id: 1, roles: [{ name: "BUDGET_TEAM" }] } } });
+    return renderHook(() => useApproveAwardApproval(1), { wrapper: createWrapper(store) });
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseBlocker.mockReturnValue({ state: "unblocked", proceed: vi.fn(), reset: vi.fn() });
+
+    useGetAgreementByIdQuery.mockReturnValue({
+        data: { id: 1, name: "Test Agreement", display_name: "Test Agreement", budget_line_items: [] },
+        isLoading: false
+    });
+    useGetServicesComponentsListQuery.mockReturnValue({ data: [] });
+    useGetGrantNumbersListQuery.mockReturnValue({ data: [] });
+    useUpdateProcurementTrackerStepMutation.mockReturnValue([vi.fn(), {}]);
+    useGetDocumentsByAgreementIdQuery.mockReturnValue({ data: { documents: [] } });
+    useGetProcurementTrackersByAgreementIdQuery.mockReturnValue({ data: mockTrackerData });
+    useGetUserFullNameFromId.mockReturnValue("Test User");
+    useAlert.mockReturnValue({ setAlert: vi.fn() });
+    groupByServicesComponent.mockReturnValue([]);
+    groupByGrantNumber.mockReturnValue([]);
+    budgetLinesTotal.mockReturnValue(0);
+});
+
+describe("useApproveAwardApproval — handleCancel modal", () => {
+    it("opens cancel modal with correct review-flow copy", () => {
+        const { result } = setup();
+
+        act(() => {
+            result.current.handleCancel();
+        });
+
+        expect(result.current.showModal).toBe(true);
+        expect(result.current.modalProps.heading).toContain("exit the review process");
+        expect(result.current.modalProps.actionButtonText).toBe("Cancel");
+        expect(result.current.modalProps.secondaryButtonText).toBe("Continue Reviewing");
+    });
+
+    it("navigates away on handleConfirm", () => {
+        const { result } = setup();
+
+        act(() => {
+            result.current.handleCancel();
+        });
+        act(() => {
+            result.current.modalProps.handleConfirm();
+        });
+
+        expect(mockNavigate).toHaveBeenCalledWith("/agreements?filter=change-requests");
+    });
+
+    it("closes modal on closeModal without navigating", () => {
+        const { result } = setup();
+
+        act(() => {
+            result.current.handleCancel();
+        });
+        act(() => {
+            result.current.modalProps.closeModal();
+        });
+
+        expect(result.current.showModal).toBe(false);
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+});
+
+describe("useApproveAwardApproval — navigation blocker", () => {
+    let mockProceed;
+    let mockReset;
+
+    beforeEach(() => {
+        mockProceed = vi.fn();
+        mockReset = vi.fn();
+        mockUseBlocker.mockReturnValue({ state: "unblocked", proceed: mockProceed, reset: mockReset });
+    });
+
+    it("does not block navigation when obligated date is empty", async () => {
+        let capturedCb;
+        mockUseBlocker.mockImplementation((cb) => {
+            capturedCb = cb;
+            return { state: "unblocked", proceed: mockProceed, reset: mockReset };
+        });
+
+        const { result } = setup();
+        await waitFor(() => expect(result.current).toBeDefined());
+
+        const shouldBlock = capturedCb({
+            currentLocation: { pathname: "/agreements/1/review-award" },
+            nextLocation: { pathname: "/agreements" }
+        });
+        expect(shouldBlock).toBe(false);
+    });
+
+    it("blocks navigation when obligated date has been entered", async () => {
+        let capturedCb;
+        mockUseBlocker.mockImplementation((cb) => {
+            capturedCb = cb;
+            return { state: "unblocked", proceed: mockProceed, reset: mockReset };
+        });
+
+        const { result } = setup();
+        await waitFor(() => expect(result.current).toBeDefined());
+
+        act(() => {
+            result.current.setObligatedDate("2026-08-12");
+        });
+
+        await waitFor(() => {
+            const shouldBlock = capturedCb({
+                currentLocation: { pathname: "/agreements/1/review-award" },
+                nextLocation: { pathname: "/agreements" }
+            });
+            expect(shouldBlock).toBe(true);
+        });
+    });
+
+    it("shows 'Save changes before leaving?' copy when blocker fires", async () => {
+        mockUseBlocker.mockReturnValue({ state: "blocked", proceed: mockProceed, reset: mockReset });
+
+        const { result } = setup();
+
+        await waitFor(() => {
+            expect(result.current.showBlockerModal).toBe(true);
+            expect(result.current.blockerModalProps.heading).toBe("Save changes before leaving?");
+            expect(result.current.blockerModalProps.actionButtonText).toBe("Go back");
+            expect(result.current.blockerModalProps.secondaryButtonText).toBe("Leave without saving");
+        });
+    });
+
+    it("resets blocker and hides modal on handleConfirm (Go back)", async () => {
+        mockUseBlocker.mockReturnValue({ state: "blocked", proceed: mockProceed, reset: mockReset });
+
+        const { result } = setup();
+        await waitFor(() => expect(result.current.showBlockerModal).toBe(true));
+
+        act(() => {
+            result.current.blockerModalProps.handleConfirm();
+        });
+
+        await waitFor(() => {
+            expect(result.current.showBlockerModal).toBe(false);
+            expect(mockReset).toHaveBeenCalled();
+            expect(mockProceed).not.toHaveBeenCalled();
+        });
+    });
+
+    it("proceeds with navigation and hides modal on handleSecondary (Leave without saving)", async () => {
+        mockUseBlocker.mockReturnValue({ state: "blocked", proceed: mockProceed, reset: mockReset });
+
+        const { result } = setup();
+        await waitFor(() => expect(result.current.showBlockerModal).toBe(true));
+
+        await act(async () => {
+            await result.current.blockerModalProps.handleSecondary();
+        });
+
+        await waitFor(() => {
+            expect(result.current.showBlockerModal).toBe(false);
+            expect(mockProceed).toHaveBeenCalled();
+            expect(mockReset).not.toHaveBeenCalled();
+        });
+    });
+
+    it("resets blocker and hides modal on closeModal (Escape)", async () => {
+        mockUseBlocker.mockReturnValue({ state: "blocked", proceed: mockProceed, reset: mockReset });
+
+        const { result } = setup();
+        await waitFor(() => expect(result.current.showBlockerModal).toBe(true));
+
+        act(() => {
+            result.current.blockerModalProps.closeModal();
+        });
+
+        await waitFor(() => {
+            expect(result.current.showBlockerModal).toBe(false);
+            expect(mockReset).toHaveBeenCalled();
+            expect(mockProceed).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/frontend/src/pages/agreements/award-approval/ApproveAwardApproval.jsx
+++ b/frontend/src/pages/agreements/award-approval/ApproveAwardApproval.jsx
@@ -39,6 +39,9 @@ export const ApproveAwardApproval = () => {
         showModal,
         setShowModal,
         modalProps,
+        showBlockerModal,
+        setShowBlockerModal,
+        blockerModalProps,
         isSubmitting,
         submitError,
         hasPermission,
@@ -76,7 +79,20 @@ export const ApproveAwardApproval = () => {
                     actionButtonText={modalProps.actionButtonText}
                     secondaryButtonText={modalProps.secondaryButtonText}
                     handleConfirm={modalProps.handleConfirm}
+                    handleSecondary={modalProps.handleSecondary}
                     closeModal={modalProps.closeModal}
+                />
+            )}
+            {showBlockerModal && (
+                <SaveChangesAndExitModal
+                    heading={blockerModalProps.heading}
+                    description={blockerModalProps.description}
+                    setShowModal={setShowBlockerModal}
+                    actionButtonText={blockerModalProps.actionButtonText}
+                    secondaryButtonText={blockerModalProps.secondaryButtonText}
+                    handleConfirm={blockerModalProps.handleConfirm}
+                    handleSecondary={blockerModalProps.handleSecondary}
+                    closeModal={blockerModalProps.closeModal}
                 />
             )}
 


### PR DESCRIPTION
## Summary

- Fixes wrong cancel modal text on the Budget Team award approval review page (`/agreements/:id/review-award`), reported in the last comment of [#5931](https://github.com/HHS/OPRE-OPS/issues/5931)
- Fixes a pre-existing bug where clicking "Continue Reviewing" in the nav-away blocker never called `blocker.reset()`, leaving the router permanently blocked
- Replaces the inline `useBlocker`/`useEffect` with the shared `useUnsavedChangesBlocker` hook (same pattern as `ApprovePreAwardApproval`), using "Save changes before leaving?" / "Go back" / "Leave without saving" for accidental navigation
- The explicit Cancel button keeps the "exit the review process" / "Continue Reviewing" copy per Figma design
- Adds `ApproveAwardApproval.hooks.test.js` (9 tests) to pin cancel modal copy and blocker behavior against regressions

## Test plan

- [ ] As a Budget Team user on the award approval review page, enter an obligated date then click away (nav link, back button) — should see "Save changes before leaving?" modal with "Go back" and "Leave without saving"
- [ ] Click "Go back" — modal dismisses, stay on page, can continue editing
- [ ] Click "Leave without saving" — navigates away, date discarded
- [ ] Click the page-level "Cancel" button — should see "Are you sure you want to cancel? This will exit the review process and you can come back to it later." with "Cancel" and "Continue Reviewing"
- [ ] Click "Continue Reviewing" — modal dismisses, stay on page
- [ ] Click "Cancel" (confirm) — navigates to `/agreements?filter=change-requests`
- [ ] Without entering a date, navigate away — no modal fires
- [ ] `bun run test --watch=false -- ApproveAwardApproval` — all tests pass