### PR TITLE
Warn before Edit discards unsaved pre-award request notes

### DIFF
--- a/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.js
+++ b/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.js
@@ -39,6 +39,8 @@ export default function useRequestPreAwardApproval(agreementId) {
     const [showModal, setShowModal] = useState(false);
     const [modalProps, setModalProps] = useState({});
     const [isNavigating, setIsNavigating] = useState(false);
+    const [showEditWarningModal, setShowEditWarningModal] = useState(false);
+    const [editWarningModalProps, setEditWarningModalProps] = useState({});
 
     const [updateProcurementTrackerStep] = useUpdateProcurementTrackerStepMutation();
     const [addDocument] = useAddDocumentMutation();
@@ -311,13 +313,39 @@ export default function useRequestPreAwardApproval(agreementId) {
 
     const handleEdit = () => {
         const returnTo = encodeURIComponent(`/agreements/${agreementId}/pre-award-approval`);
-        // flushSync forces the isNavigating commit (and blocker re-registration) before
-        // navigate() so the blocker's synchronous forward-push check sees isNavigating=true
-        // and lets the edit navigation through instead of showing the cancel modal.
-        flushSync(() => {
-            setIsNavigating(true);
+        const goToEditPage = () => {
+            // flushSync forces the isNavigating commit (and blocker re-registration) before
+            // navigate() so the blocker's synchronous forward-push check sees isNavigating=true
+            // and lets the edit navigation through instead of showing the cancel modal.
+            flushSync(() => {
+                setIsNavigating(true);
+            });
+            navigate(`/agreements/review/${agreementId}/edit?returnTo=${returnTo}`);
+        };
+
+        if (!hasChanged) {
+            goToEditPage();
+            return;
+        }
+
+        setShowEditWarningModal(true);
+        setEditWarningModalProps({
+            heading: "Save changes before leaving?",
+            description:
+                "You have unsaved changes in this pre-award request. If you leave without saving, these changes will be lost.",
+            actionButtonText: "Go back",
+            secondaryButtonText: "Leave without saving",
+            handleConfirm: () => {
+                setShowEditWarningModal(false);
+            },
+            handleSecondary: () => {
+                setShowEditWarningModal(false);
+                goToEditPage();
+            },
+            closeModal: () => {
+                setShowEditWarningModal(false);
+            }
         });
-        navigate(`/agreements/review/${agreementId}/edit?returnTo=${returnTo}`);
     };
 
     return {
@@ -331,6 +359,9 @@ export default function useRequestPreAwardApproval(agreementId) {
         handleSubmit,
         handleCancel,
         handleEdit,
+        showEditWarningModal,
+        setShowEditWarningModal,
+        editWarningModalProps,
         projectOfficerName,
         alternateProjectOfficerName,
         servicesComponents,

--- a/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.test.js
+++ b/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.test.js
@@ -124,6 +124,7 @@ describe("useRequestPreAwardApproval — navigation blocker", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        navigateMock.mockReset();
         mockProceed = vi.fn();
         mockReset = vi.fn();
         mockUseBlocker.mockReturnValue({ state: "unblocked", proceed: mockProceed, reset: mockReset });
@@ -233,6 +234,7 @@ describe("useRequestPreAwardApproval — edit warning modal", () => {
 
     beforeEach(() => {
         vi.clearAllMocks();
+        navigateMock.mockReset();
         mockProceed = vi.fn();
         mockReset = vi.fn();
         mockUseBlocker.mockReturnValue({ state: "unblocked", proceed: mockProceed, reset: mockReset });

--- a/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.test.js
+++ b/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.test.js
@@ -171,30 +171,19 @@ describe("useRequestPreAwardApproval — navigation blocker", () => {
         const { result } = setup(buildAgreement());
         await waitFor(() => expect(result.current).toBeDefined());
 
-        // Typed notes -> hasChanged=true, so the blocker would fire on navigation.
-        act(() => {
-            result.current.setNotes("some note");
-        });
-
         const nav = {
             currentLocation: { pathname: "/agreements/1/pre-award-approval" },
             nextLocation: { pathname: "/agreements/review/1/edit" }
         };
 
-        // BEFORE handleEdit: predicate blocks (isNavigating=false).
-        await waitFor(() => expect(capturedCb(nav)).toBe(true));
+        // BEFORE handleEdit: predicate does not block (hasChanged=false, no unsaved notes).
+        await waitFor(() => expect(capturedCb(nav)).toBe(false));
 
         // handleEdit sets the isNavigating bypass then navigates to the edit form.
         act(() => {
             result.current.handleEdit();
         });
 
-        // AFTER handleEdit: the bypass is set so the predicate no longer blocks, and
-        // navigate got the encoded returnTo URL. NOTE: with useBlocker mocked, this
-        // guards the bypass-flag contract and the URL — but not the flushSync timing
-        // itself (react-router's synchronous re-check on a real forward push is what
-        // requires flushSync; that is only observable with a real router, not here).
-        expect(capturedCb(nav)).toBe(false);
         expect(navigateMock).toHaveBeenCalledWith(
             "/agreements/review/1/edit?returnTo=%2Fagreements%2F1%2Fpre-award-approval"
         );
@@ -235,6 +224,141 @@ describe("useRequestPreAwardApproval — navigation blocker", () => {
             expect(mockReset).toHaveBeenCalled();
             expect(mockProceed).not.toHaveBeenCalled();
         });
+    });
+});
+
+describe("useRequestPreAwardApproval — edit warning modal", () => {
+    let mockProceed;
+    let mockReset;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockProceed = vi.fn();
+        mockReset = vi.fn();
+        mockUseBlocker.mockReturnValue({ state: "unblocked", proceed: mockProceed, reset: mockReset });
+    });
+
+    it("navigates straight to the edit page when there are no unsaved notes", async () => {
+        const { result } = setup(buildAgreement());
+        await waitFor(() => expect(result.current).toBeDefined());
+
+        act(() => {
+            result.current.handleEdit();
+        });
+
+        expect(result.current.showEditWarningModal).toBe(false);
+        expect(navigateMock).toHaveBeenCalledWith(
+            "/agreements/review/1/edit?returnTo=%2Fagreements%2F1%2Fpre-award-approval"
+        );
+    });
+
+    it("shows the warning modal instead of navigating when notes are unsaved", async () => {
+        const { result } = setup(buildAgreement());
+        await waitFor(() => expect(result.current).toBeDefined());
+
+        act(() => {
+            result.current.setNotes("some note");
+        });
+
+        act(() => {
+            result.current.handleEdit();
+        });
+
+        expect(navigateMock).not.toHaveBeenCalled();
+        expect(result.current.showEditWarningModal).toBe(true);
+        expect(result.current.editWarningModalProps.heading).toBe("Save changes before leaving?");
+        expect(result.current.editWarningModalProps.description).toBe(
+            "You have unsaved changes in this pre-award request. If you leave without saving, these changes will be lost."
+        );
+        expect(result.current.editWarningModalProps.actionButtonText).toBe("Go back");
+        expect(result.current.editWarningModalProps.secondaryButtonText).toBe("Leave without saving");
+    });
+
+    it("handleConfirm (Go back) closes the modal and does not navigate", async () => {
+        const { result } = setup(buildAgreement());
+        await waitFor(() => expect(result.current).toBeDefined());
+
+        act(() => {
+            result.current.setNotes("some note");
+        });
+        act(() => {
+            result.current.handleEdit();
+        });
+        expect(result.current.showEditWarningModal).toBe(true);
+
+        act(() => {
+            result.current.editWarningModalProps.handleConfirm();
+        });
+
+        expect(result.current.showEditWarningModal).toBe(false);
+        expect(navigateMock).not.toHaveBeenCalled();
+    });
+
+    it("handleSecondary (Leave without saving) bypasses the blocker at navigate-time and navigates to the edit page", async () => {
+        // This test guards the flushSync timing inside goToEditPage(), not just the URL.
+        // Notes are NOT cleared by handleSecondary, so hasChanged stays true the whole
+        // time — only isNavigating flipping via flushSync (a synchronous commit, not a
+        // batched setState) makes the blocker predicate false at the instant navigate()
+        // fires, matching react-router's real synchronous re-check on a forward push.
+        // See the useblocker-bypass-regression-test skill for why an after-act() check
+        // of capturedCb would pass even if flushSync were replaced by a plain setState.
+        let capturedCb;
+        mockUseBlocker.mockImplementation((cb) => {
+            capturedCb = cb;
+            return { state: "unblocked", proceed: mockProceed, reset: mockReset };
+        });
+        const { result } = setup(buildAgreement());
+        await waitFor(() => expect(result.current).toBeDefined());
+
+        act(() => {
+            result.current.setNotes("some note");
+        });
+
+        const nav = {
+            currentLocation: { pathname: "/agreements/1/pre-award-approval" },
+            nextLocation: { pathname: "/agreements/review/1/edit" }
+        };
+        await waitFor(() => expect(capturedCb(nav)).toBe(true));
+
+        act(() => {
+            result.current.handleEdit();
+        });
+        expect(result.current.showEditWarningModal).toBe(true);
+
+        // Capture the predicate's value at the exact moment navigate() runs.
+        let blockedAtNavigateTime;
+        navigateMock.mockImplementation(() => {
+            blockedAtNavigateTime = capturedCb(nav);
+        });
+
+        act(() => {
+            result.current.editWarningModalProps.handleSecondary();
+        });
+
+        expect(blockedAtNavigateTime).toBe(false);
+        expect(result.current.showEditWarningModal).toBe(false);
+        expect(navigateMock).toHaveBeenCalledWith(
+            "/agreements/review/1/edit?returnTo=%2Fagreements%2F1%2Fpre-award-approval"
+        );
+    });
+
+    it("closeModal behaves the same as handleConfirm (Go back)", async () => {
+        const { result } = setup(buildAgreement());
+        await waitFor(() => expect(result.current).toBeDefined());
+
+        act(() => {
+            result.current.setNotes("some note");
+        });
+        act(() => {
+            result.current.handleEdit();
+        });
+
+        act(() => {
+            result.current.editWarningModalProps.closeModal();
+        });
+
+        expect(result.current.showEditWarningModal).toBe(false);
+        expect(navigateMock).not.toHaveBeenCalled();
     });
 });
 

--- a/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.jsx
+++ b/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.jsx
@@ -9,6 +9,7 @@ import Accordion from "../../../components/UI/Accordion";
 import TextArea from "../../../components/UI/Form/TextArea";
 import SimpleAlert from "../../../components/UI/Alert/SimpleAlert";
 import ConfirmationModal from "../../../components/UI/Modals/ConfirmationModal";
+import SaveChangesAndExitModal from "../../../components/UI/Modals/SaveChangesAndExitModal";
 import DisabledButtonWithTooltip from "../../../components/UI/Button/DisabledButtonWithTooltip";
 import { convertCodeForDisplay } from "../../../helpers/utils";
 import { scrollToTop } from "../../../helpers/scrollToTop.helper";
@@ -38,6 +39,9 @@ export const RequestPreAwardApproval = () => {
         handleSubmit,
         handleCancel,
         handleEdit,
+        showEditWarningModal,
+        setShowEditWarningModal,
+        editWarningModalProps,
         projectOfficerName,
         alternateProjectOfficerName,
         servicesComponents,
@@ -127,6 +131,19 @@ export const RequestPreAwardApproval = () => {
                     actionButtonText={modalProps.actionButtonText}
                     secondaryButtonText={modalProps.secondaryButtonText}
                     handleConfirm={modalProps.handleConfirm}
+                />
+            )}
+
+            {showEditWarningModal && (
+                <SaveChangesAndExitModal
+                    heading={editWarningModalProps.heading}
+                    description={editWarningModalProps.description}
+                    actionButtonText={editWarningModalProps.actionButtonText}
+                    secondaryButtonText={editWarningModalProps.secondaryButtonText}
+                    handleConfirm={editWarningModalProps.handleConfirm}
+                    handleSecondary={editWarningModalProps.handleSecondary}
+                    closeModal={editWarningModalProps.closeModal}
+                    setShowModal={setShowEditWarningModal}
                 />
             )}
 

--- a/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.test.jsx
+++ b/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.test.jsx
@@ -68,6 +68,20 @@ vi.mock("../../../components/UI/Form/TextArea", () => ({
     )
 }));
 
+vi.mock("../../../components/UI/Modals/SaveChangesAndExitModal", () => ({
+    __esModule: true,
+    default: (/** @type {{ heading: string; secondaryButtonText: string; handleSecondary: () => void }} */ {
+        heading,
+        secondaryButtonText,
+        handleSecondary
+    }) => (
+        <div data-testid="save-changes-modal">
+            <h3>{heading}</h3>
+            <button onClick={handleSecondary}>{secondaryButtonText}</button>
+        </div>
+    )
+}));
+
 vi.mock("../../../components/UI/PageHeader", () => ({
     __esModule: true,
     default: (/** @type {{ title: string; subTitle: string }} */ { title, subTitle }) => (
@@ -118,6 +132,9 @@ const baseHookResult = () => ({
     showModal: false,
     setShowModal: vi.fn(),
     modalProps: {},
+    showEditWarningModal: false,
+    setShowEditWarningModal: vi.fn(),
+    editWarningModalProps: {},
     agreementValidationResults: null,
     hasBLIError: false,
     pageErrors: {},
@@ -482,6 +499,36 @@ describe("RequestPreAwardApproval", () => {
             render(<RequestPreAwardApproval />);
 
             expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+        });
+
+        it("shows the save-changes-before-leaving modal instead of the Edit button's own navigation when showEditWarningModal is true", () => {
+            requestPreAwardApprovalHookMock.mockReturnValue({
+                ...baseHookResult(),
+                showEditWarningModal: true,
+                editWarningModalProps: {
+                    heading: "Save changes before leaving?",
+                    description:
+                        "You have unsaved changes in this pre-award request. If you leave without saving, these changes will be lost.",
+                    actionButtonText: "Go back",
+                    secondaryButtonText: "Leave without saving",
+                    handleConfirm: vi.fn(),
+                    handleSecondary: vi.fn(),
+                    closeModal: vi.fn()
+                }
+            });
+
+            render(<RequestPreAwardApproval />);
+
+            expect(screen.getByTestId("save-changes-modal")).toBeInTheDocument();
+            expect(screen.getByText("Save changes before leaving?")).toBeInTheDocument();
+        });
+
+        it("does not render the save-changes modal when showEditWarningModal is false", () => {
+            requestPreAwardApprovalHookMock.mockReturnValue(baseHookResult());
+
+            render(<RequestPreAwardApproval />);
+
+            expect(screen.queryByTestId("save-changes-modal")).not.toBeInTheDocument();
         });
     });
 

--- a/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.test.jsx
+++ b/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.test.jsx
@@ -70,13 +70,20 @@ vi.mock("../../../components/UI/Form/TextArea", () => ({
 
 vi.mock("../../../components/UI/Modals/SaveChangesAndExitModal", () => ({
     __esModule: true,
-    default: (/** @type {{ heading: string; secondaryButtonText: string; handleSecondary: () => void }} */ {
-        heading,
-        secondaryButtonText,
-        handleSecondary
-    }) => (
+    default: (
+        /** @type {{ heading: string; description: string; actionButtonText: string; secondaryButtonText: string; handleConfirm: () => void; handleSecondary: () => void }} */ {
+            heading,
+            description,
+            actionButtonText,
+            secondaryButtonText,
+            handleConfirm,
+            handleSecondary
+        }
+    ) => (
         <div data-testid="save-changes-modal">
             <h3>{heading}</h3>
+            <p>{description}</p>
+            <button onClick={handleConfirm}>{actionButtonText}</button>
             <button onClick={handleSecondary}>{secondaryButtonText}</button>
         </div>
     )
@@ -501,7 +508,8 @@ describe("RequestPreAwardApproval", () => {
             expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
         });
 
-        it("shows the save-changes-before-leaving modal instead of the Edit button's own navigation when showEditWarningModal is true", () => {
+        it("shows the save-changes-before-leaving modal instead of the Edit button's own navigation when showEditWarningModal is true", async () => {
+            const handleSecondaryMock = vi.fn();
             requestPreAwardApprovalHookMock.mockReturnValue({
                 ...baseHookResult(),
                 showEditWarningModal: true,
@@ -512,15 +520,26 @@ describe("RequestPreAwardApproval", () => {
                     actionButtonText: "Go back",
                     secondaryButtonText: "Leave without saving",
                     handleConfirm: vi.fn(),
-                    handleSecondary: vi.fn(),
+                    handleSecondary: handleSecondaryMock,
                     closeModal: vi.fn()
                 }
             });
 
+            const user = userEvent.setup();
             render(<RequestPreAwardApproval />);
 
             expect(screen.getByTestId("save-changes-modal")).toBeInTheDocument();
             expect(screen.getByText("Save changes before leaving?")).toBeInTheDocument();
+            expect(
+                screen.getByText(
+                    "You have unsaved changes in this pre-award request. If you leave without saving, these changes will be lost."
+                )
+            ).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Go back" })).toBeInTheDocument();
+
+            await user.click(screen.getByRole("button", { name: "Leave without saving" }));
+
+            expect(handleSecondaryMock).toHaveBeenCalledTimes(1);
         });
 
         it("does not render the save-changes modal when showEditWarningModal is false", () => {


### PR DESCRIPTION
## What changed

On the Request Pre-Award Approval page (`/agreements/:id/pre-award-approval`), clicking "Edit" while the Notes field has unsaved text now shows a "Save changes before leaving?" warning modal instead of silently discarding the notes and navigating straight to the edit form.

This is a follow-up to #6061: the original fix for that issue made Edit always bypass the page's navigation blocker (because it was incorrectly showing an "Are you sure you want to cancel your pre-award request?" modal on every Edit click, even with nothing unsaved). The client later clarified that unsaved notes should still trigger a warning — just not the cancel-specific one.

**`RequestPreAwardApproval.hooks.js`** — `handleEdit` now branches on the existing `hasChanged` flag: with no unsaved changes it behaves exactly as before (bypass + navigate); with unsaved changes it shows new modal state (`showEditWarningModal` / `editWarningModalProps`) instead of navigating. Reuses the existing `SaveChangesAndExitModal` component and copy pattern already used by sibling pages (`ApprovePreAwardApproval`, `ApproveAgreement`, `ApproveAwardApproval`) rather than introducing a new mechanism. Deliberately does not add a second `useBlocker` — a second blocker instance would race with the existing Cancel-button guard, so this is a plain click-time check instead.

**`RequestPreAwardApproval.jsx`** — renders the new `SaveChangesAndExitModal` alongside the existing `ConfirmationModal`, gated on `showEditWarningModal`.

**Tests** — hook tests cover both branches plus all three modal actions (Go back / Leave without saving / close). One test specifically guards the `flushSync` bypass timing by evaluating the blocker predicate at the exact moment `navigate()` fires (not just after `act()` settles), since a naive after-the-fact check would pass even if `flushSync` were silently replaced by a plain `setState` — this is the same class of regression the original #6061 fix addressed. Component tests confirm the modal renders with the right copy and wiring when shown, and does not render otherwise.

## Issue

https://github.com/HHS/OPRE-OPS/issues/6061

## How to test

**Automated:**
```
cd frontend
bun run test --watch=false src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.test.js src/pages/agreements/pre-award-approval/RequestPreAwardApproval.test.jsx
```

**Manual** (needs an agreement with Step 4 completed and pre-award approval not yet requested, e.g. seeded agreement 13):
- [ ] Visit `/agreements/13/pre-award-approval`. With the Notes field empty, click Edit — should navigate straight to the edit form, no modal.
- [ ] Return to the page, type text into Notes, click Edit — should see "Save changes before leaving?" with "Go back" and "Leave without saving".
- [ ] Click "Go back" — modal closes, stays on the page, typed notes are still there.
- [ ] Click Edit again, then "Leave without saving" — navigates to the edit form.
- [ ] With notes typed, click the page's "Cancel" button (not Edit) — should still show the original "Are you sure you want to cancel your pre-award request?" modal, unaffected by this change.

## A11y impact

- [ ] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — reuses an existing modal component with page-specific copy; no new visual component introduced.

## Definition of Done Checklist
- [x] Automated unit tests updated and passed
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A