### PR TITLE
ci: notify Slack when a user is @-mentioned in a GitHub comment

### DIFF
--- a/.github/slack_user_map.json
+++ b/.github/slack_user_map.json
@@ -1,10 +1,9 @@
 {
     "_comment": "Map GitHub usernames (lowercase) to Slack member IDs, used by slack_mention_notify.yml to turn @github-mentions into real Slack pings. Find a Slack member ID via a user's profile > More (kebab menu) > Copy member ID.",
-    "octocat": "U0123456789",
     "rajohnson90": "U070RCWHMCL",
     "weimiao67": "U04P2UN6N0K",
     "josbell": "U02D0HFJ725",
-    "Santi-3rd": "U074V0UH1D4",
+    "santi-3rd": "U074V0UH1D4",
     "jonnalley": "U02FKHMF2GN",
     "npage123": "U02933CUQ",
     "kimschulke": "U013RKN5CEN",

--- a/.github/slack_user_map.json
+++ b/.github/slack_user_map.json
@@ -1,0 +1,12 @@
+{
+    "_comment": "Map GitHub usernames (lowercase) to Slack member IDs, used by slack_mention_notify.yml to turn @github-mentions into real Slack pings. Find a Slack member ID via a user's profile > More (kebab menu) > Copy member ID.",
+    "octocat": "U0123456789",
+    "rajohnson90": "U070RCWHMCL",
+    "weimiao67": "U04P2UN6N0K",
+    "josbell": "U02D0HFJ725",
+    "Santi-3rd": "U074V0UH1D4",
+    "jonnalley": "U02FKHMF2GN",
+    "npage123": "U02933CUQ",
+    "kimschulke": "U013RKN5CEN",
+    "andressacurvelo": "U03U61WS6Q0"
+}

--- a/.github/workflows/slack_mention_notify.yml
+++ b/.github/workflows/slack_mention_notify.yml
@@ -1,0 +1,96 @@
+name: Notify Slack on PR/Issue Mention
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  notify-mention:
+    runs-on: ubuntu-latest
+    # Restrict to org members/collaborators so a public-repo commenter can't trigger real Slack pings
+    if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    steps:
+      - name: Rate limit check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.event.comment.user.login }}
+          MAX_RUNS: "5"
+          WINDOW_MINUTES: "10"
+        run: |
+          # Even a trusted member/collaborator account can be compromised or turn malicious,
+          # so cap how many times this workflow can fire per commenter in a rolling window --
+          # using GitHub's own run history as state, since Actions has no persistent store.
+          since=$(date -u -d "${WINDOW_MINUTES} minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+          run_count=$(gh api "repos/${REPO}/actions/workflows/slack_mention_notify.yml/runs" \
+            -f actor="$ACTOR" -f created=">=${since}" --jq '.total_count')
+
+          echo "run_count=${run_count}" >> "$GITHUB_ENV"
+
+          if [ "$run_count" -gt "$MAX_RUNS" ]; then
+            echo "::warning::${ACTOR} has triggered this workflow ${run_count} times in the last ${WINDOW_MINUTES} minutes (limit ${MAX_RUNS}); skipping Slack notification."
+            echo "rate_limited=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Checkout (for slack_user_map.json)
+        if: env.rate_limited != 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          sparse-checkout: |
+            .github/slack_user_map.json
+          sparse-checkout-cone-mode: false
+
+      - name: Find mentions and notify Slack
+        if: env.rate_limited != 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          IS_PR: ${{ github.event.issue.pull_request && 'true' || 'false' }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Strip fenced code blocks so mentions inside code samples don't trigger a false positive
+          body_no_code=$(printf '%s\n' "$COMMENT_BODY" | sed '/^```/,/^```/d')
+
+          mentions=$(printf '%s' "$body_no_code" \
+            | grep -oP '(?<![\w.@-])@[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}\b' \
+            | sed 's/^@//' | sort -u)
+
+          if [ -z "$mentions" ]; then
+            echo "No user mentions found in comment, skipping Slack notification."
+            exit 0
+          fi
+
+          # Resolve each mentioned GitHub username to a Slack member ID via the
+          # mapping file, falling back to the plain @username text if unmapped.
+          mention_text=""
+          while IFS= read -r gh_user; do
+            gh_user_lower=$(printf '%s' "$gh_user" | tr '[:upper:]' '[:lower:]')
+            slack_id=$(jq -r --arg u "$gh_user_lower" '.[$u] // empty' .github/slack_user_map.json)
+            if [ -n "$slack_id" ]; then
+              mention_text="${mention_text}<@${slack_id}> "
+            else
+              mention_text="${mention_text}@${gh_user} "
+            fi
+          done <<< "$mentions"
+
+          kind="issue"
+          if [ "$IS_PR" = "true" ]; then
+            kind="pull request"
+          fi
+
+          # Slack mrkdwn treats &, <, > as syntax (e.g. closing a <url|label> link early to
+          # inject new links or <!channel> mentions) -- escape them per Slack's formatting spec.
+          escaped_title=$(printf '%s' "$ISSUE_TITLE" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g')
+
+          text="*${COMMENT_AUTHOR}* mentioned ${mention_text}in a comment on ${kind} <${COMMENT_URL}|${REPO}#${ISSUE_NUMBER}: ${escaped_title}>"
+
+          payload=$(jq -n --arg text "$text" '{text: $text}')
+          curl -sf -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/slack_mention_notify.yml
+++ b/.github/workflows/slack_mention_notify.yml
@@ -60,7 +60,7 @@ jobs:
           body_no_code=$(printf '%s\n' "$COMMENT_BODY" | sed '/^```/,/^```/d')
 
           mentions=$(printf '%s' "$body_no_code" \
-            | grep -oP '(?<![\w.@-])@[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}\b' \
+            | { grep -oP '(?<![\w.@-])@[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}\b' || true; } \
             | sed 's/^@//' | sort -u)
 
           if [ -z "$mentions" ]; then

--- a/.github/workflows/slack_mention_notify.yml
+++ b/.github/workflows/slack_mention_notify.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   notify-mention:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     # Restrict to org members/collaborators so a public-repo commenter can't trigger real Slack pings
     if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     steps:
@@ -26,6 +27,9 @@ jobs:
           # so cap how many times this workflow can fire per commenter in a rolling window --
           # using GitHub's own run history as state, since Actions has no persistent store.
           since=$(date -u -d "${WINDOW_MINUTES} minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+          # Filename below must match this workflow's own file -- if this file is ever
+          # renamed, update it too, or this 404s, run_count comes back empty, and the
+          # rate limit silently stops enforcing.
           run_count=$(gh api "repos/${REPO}/actions/workflows/slack_mention_notify.yml/runs" \
             -f actor="$ACTOR" -f created=">=${since}" --jq '.total_count')
 
@@ -56,7 +60,9 @@ jobs:
           IS_PR: ${{ github.event.issue.pull_request && 'true' || 'false' }}
           REPO: ${{ github.repository }}
         run: |
-          # Strip fenced code blocks so mentions inside code samples don't trigger a false positive
+          # Strip fenced code blocks so mentions inside code samples don't trigger a false positive.
+          # Detection-accuracy limitation only: an unclosed ``` fence deletes to EOF (dropping any
+          # later mentions), and indented or ~~~-style fences aren't recognized and won't be stripped.
           body_no_code=$(printf '%s\n' "$COMMENT_BODY" | sed '/^```/,/^```/d')
 
           mentions=$(printf '%s' "$body_no_code" \
@@ -93,4 +99,4 @@ jobs:
           text="*${COMMENT_AUTHOR}* mentioned ${mention_text}in a comment on ${kind} <${COMMENT_URL}|${REPO}#${ISSUE_NUMBER}: ${escaped_title}>"
 
           payload=$(jq -n --arg text "$text" '{text: $text}')
-          curl -sf -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+          curl -s --fail-with-body -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## What changed

Adds a GitHub Action that posts a Slack notification whenever a GitHub username is @-mentioned in an issue or PR comment.

**`.github/workflows/slack_mention_notify.yml`**
- Triggers on `issue_comment: created`, extracts `@username` mentions from the comment body (ignoring mentions inside fenced code blocks), and resolves each to a real Slack member ID via `.github/slack_user_map.json`, falling back to plain `@username` text for unmapped users.
- Posts the resulting message to a Slack channel via an Incoming Webhook (`secrets.SLACK_WEBHOOK_URL`).
- Includes hardening added after an adversarial security review (threat model: a malicious actor with only comment permissions, or a compromised/malicious insider):
  - **Access gate**: only runs for comments from `OWNER`/`MEMBER`/`COLLABORATOR`, so a random public-repo commenter can't trigger real Slack pings.
  - **Mrkdwn escaping**: the issue/PR title is HTML-entity-escaped (`&`, `<`, `>`) before being embedded in the Slack message, preventing an attacker-controlled title from breaking out of the link syntax to inject a fake link or a `<!channel>` mass-ping.
  - **Rate limiting**: a first step queries GitHub's own workflow-run history for the commenting actor and skips the notification if that actor has triggered this workflow more than 5 times in the last 10 minutes — bounding harassment/spam potential from a single compromised or malicious insider account.

**`.github/slack_user_map.json`**
- New mapping of GitHub usernames to Slack member IDs used to resolve mentions to real Slack pings.

## Issue

N/A

## How to test

1. Ensure the `SLACK_WEBHOOK_URL` repo secret is configured (Settings → Secrets and variables → Actions) pointing at the desired Slack channel's Incoming Webhook.
2. As an org member/collaborator, comment on any issue or PR with `@<a-github-username-from-slack_user_map.json>` and confirm a message appears in the target Slack channel with a real `<@member-id>` mention.
3. Comment with `@some-unmapped-username` and confirm the notification still posts, falling back to plain `@some-unmapped-username` text.
4. Comment with a title/body containing `<`, `>`, or `&` characters (e.g. open an issue titled `Test > <!channel> test`) and mention someone, then confirm in Slack that the message renders as plain text rather than as a live `@channel` ping or a broken/injected link.
5. Trigger the workflow more than 5 times within 10 minutes as the same actor and confirm the 6th+ run logs a `::warning::` and skips the checkout/notify steps (visible in the Actions run log).
6. Confirm the workflow does not fire at all when a non-collaborator/non-member comments (check `author_association` via a test account without repo permissions, if available).

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] No UI component changes in this PR

## Screenshots

N/A — backend/CI-only change, no UI

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A