### PR TITLE
fix(agreements): resolve UX feedback for Draft→Planned change request skip

### DIFF
--- a/backend/models/agreement_history.py
+++ b/backend/models/agreement_history.py
@@ -162,8 +162,12 @@ def agreement_history_trigger_func(event: OpsEvent, session: Session, system_use
                 )
             )
         case OpsEventType.UPDATE_AGREEMENT:
-            # Handle CAN Updates
-            change_dict = event.event_details["agreement_updates"]["changes"]
+            # `agreement_updates` is absent when a publisher of UPDATE_AGREEMENT does not
+            # compute a field diff (e.g. an edit-bundle save that changes no diffed agreement
+            # field). Default to empty so this handler records nothing rather than KeyError-ing
+            # (the error was previously swallowed by the subscriber, silently losing all history).
+            agreement_updates = event.event_details.get("agreement_updates") or {}
+            change_dict = agreement_updates.get("changes", {})
             for key in change_dict.keys():
                 history_item = create_agreement_update_history_event(
                     key,
@@ -171,22 +175,22 @@ def agreement_history_trigger_func(event: OpsEvent, session: Session, system_use
                     change_dict[key]["new_value"],
                     event_user,
                     event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-                    event.event_details["agreement_updates"]["owner_id"],
+                    agreement_updates["owner_id"],
                     event.id,
                     session,
                     system_user,
                 )
                 if history_item:
                     history_events.append(history_item)
-            if event.event_details["agreement_updates"].get("team_member_changes"):
+            if agreement_updates.get("team_member_changes"):
                 # Handle team member changes
-                team_member_changes = event.event_details["agreement_updates"]["team_member_changes"]
+                team_member_changes = agreement_updates["team_member_changes"]
                 for item in team_member_changes.get("user_ids_added", []):
                     added_user_id = session.get(User, item)
                     history_events.append(
                         AgreementHistory(
-                            agreement_id=event.event_details["agreement_updates"]["owner_id"],
-                            agreement_id_record=event.event_details["agreement_updates"]["owner_id"],
+                            agreement_id=agreement_updates["owner_id"],
+                            agreement_id_record=agreement_updates["owner_id"],
                             ops_event_id=event.id,
                             history_title="Change to Team Members",
                             history_message=f"{event_user.full_name} added team member {added_user_id.full_name}.",
@@ -198,8 +202,8 @@ def agreement_history_trigger_func(event: OpsEvent, session: Session, system_use
                     removed_user_id = session.get(User, item)
                     history_events.append(
                         AgreementHistory(
-                            agreement_id=event.event_details["agreement_updates"]["owner_id"],
-                            agreement_id_record=event.event_details["agreement_updates"]["owner_id"],
+                            agreement_id=agreement_updates["owner_id"],
+                            agreement_id_record=agreement_updates["owner_id"],
                             ops_event_id=event.id,
                             history_title="Change to Team Members",
                             history_message=f"{event_user.full_name} removed team member {removed_user_id.full_name}.",
@@ -207,15 +211,15 @@ def agreement_history_trigger_func(event: OpsEvent, session: Session, system_use
                             history_type=AgreementHistoryType.AGREEMENT_UPDATED,
                         )
                     )
-            if event.event_details["agreement_updates"].get("special_topic_changes"):
+            if agreement_updates.get("special_topic_changes"):
                 # Handle special topic changes
-                special_topic_changes = event.event_details["agreement_updates"]["special_topic_changes"]
+                special_topic_changes = agreement_updates["special_topic_changes"]
                 for item in special_topic_changes.get("special_topics_ids_added", []):
                     added_special_topic = session.get(SpecialTopic, item)
                     history_events.append(
                         AgreementHistory(
-                            agreement_id=event.event_details["agreement_updates"]["owner_id"],
-                            agreement_id_record=event.event_details["agreement_updates"]["owner_id"],
+                            agreement_id=agreement_updates["owner_id"],
+                            agreement_id_record=agreement_updates["owner_id"],
                             ops_event_id=event.id,
                             history_title="Change to Special Topic/Population Studied",
                             history_message=f"{event_user.full_name} added Special Topic/Population Studied {added_special_topic.name}.",
@@ -227,8 +231,8 @@ def agreement_history_trigger_func(event: OpsEvent, session: Session, system_use
                     removed_special_topic = session.get(SpecialTopic, item)
                     history_events.append(
                         AgreementHistory(
-                            agreement_id=event.event_details["agreement_updates"]["owner_id"],
-                            agreement_id_record=event.event_details["agreement_updates"]["owner_id"],
+                            agreement_id=agreement_updates["owner_id"],
+                            agreement_id_record=agreement_updates["owner_id"],
                             ops_event_id=event.id,
                             history_title="Change to Special Topic/Population Studied",
                             history_message=f"{event_user.full_name} removed Special Topic/Population Studied {removed_special_topic.name}.",
@@ -236,15 +240,15 @@ def agreement_history_trigger_func(event: OpsEvent, session: Session, system_use
                             history_type=AgreementHistoryType.AGREEMENT_UPDATED,
                         )
                     )
-            if event.event_details["agreement_updates"].get("research_methodology_changes"):
+            if agreement_updates.get("research_methodology_changes"):
                 # Handle research methodology changes
-                research_methodology_changes = event.event_details["agreement_updates"]["research_methodology_changes"]
+                research_methodology_changes = agreement_updates["research_methodology_changes"]
                 for item in research_methodology_changes.get("research_methodologies_ids_added", []):
                     added_research_methodology = session.get(ResearchMethodology, item)
                     history_events.append(
                         AgreementHistory(
-                            agreement_id=event.event_details["agreement_updates"]["owner_id"],
-                            agreement_id_record=event.event_details["agreement_updates"]["owner_id"],
+                            agreement_id=agreement_updates["owner_id"],
+                            agreement_id_record=agreement_updates["owner_id"],
                             ops_event_id=event.id,
                             history_title="Change to Research Methodologies",
                             history_message=f"{event_user.full_name} added Research Methodology {added_research_methodology.name}.",
@@ -256,8 +260,8 @@ def agreement_history_trigger_func(event: OpsEvent, session: Session, system_use
                     removed_research_methodology = session.get(ResearchMethodology, item)
                     history_events.append(
                         AgreementHistory(
-                            agreement_id=event.event_details["agreement_updates"]["owner_id"],
-                            agreement_id_record=event.event_details["agreement_updates"]["owner_id"],
+                            agreement_id=agreement_updates["owner_id"],
+                            agreement_id_record=agreement_updates["owner_id"],
                             ops_event_id=event.id,
                             history_title="Change to Research Methodologies",
                             history_message=f"{event_user.full_name} removed Research Methodology {removed_research_methodology.name}.",

--- a/backend/models/agreement_history.py
+++ b/backend/models/agreement_history.py
@@ -997,13 +997,11 @@ def create_bli_update_history_events(
             # otherwise leave no agreement-history entry. Mirror the CR path's wording.
             old_status = fix_stringified_enum_values(old_value)
             new_status = fix_stringified_enum_values(new_value)
-            history_title = f"Status Change to {new_status}"
+            history_title = "Change to Budget Line Status"
             if updated_by_system_user:
                 history_message = f"Changes made to the OPRE budget spreadsheet changed the status for BL {bli_id} from {old_status} to {new_status}."
             else:
-                history_message = (
-                    f"{event_user.full_name} changed the budget line status on BL {bli_id} from {old_status} to {new_status}."
-                )
+                history_message = f"{event_user.full_name} changed the budget line status on BL {bli_id} from {old_status} to {new_status}."
         if history_title and history_message:
             history_events.append(
                 AgreementHistory(

--- a/backend/models/agreement_history.py
+++ b/backend/models/agreement_history.py
@@ -1035,18 +1035,20 @@ def create_services_component_history_event(event: OpsEvent, event_user: User, s
             else:
                 history_message = f"{event_user.full_name} changed the {get_services_component_property_display_name(key)} for Services Component {event.event_details['services_component_updates']['sc_display_name']} from {old_value} to {new_value}."
         elif key == "period_start" or key == "period_end":
-            if old_value is None or old_value == "":
-                old_value = "None"
-            else:
-                old_date = datetime.strftime(datetime.strptime(old_value, "%Y-%m-%d"), "%m/%d/%Y")
-            if new_value is None or new_value == "":
-                new_value = "None"
-            else:
-                new_date = datetime.strftime(datetime.strptime(new_value, "%Y-%m-%d"), "%m/%d/%Y")
+            old_value = (
+                "None"
+                if old_value is None or old_value == ""
+                else datetime.strftime(datetime.strptime(old_value, "%Y-%m-%d"), "%m/%d/%Y")
+            )
+            new_value = (
+                "None"
+                if new_value is None or new_value == ""
+                else datetime.strftime(datetime.strptime(new_value, "%Y-%m-%d"), "%m/%d/%Y")
+            )
             if system_user_created_event:
-                history_message = f"Changes made to the OPRE budget spreadsheet changed the {get_services_component_property_display_name(key)} for Services Component {event.event_details['services_component_updates']['sc_display_name']} from {old_date} to {new_date}."
+                history_message = f"Changes made to the OPRE budget spreadsheet changed the {get_services_component_property_display_name(key)} for Services Component {event.event_details['services_component_updates']['sc_display_name']} from {old_value} to {new_value}."
             else:
-                history_message = f"{event_user.full_name} changed the {get_services_component_property_display_name(key)} for Services Component {event.event_details['services_component_updates']['sc_display_name']} from {old_date} to {new_date}."
+                history_message = f"{event_user.full_name} changed the {get_services_component_property_display_name(key)} for Services Component {event.event_details['services_component_updates']['sc_display_name']} from {old_value} to {new_value}."
         elif key == "description":
             if system_user_created_event:
                 history_message = f"Changes made to the OPRE budget spreadsheet changed the description for Services Component {event.event_details['services_component_updates']['sc_display_name']}."

--- a/backend/ops_api/ops/resources/agreement_edit_bundle.py
+++ b/backend/ops_api/ops/resources/agreement_edit_bundle.py
@@ -52,6 +52,12 @@ class AgreementEditBundleAPI(BaseItemAPI):
 
             meta.metadata.update({"bundle_result": asdict(result)})
 
+            # Surface the agreement field diff (scoped to a directly-applied procurement-shop
+            # change) so the UPDATE_AGREEMENT history subscriber records "Change to Procurement
+            # Shop". None for every other bundle save, leaving history behavior unchanged.
+            if service.agreement_updates is not None:
+                meta.metadata.update({"agreement_updates": service.agreement_updates})
+
             response_body = {"message": "Agreement edit bundle saved", "id": id, **asdict(result)}
             status_code = 202 if result.change_request_ids else 200
             return make_response_with_headers(response_body, status_code)

--- a/backend/ops_api/ops/services/agreement_edit_bundle.py
+++ b/backend/ops_api/ops/services/agreement_edit_bundle.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from types import SimpleNamespace
 from typing import Any
 
+from flask_jwt_extended import get_current_user
 from loguru import logger
 from marshmallow import EXCLUDE
 from sqlalchemy.exc import IntegrityError
@@ -212,11 +213,17 @@ class AgreementEditBundleService:
         # deliberately do not gain history here (matching prior behavior; a separate concern).
         old_serialized = agreement.to_dict()
         self._agreements.update(agreement.id, loaded, partial=True, commit=False)
+        # Use the current request user rather than agreement.updated_by: this runs under
+        # commit=False (flush only), and the created/updated-by stamping fires on before_commit,
+        # so agreement.updated_by is still the prior editor's id at this point. (The persisted
+        # history actor is derived from OpsEvent.created_by, so this only affects the value stored
+        # under event_details["agreement_updates"]["updated_by"], but keep it accurate.)
+        current_user = get_current_user()
         full_updates = generate_agreement_events_update(
             old_serialized,
             agreement.to_dict(),
             agreement.id,
-            agreement.updated_by,
+            current_user.id if current_user else None,
         )
         proc_shop_change = full_updates.get("changes", {}).get("awarding_entity_id")
         if proc_shop_change is not None:

--- a/backend/ops_api/ops/services/agreement_edit_bundle.py
+++ b/backend/ops_api/ops/services/agreement_edit_bundle.py
@@ -18,6 +18,7 @@ from marshmallow import EXCLUDE
 from sqlalchemy.exc import IntegrityError
 
 from models import Agreement, GrantNumber
+from models.utils import generate_agreement_events_update
 from ops_api.ops.resources.agreements_constants import (
     AGREEMENT_TYPE_TO_CLASS_MAPPING,
     AGREEMENT_TYPE_TO_DATACLASS_MAPPING,
@@ -75,6 +76,10 @@ class AgreementEditBundleService:
         self._grant_numbers = GrantNumberService(db_session)
         self._blis = BudgetLineItemService(db_session)
         self._change_requests = ChangeRequestService(db_session)
+        # Filtered agreement field-diff for the UPDATE_AGREEMENT history subscriber. Populated
+        # (scoped to awarding_entity_id only) when a procurement-shop change is applied directly
+        # via this bundle; the resource reads it into the event metadata. See _apply_agreement_update.
+        self.agreement_updates: dict | None = None
 
     def update(self, agreement_id: int, payload: dict[str, Any]) -> BundleResult:
         """Apply every section of ``payload`` to ``agreement_id`` atomically.
@@ -197,7 +202,29 @@ class AgreementEditBundleService:
         loaded.pop("services_components", None)
         loaded.pop("grant_numbers", None)
         loaded["agreement_cls"] = AGREEMENT_TYPE_TO_CLASS_MAPPING.get(agreement.agreement_type)
+
+        # Unlike the standard PATCH resource, this orchestrator does not compute an agreement
+        # field diff for history. When a procurement-shop change is applied directly here (the
+        # SKIP_CR_FOR_DRAFT_PLANNED capability skips the Change Request that would otherwise carry
+        # the history), no "Change to Procurement Shop" entry would be recorded. Snapshot the
+        # agreement before/after and surface the awarding_entity_id diff so the UPDATE_AGREEMENT
+        # subscriber records it. Scoped to awarding_entity_id only — other bundle-edited fields
+        # deliberately do not gain history here (matching prior behavior; a separate concern).
+        old_serialized = agreement.to_dict()
         self._agreements.update(agreement.id, loaded, partial=True, commit=False)
+        full_updates = generate_agreement_events_update(
+            old_serialized,
+            agreement.to_dict(),
+            agreement.id,
+            agreement.updated_by,
+        )
+        proc_shop_change = full_updates.get("changes", {}).get("awarding_entity_id")
+        if proc_shop_change is not None:
+            self.agreement_updates = {
+                "owner_id": full_updates["owner_id"],
+                "updated_by": full_updates["updated_by"],
+                "changes": {"awarding_entity_id": proc_shop_change},
+            }
 
     # ------------------------------------------------------------------
     # Services Components

--- a/backend/ops_api/ops/services/agreements.py
+++ b/backend/ops_api/ops/services/agreements.py
@@ -626,10 +626,7 @@ class AgreementsService(OpsService[Agreement]):
         # assignment lands on the identity-mapped agreement before the resource re-serializes it,
         # so agreement history still records the "Change to Procurement Shop" entry via the
         # UPDATE_AGREEMENT field diff (see resources/agreements.py and agreement_edit_bundle.py).
-        if any(
-            bli.status in (BudgetLineItemStatus.PLANNED, BudgetLineItemStatus.PLANNED_MOD)
-            for bli in agreement.budget_line_items
-        ):
+        if any(bli.status == BudgetLineItemStatus.PLANNED for bli in agreement.budget_line_items):
             if current_app.config.get("SKIP_CR_FOR_DRAFT_PLANNED", False):
                 agreement.awarding_entity_id = new_value
                 return None

--- a/backend/ops_api/ops/services/agreements.py
+++ b/backend/ops_api/ops/services/agreements.py
@@ -618,11 +618,22 @@ class AgreementsService(OpsService[Agreement]):
             # self._update_draft_blis_proc_shop_fees(agreement)
             return None
 
-        # Create a change request if at least one BLI is in PLANNED or PLANNED_MOD status
+        # At least one BLI is in PLANNED status (PLANNED_MOD is unreachable here — the
+        # blocked-status guard above raises first for it). Normally this needs a Change
+        # Request for Division Director approval. When the SKIP_CR_FOR_DRAFT_PLANNED
+        # capability is enabled (per-environment), apply the change directly instead —
+        # matching the same flag's behavior for BLI Draft→Planned edits. The awarding_entity_id
+        # assignment lands on the identity-mapped agreement before the resource re-serializes it,
+        # so agreement history still records the "Change to Procurement Shop" entry via the
+        # UPDATE_AGREEMENT field diff (see resources/agreements.py and agreement_edit_bundle.py).
         if any(
             bli.status in (BudgetLineItemStatus.PLANNED, BudgetLineItemStatus.PLANNED_MOD)
             for bli in agreement.budget_line_items
         ):
+            if current_app.config.get("SKIP_CR_FOR_DRAFT_PLANNED", False):
+                agreement.awarding_entity_id = new_value
+                return None
+
             change_request_service = ChangeRequestService(current_app.db_session)
             with OpsEventHandler(OpsEventType.CREATE_CHANGE_REQUEST) as cr_meta:
                 change_request = change_request_service.create(

--- a/backend/ops_api/tests/ops/agreement/test_agreement_history.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement_history.py
@@ -766,7 +766,7 @@ def test_agreement_history_direct_draft_to_planned_status_change(loaded_db, app_
     )
 
     assert history_item.history_type == AgreementHistoryType.BUDGET_LINE_ITEM_UPDATED
-    assert history_item.history_title == "Status Change to Planned"
+    assert history_item.history_title == "Change to Budget Line Status"
     assert (
         history_item.history_message
         == f"{test_user_name} changed the budget line status on BL 16043 from Draft to Planned."

--- a/backend/ops_api/tests/ops/agreement/test_agreement_history.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement_history.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 
 from sqlalchemy import select
 
@@ -11,7 +12,12 @@ from models import (
     OpsEventStatus,
     OpsEventType,
 )
-from models.agreement_history import add_history_events, create_agreement_update_history_event, get_project_display_name
+from models.agreement_history import (
+    add_history_events,
+    create_agreement_update_history_event,
+    create_services_component_history_event,
+    get_project_display_name,
+)
 from ops_api.ops.services.agreement_messages import agreement_history_trigger
 from ops_api.ops.utils.users import get_sys_user
 
@@ -648,6 +654,34 @@ def test_agreement_history_services_components(loaded_db, app_ctx):
         == "Changes made to the OPRE budget spreadsheet changed the component number for Services Component "
         "SC22 from 99 to 22."
     )
+
+
+def test_services_component_period_change_with_none_value():
+    """Regression: a period_start/period_end change where the old or new value is None/empty
+    must not raise NameError. Previously the empty branch left old_date/new_date unassigned
+    while the f-string referenced them unconditionally, silently dropping SC history."""
+    event = SimpleNamespace(
+        id=999,
+        created_on=datetime(2026, 1, 2, 3, 4, 5),
+        event_details={
+            "services_component_updates": {
+                "sc_display_name": "SC1",
+                "owner_id": 1,
+                "changes": {
+                    "period_start": {"old_value": None, "new_value": "2025-01-01"},
+                    "period_end": {"old_value": "2024-06-30", "new_value": ""},
+                },
+            }
+        },
+    )
+    event_user = SimpleNamespace(full_name="Amelia Popham")
+
+    history_events = create_services_component_history_event(event, event_user, system_user_created_event=False)
+
+    messages = [h.history_message for h in history_events]
+    assert len(messages) == 2
+    assert any("from None to 01/01/2025" in m for m in messages)
+    assert any("from 06/30/2024 to None" in m for m in messages)
 
 
 def test_agreement_history_bli_deletion(loaded_db, app_ctx):

--- a/backend/ops_api/tests/ops/agreement/test_skip_cr_proc_shop.py
+++ b/backend/ops_api/tests/ops/agreement/test_skip_cr_proc_shop.py
@@ -1,0 +1,266 @@
+"""Tests for skipping the procurement-shop Change Request under SKIP_CR_FOR_DRAFT_PLANNED.
+
+When the flag is ON, a procurement-shop change on an agreement whose budget lines are
+PLANNED applies immediately instead of creating an AgreementChangeRequest — mirroring the
+same flag's behavior for BLI Draft→Planned edits. The directly-applied change must still
+record a "Change to Procurement Shop" agreement-history entry.
+
+When OFF, the change routes through the change-request workflow exactly as today (regression
+baseline in test_agreement_change_requests.py).
+
+Fixture discipline: the flag is exercised as a non-bypass user so the flag is the only thing
+that changes routing. `auth_client` and the AgreementsService-with-patched-user paths below
+are not superuser/budget-team, so they hit the flag branch rather than an existing bypass.
+"""
+
+import datetime
+
+import pytest
+
+from models import (
+    AgreementChangeRequest,
+    AgreementHistory,
+    AgreementType,
+    BudgetLineItemStatus,
+    ChangeRequestType,
+    GrantAgreement,
+    GrantBudgetLineItem,
+    ProcurementShop,
+    ProcurementShopFee,
+    User,
+)
+from ops_api.ops.services.agreements import AgreementsService
+from ops_api.ops.services.change_requests import ChangeRequestService
+
+
+@pytest.fixture()
+def skip_cr_enabled(app):
+    """Turn the capability ON for the duration of a test."""
+    original = app.config.get("SKIP_CR_FOR_DRAFT_PLANNED", False)
+    app.config["SKIP_CR_FOR_DRAFT_PLANNED"] = True
+    yield
+    app.config["SKIP_CR_FOR_DRAFT_PLANNED"] = original
+
+
+@pytest.fixture()
+def skip_cr_disabled(app):
+    """Turn the capability OFF for the duration of a test (regression baseline)."""
+    original = app.config.get("SKIP_CR_FOR_DRAFT_PLANNED", False)
+    app.config["SKIP_CR_FOR_DRAFT_PLANNED"] = False
+    yield
+    app.config["SKIP_CR_FOR_DRAFT_PLANNED"] = original
+
+
+@pytest.fixture()
+def test_grant_agreement(loaded_db, test_admin_user):
+    grant = GrantAgreement(
+        agreement_type=AgreementType.GRANT,
+        name="Test Grant for Proc Shop Skip",
+        nick_name="Test Grant Proc Skip",
+        description="Test Grant for Proc Shop Skip",
+        product_service_code_id=1,
+        project_officer_id=test_admin_user.id,
+        awarding_entity_id=1,
+        nofo_number="NOFO-2026-02",
+        aln_numbers=[3, 7],
+        funding_period_months=18,
+    )
+    loaded_db.add(grant)
+    loaded_db.commit()
+
+    yield grant
+
+    loaded_db.query(AgreementHistory).where(AgreementHistory.agreement_id_record == grant.id).delete()
+    loaded_db.delete(grant)
+    loaded_db.commit()
+
+
+@pytest.fixture()
+def test_psf(loaded_db):
+    ps = ProcurementShop(name="Test Procurement Shop for Skip", abbr="TPSSK")
+    loaded_db.add(ps)
+    loaded_db.commit()
+    loaded_db.refresh(ps)
+
+    psf = ProcurementShopFee(procurement_shop_id=ps.id, fee=0.5)
+    ps.procurement_shop_fees.append(psf)
+    loaded_db.add(psf)
+    loaded_db.commit()
+
+    yield psf
+
+    loaded_db.delete(ps)
+    loaded_db.delete(psf)
+    loaded_db.commit()
+
+
+@pytest.fixture()
+def test_planned_bli(loaded_db, test_admin_user, test_grant_agreement, test_psf, test_can):
+    bli = GrantBudgetLineItem(
+        line_description="Test PLANNED BLI for Proc Shop Skip",
+        agreement_id=test_grant_agreement.id,
+        can_id=test_can.id,
+        status=BudgetLineItemStatus.PLANNED,
+        procurement_shop_fee=test_psf,
+        date_needed=datetime.date(2043, 6, 30),
+        created_by=test_admin_user.id,
+    )
+    loaded_db.add(bli)
+    loaded_db.commit()
+
+    yield bli
+
+    loaded_db.delete(bli)
+    loaded_db.commit()
+
+
+def _proc_shop_change_requests(loaded_db, agreement_id):
+    return (
+        loaded_db.query(AgreementChangeRequest)
+        .filter(
+            AgreementChangeRequest.agreement_id == agreement_id,
+            AgreementChangeRequest.change_request_type == ChangeRequestType.AGREEMENT_CHANGE_REQUEST,
+        )
+        .all()
+    )
+
+
+def test_proc_shop_change_applies_directly_when_flag_on(
+    monkeypatch,
+    test_admin_user,
+    loaded_db,
+    test_grant_agreement,
+    test_planned_bli,
+    skip_cr_enabled,
+):
+    """Flag ON + PLANNED BLI: proc-shop change applies immediately (200), no change request."""
+    monkeypatch.setattr("ops_api.ops.services.agreements.get_current_user", lambda: test_admin_user)
+    monkeypatch.setattr("ops_api.ops.services.agreements.associated_with_agreement", lambda _: True)
+
+    service = AgreementsService(loaded_db)
+    agreement, status_code = service.update(
+        test_grant_agreement.id,
+        {"awarding_entity_id": 2, "agreement_cls": GrantAgreement},
+    )
+
+    assert status_code == 200
+    updated = loaded_db.get(GrantAgreement, test_grant_agreement.id)
+    assert updated.awarding_entity_id == 2
+    assert updated.in_review is False
+    assert updated.change_requests_in_review is None
+    assert _proc_shop_change_requests(loaded_db, test_grant_agreement.id) == []
+
+
+def test_proc_shop_change_creates_cr_when_flag_off(
+    monkeypatch,
+    test_admin_user,
+    loaded_db,
+    test_grant_agreement,
+    test_planned_bli,
+    skip_cr_disabled,
+):
+    """Flag OFF + PLANNED BLI: proc-shop change routes through a change request (202). Regression."""
+    monkeypatch.setattr("ops_api.ops.services.agreements.get_current_user", lambda: test_admin_user)
+    monkeypatch.setattr("ops_api.ops.services.agreements.associated_with_agreement", lambda _: True)
+    monkeypatch.setattr("ops_api.ops.services.change_requests.current_user", loaded_db.get(User, 522))
+
+    service = AgreementsService(loaded_db)
+    agreement, status_code = service.update(
+        test_grant_agreement.id,
+        {"awarding_entity_id": 2, "agreement_cls": GrantAgreement},
+    )
+
+    assert status_code == 202
+    updated = loaded_db.get(GrantAgreement, test_grant_agreement.id)
+    # Not applied yet — still pending approval.
+    assert updated.awarding_entity_id == 1
+    crs = _proc_shop_change_requests(loaded_db, test_grant_agreement.id)
+    assert len(crs) == 1
+
+    # Cleanup
+    ChangeRequestService(loaded_db).delete(crs[0].id)
+
+
+def test_proc_shop_change_still_blocked_for_in_execution_when_flag_on(
+    monkeypatch,
+    test_admin_user,
+    loaded_db,
+    test_grant_agreement,
+    test_planned_bli,
+    skip_cr_enabled,
+):
+    """Flag ON must NOT relax the IN_EXECUTION block: proc-shop change still raises ValidationError."""
+    from ops_api.ops.services.ops_service import ValidationError
+
+    monkeypatch.setattr("ops_api.ops.services.agreements.get_current_user", lambda: test_admin_user)
+    monkeypatch.setattr("ops_api.ops.services.agreements.associated_with_agreement", lambda _: True)
+
+    test_planned_bli.status = BudgetLineItemStatus.IN_EXECUTION
+    loaded_db.commit()
+
+    service = AgreementsService(loaded_db)
+    with pytest.raises(ValidationError):
+        service.update(
+            test_grant_agreement.id,
+            {"awarding_entity_id": 2, "agreement_cls": GrantAgreement},
+        )
+
+
+def test_proc_shop_change_via_edit_bundle_writes_history_when_flag_on(
+    auth_client,
+    loaded_db,
+    test_grant_agreement,
+    test_planned_bli,
+    skip_cr_enabled,
+    app_ctx,
+):
+    """Flag ON via the edit-bundle endpoint: proc-shop change applies directly (200), creates no
+    change request, AND still records the "Change to Procurement Shop" agreement-history entry."""
+    from flask import url_for
+
+    response = auth_client.patch(
+        url_for("api.agreements-edit-bundle", id=test_grant_agreement.id),
+        json={"agreement": {"awarding_entity_id": 2}},
+    )
+    assert response.status_code == 200
+
+    updated = loaded_db.get(GrantAgreement, test_grant_agreement.id)
+    assert updated.awarding_entity_id == 2
+    assert _proc_shop_change_requests(loaded_db, test_grant_agreement.id) == []
+
+    history = (
+        loaded_db.query(AgreementHistory).where(AgreementHistory.agreement_id_record == test_grant_agreement.id).all()
+    )
+    proc_shop_history = [h for h in history if h.history_title == "Change to Procurement Shop"]
+    assert len(proc_shop_history) == 1
+    # Only the proc-shop entry — the bundle diff is scoped to awarding_entity_id, so no
+    # spurious history for other agreement fields.
+    assert all(
+        h.history_title == "Change to Procurement Shop"
+        for h in history
+        if h.history_type == proc_shop_history[0].history_type and h.ops_event_id == proc_shop_history[0].ops_event_id
+    )
+
+
+def test_edit_bundle_no_proc_shop_change_writes_no_agreement_updates_history(
+    auth_client,
+    loaded_db,
+    test_grant_agreement,
+    test_planned_bli,
+    skip_cr_enabled,
+    app_ctx,
+):
+    """An edit-bundle save that does not change the proc shop must not KeyError and must not
+    fabricate agreement field-diff history (hardening for the UPDATE_AGREEMENT handler)."""
+    from flask import url_for
+
+    response = auth_client.patch(
+        url_for("api.agreements-edit-bundle", id=test_grant_agreement.id),
+        json={"agreement": {"description": "Updated description via bundle"}},
+    )
+    assert response.status_code == 200
+
+    history = (
+        loaded_db.query(AgreementHistory).where(AgreementHistory.agreement_id_record == test_grant_agreement.id).all()
+    )
+    assert [h for h in history if h.history_title == "Change to Procurement Shop"] == []

--- a/frontend/cypress/e2e/agreementList.cy.js
+++ b/frontend/cypress/e2e/agreementList.cy.js
@@ -46,10 +46,6 @@ describe("Agreement List", () => {
         cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(5)").should("have.text", "$1,000,000.00");
         cy.get("tbody > [data-testid='agreement-table-row-9'] > :nth-child(6)").should("have.text", "$0");
 
-        cy.get("[data-testid='agreement-table-row-9']").trigger("mouseover");
-        cy.get("button[id^='submit-for-approval-']").first().should("exist");
-        cy.get("button[id^='submit-for-approval-']").first().should("not.be.disabled");
-
         // expand agreement-table-row-9
         cy.get('[data-testid="agreement-table-row-9"] > :nth-child(7) > [data-cy="expand-row"]').should("exist");
         cy.get('[data-testid="agreement-table-row-9"] > :nth-child(7) > [data-cy="expand-row"]').click();
@@ -62,21 +58,6 @@ describe("Agreement List", () => {
         cy.get('[data-cy="expanded-data"]').should("contain.text", "Lifetime Obligated");
         cy.get('[data-cy="expanded-data"]').should("contain.text", "Contract #");
         cy.get('[data-cy="expanded-data"]').should("contain.text", "Vendor");
-    });
-
-    it("navigates to the ReviewAgreements page when the review button is clicked", () => {
-        // Wait for table to load with data
-        cy.get(".usa-table", { timeout: 20000 }).should("exist");
-        cy.get("tbody tr", { timeout: 20000 }).should("have.length.at.least", 1);
-        cy.get("#fiscal-year-select").select("2044");
-        cy.get("[data-testid='agreement-table-row-9']", { timeout: 10000 }).should("exist");
-        cy.get("[data-testid='agreement-table-row-9']").trigger("mouseover");
-        cy.get("button[id^='submit-for-approval-']").first().should("exist");
-        cy.get("button[id^='submit-for-approval-']").first().should("not.be.disabled");
-        cy.get("button[id^='submit-for-approval-']").first().click();
-        cy.url().should("include", "/agreements/review");
-        cy.get("h1").should("exist");
-        cy.get("h1").should("have.text", "Change Budget Line Status");
     });
 
     it("Agreements Table is correctly filtered on all-agreements or my-agreements", () => {

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.js
@@ -7,6 +7,7 @@ import {
     useDeleteAgreementMutation,
     useGetProjectsQuery,
     useGetProductServiceCodesQuery,
+    useGetVersionQuery,
     useLazyGetAgreementsQuery,
     useUpdateAgreementMutation
 } from "../../../api/opsAPI";
@@ -208,8 +209,18 @@ const useAgreementEditForm = (
     const isBudgetTeam = useIsUserBudgetTeam();
     // Superusers and Budget Team members bypass the procurement-shop change-request workflow.
     const canEditDirectly = isSuperUser || isBudgetTeam;
+    // Per-environment capability: when ON, a procurement-shop change applies immediately (no
+    // Change Request), matching the backend's SKIP_CR_FOR_DRAFT_PLANNED behavior. Defaults to
+    // false until the version query resolves so the approval UX is never suppressed prematurely.
+    // The backend is the enforcement authority; this only drives the modal/alert copy.
+    const { data: versionData } = useGetVersionQuery();
+    const skipCrForDraftPlanned = versionData?.skip_cr_for_draft_planned ?? false;
     const shouldRequestChange =
-        hasProcurementShopChanged && areAnyBudgetLinesPlanned && !isAgreementAwarded && !canEditDirectly;
+        hasProcurementShopChanged &&
+        areAnyBudgetLinesPlanned &&
+        !isAgreementAwarded &&
+        !canEditDirectly &&
+        !skipCrForDraftPlanned;
 
     const runValidate = React.useCallback(
         (name, value, overrides = {}) => {

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.test.js
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.hooks.test.js
@@ -17,6 +17,7 @@ const useLocationMock = vi.fn();
 const hasStateChangedMock = vi.fn();
 const scrollToCenterMock = vi.fn();
 const setIsCancellingMock = vi.fn();
+const useGetVersionQueryMock = vi.fn();
 
 vi.mock("react-router-dom", async (importOriginal) => {
     const actual = await importOriginal();
@@ -37,7 +38,10 @@ vi.mock("../../../api/opsAPI", () => ({
     useGetProjectsQuery: () => ({ data: { projects: [] }, error: null, isLoading: false }),
     useGetProductServiceCodesQuery: () => ({ data: [], error: null, isLoading: false }),
     useLazyGetAgreementsQuery: () => [triggerGetAgreementsMock],
-    useUpdateAgreementMutation: () => [updateAgreementMock]
+    useUpdateAgreementMutation: () => [updateAgreementMock],
+    // Default to an empty result (flag off) so vi.clearAllMocks() between tests never
+    // leaves this returning undefined, which would break the hook's destructuring.
+    useGetVersionQuery: () => useGetVersionQueryMock() ?? { data: undefined }
 }));
 
 vi.mock("../../../helpers/scrollToCenter.helper", () => ({
@@ -777,5 +781,58 @@ describe("useAgreementEditForm - runValidate project_officer validation", () => 
 
         const errors = result.current.res.getErrors("project_officer");
         expect(errors).toContain("This is required information");
+    });
+});
+
+describe("useAgreementEditForm - procurement-shop change request gating (SKIP_CR_FOR_DRAFT_PLANNED)", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useLocationMock.mockReturnValue({ pathname: "/agreements/1/edit" });
+        useSelectorMock.mockReturnValue(false); // not superuser
+        // useHasStateChanged is used for both the agreement and the selected procurement shop;
+        // returning true makes hasProcurementShopChanged true (the proc-shop change condition).
+        hasStateChangedMock.mockReturnValue(true);
+        useEditAgreementDispatchMock.mockReturnValue(vi.fn());
+        useSetStateMock.mockReturnValue(vi.fn());
+        useUpdateAgreementMock.mockReturnValue(vi.fn());
+        useEditAgreementMock.mockReturnValue(
+            makeEditState({ id: 42, agreement_type: "CONTRACT", name: "Proc Shop Agreement" })
+        );
+        // No title/nickname uniqueness conflict so handleContinue reaches the save/modal branch.
+        setLazyQueryResult(0);
+        setLazyQueryResult(0);
+        updateAgreementMock.mockReturnValue({ unwrap: vi.fn().mockResolvedValue({ id: 42 }) });
+    });
+
+    it("requires a change request (shows modal) when the flag is OFF and a planned BL exists", async () => {
+        useGetVersionQueryMock.mockReturnValue({ data: { version: "1.0.0", skip_cr_for_draft_planned: false } });
+
+        const { result } = renderUseAgreementEditForm({ areAnyBudgetLinesPlanned: true });
+
+        expect(result.current.shouldRequestChange).toBe(true);
+
+        await act(async () => {
+            await result.current.handleContinue();
+        });
+
+        expect(result.current.showModal).toBe(true);
+        expect(result.current.modalProps.heading).toContain("Procurement Shop");
+        expect(result.current.modalProps.actionButtonText).toBe("Send to Approval");
+    });
+
+    it("skips the change request (no modal, saves directly) when the flag is ON", async () => {
+        useGetVersionQueryMock.mockReturnValue({ data: { version: "1.0.0", skip_cr_for_draft_planned: true } });
+
+        const { result } = renderUseAgreementEditForm({ areAnyBudgetLinesPlanned: true, goToNext: vi.fn() });
+
+        expect(result.current.shouldRequestChange).toBe(false);
+
+        await act(async () => {
+            await result.current.handleContinue();
+        });
+
+        // No approval modal — the change is saved directly.
+        expect(result.current.showModal).toBe(false);
+        expect(updateAgreementMock).toHaveBeenCalled();
     });
 });

--- a/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
+++ b/frontend/src/components/Agreements/AgreementEditor/AgreementEditForm.jsx
@@ -559,7 +559,7 @@ const AgreementEditForm = ({
                         name="product_service_code_id"
                         label="Product Service Code"
                         messages={res.getErrors("product_service_code_id")}
-                        className={cn("product_service_code_id")}
+                        className={`margin-top-3 ${cn("product_service_code_id")}`}
                         selectedProductServiceCode={selectedProductServiceCode || ""}
                         codes={productServiceCodes}
                         onChange={(name, value) => {

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
@@ -1,4 +1,4 @@
-import { Link, useSearchParams } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useSelector } from "react-redux";
 import { NO_DATA } from "../../../constants";
 import { getAgreementType, isNotDevelopedYet } from "../../../helpers/agreement.helpers";
@@ -23,7 +23,7 @@ import {
 } from "./AgreementsTable.helpers";
 import { TABLE_HEADINGS_LIST } from "./AgreementsTable.constants";
 import { AWARD_TYPE_LABELS } from "../../../pages/agreements/agreements.constants";
-import { useHandleDeleteAgreement, useHandleEditAgreement, useNavigateAgreementReview } from "./AgreementsTable.hooks";
+import { useHandleDeleteAgreement, useHandleEditAgreement } from "./AgreementsTable.hooks";
 import { useIsUserReadOnly } from "../../../hooks/user.hooks";
 
 /**
@@ -63,16 +63,12 @@ export const AgreementTableRow = ({ agreement }) => {
     const isEditable = canUserEditAgreement && (!isAgreementTypeNotDeveloped || isSuperUser);
     const canUserDeleteAgreement =
         isSuperUser || (canUserEditAgreement && (areAllBudgetLinesInDraftStatus || !areThereAnyBudgetLines));
-    const handleSubmitAgreementForApproval = useNavigateAgreementReview();
     const handleEditAgreement = useHandleEditAgreement();
     const { handleDeleteAgreement, modalProps, setShowModal, showModal } = useHandleDeleteAgreement();
 
-    const [searchParams] = useSearchParams();
-    const forApprovalUrl = searchParams.get("filter") === "for-approval";
-
     function getLockedMessage() {
         const lockedMessages = {
-            notTeamMember: "Only team members on this agreement can edit, delete, or send to approval",
+            notTeamMember: "Only team members on this agreement can edit or delete",
             notDeveloped:
                 "This agreement cannot be edited because it is not developed yet, \nplease contact the Budget Team.",
             default: "Disabled"
@@ -99,8 +95,6 @@ export const AgreementTableRow = ({ agreement }) => {
             handleDeleteItem={handleDeleteAgreement}
             handleSetItemForEditing={handleEditAgreement}
             duplicateIcon={false}
-            sendToReviewIcon={!forApprovalUrl}
-            handleSubmitItemForApproval={handleSubmitAgreementForApproval}
         />
     ) : null;
 

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.hooks.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.hooks.js
@@ -3,17 +3,6 @@ import { useNavigate } from "react-router-dom";
 import { useDeleteAgreementMutation } from "../../../api/opsAPI";
 import useAlert from "../../../hooks/use-alert.hooks";
 
-export const useNavigateAgreementReview = () => {
-    const navigate = useNavigate();
-    /**
-     * Navigates to the agreement review page.
-     * @param {number} id - The id of the agreement to review.
-     */
-    return (id) => {
-        navigate(`/agreements/review/${id}`);
-    };
-};
-
 export const useHandleEditAgreement = () => {
     const navigate = useNavigate();
     /**

--- a/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.jsx
+++ b/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.jsx
@@ -63,22 +63,14 @@ const BLIReviewRow = ({
     // Suppress by pretending we're not in review mode — the existing helpers gate all error styling on that flag.
     const rowInReviewMode = isReviewMode && (!errorStatuses || errorStatuses.includes(budgetLine?.status));
 
-    // Services component (or, for grants, grant number) has no column in this table; surface its
-    // absence as a row-level error class so the user can locate the offending BLI when
-    // errorStatuses-mode is active.
+    // A missing services component (or, for grants, grant number) has no column in this table.
+    // Its absence is surfaced as a red border on the enclosing accordion (see
+    // ServicesComponentAccordion/GrantNumberAccordion isError), not as a row-level highlight.
     const statusScopedErrors = Array.isArray(errorStatuses);
     const showCellErrors = statusScopedErrors ? rowInReviewMode : budgetLine?.selected;
-    const isGrantBudgetLine = budgetLine?.agreement?.agreement_type === "GRANT";
-    const missingLink = isGrantBudgetLine ? !budgetLine?.grant_number_id : !budgetLine?.services_component_id;
 
     // Tooltip for BLIs with pending change requests (in_review=true)
     const inReviewTooltip = useChangeRequestsForTooltip(budgetLine, "This budget line has pending edits:");
-    // Row-level error class for a missing services component. Only used in selection-gated
-    // mode (Review Agreement) where highlighting the whole row is correct. In errorStatuses
-    // mode (pre-award), table-item-error on the <tr> would cascade color:#b50909 to every
-    // child <td> including cells with valid data — use cell-level errors only there.
-    const missingServicesComponentClass =
-        !statusScopedErrors && showCellErrors && missingLink ? "table-item-error" : "";
 
     const { isExpanded, setIsExpanded, isRowActive, setIsRowActive } = useTableRow();
     const budgetLineCreatorName = useGetUserFullNameFromId(budgetLine?.created_by);
@@ -310,7 +302,7 @@ const BLIReviewRow = ({
                 isExpanded={isExpanded}
                 setIsExpanded={setIsExpanded}
                 setIsRowActive={setIsRowActive}
-                className={`${!readOnly && !budgetLine.actionable ? "text-gray-50" : ""} ${missingServicesComponentClass}`.trim()}
+                className={`${!readOnly && !budgetLine.actionable ? "text-gray-50" : ""}`.trim()}
             />
         </>
     );

--- a/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.jsx
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.jsx
@@ -20,7 +20,7 @@ import { useTableRow } from "../../UI/TableRowExpandable/TableRowExpandable.hook
 import TableTag from "../../UI/TableTag";
 import Tooltip from "../../UI/USWDS/Tooltip";
 import ChangeIcons from "../ChangeIcons";
-import { addErrorClassIfNotFound, futureDateErrorClass } from "./BLIRow.helpers";
+import { addErrorClassIfNotFound, futureDateErrorClass, isDateOutsidePopRange } from "./BLIRow.helpers";
 
 /**
  * @typedef {Object} BLIRowProps
@@ -61,6 +61,7 @@ const BLIRow = ({
     const isBLIInReview = budgetLine?.in_review || false;
     const isBudgetLineObe = budgetLine?.is_obe;
     const isApprovePageAndBLIIsNotInPacket = isApprovePage && !isBLIInCurrentWorkflow;
+    const isOutsidePopRange = isDateOutsidePopRange(budgetLine);
     const lockedMessage = useChangeRequestsForTooltip(budgetLine);
 
     const changeIcons = (
@@ -97,9 +98,20 @@ const BLIRow = ({
                 className={`${futureDateErrorClass(
                     formatDateNeeded(budgetLine?.date_needed),
                     isReviewMode
-                )} ${addErrorClassIfNotFound(formatDateNeeded(budgetLine?.date_needed), isReviewMode)}`}
+                )} ${addErrorClassIfNotFound(formatDateNeeded(budgetLine?.date_needed), isReviewMode)} ${
+                    isReviewMode && isOutsidePopRange ? "table-item-error" : ""
+                }`}
             >
-                {formatDateNeeded(budgetLine?.date_needed, budgetLine.is_obe)}
+                {isReviewMode && isOutsidePopRange ? (
+                    <Tooltip
+                        label="Obligate By date is outside the agreement’s Period of Performance"
+                        position="right"
+                    >
+                        <span>{formatDateNeeded(budgetLine?.date_needed, budgetLine.is_obe)}</span>
+                    </Tooltip>
+                ) : (
+                    formatDateNeeded(budgetLine?.date_needed, budgetLine.is_obe)
+                )}
             </td>
             <td>{fiscalYearFromDate(budgetLine?.date_needed)}</td>
             <td className={addErrorClassIfNotFound(budgetLine?.can?.number, isReviewMode)}>

--- a/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.test.jsx
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.test.jsx
@@ -367,6 +367,59 @@ describe("BLIRow", () => {
         expect(deleteBtn).not.toBeDisabled();
     });
 
+    const renderInReview = (budgetLineOverrides = {}) => {
+        useGetUserByIdQuery.mockReturnValue({ data: { full_name: "John Doe" } });
+        useGetAgreementByIdQuery.mockReturnValue({ data: agreement });
+        useGetCansQuery.mockReturnValue({
+            data: { cans: [{ id: 1, code: "CAN 1", name: "CAN 1" }], count: 1, limit: 10, offset: 0 }
+        });
+        useLazyGetCansQuery.mockReturnValue([
+            vi.fn().mockResolvedValue({ unwrap: () => Promise.resolve({ cans: [], count: 0 }) }),
+            { isLoading: false, isError: false }
+        ]);
+        useGetProcurementShopsQuery.mockReturnValue({ data: [], isSuccess: true });
+
+        const mockStore = createMockStore([USER_ROLES.VIEWER_EDITOR]);
+        const testBli = { ...budgetLine, ...budgetLineOverrides };
+        render(
+            <Router location="/">
+                <Provider store={mockStore}>
+                    <BLIRow
+                        budgetLine={testBli}
+                        isEditable={true}
+                        isBLIInCurrentWorkflow={false}
+                        isReviewMode={true}
+                        readOnly={false}
+                    />
+                </Provider>
+            </Router>
+        );
+    };
+
+    it("should show the PoP error styling and tooltip when Obligate By is outside the SC PoP range in review mode", () => {
+        renderInReview({
+            date_needed: "2043-06-13",
+            sc_period_start: "2044-01-01",
+            sc_period_end: "2044-12-31"
+        });
+
+        const dateCell = screen.getByRole("cell", { name: /6\/13\/2043/ });
+        expect(dateCell).toHaveClass("table-item-error");
+        expect(screen.getByText(/outside the agreement.s Period of Performance/i)).toBeInTheDocument();
+    });
+
+    it("should not flag the Obligate By cell when date_needed is within the SC PoP range", () => {
+        renderInReview({
+            date_needed: "2043-06-13",
+            sc_period_start: "2043-01-01",
+            sc_period_end: "2043-12-31"
+        });
+
+        const dateCell = screen.getByRole("cell", { name: "6/13/2043" });
+        expect(dateCell).not.toHaveClass("table-item-error");
+        expect(screen.queryByText(/outside the agreement.s Period of Performance/i)).not.toBeInTheDocument();
+    });
+
     it("should display all BIL amount with correct rounded decimal", async () => {
         renderComponent();
 

--- a/frontend/src/components/BudgetLineItems/ChangeIcons/ChangeIcons.jsx
+++ b/frontend/src/components/BudgetLineItems/ChangeIcons/ChangeIcons.jsx
@@ -3,7 +3,6 @@ import { faPen, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { getTooltipLabel } from "../../../helpers/budgetLines.helpers";
 import { CHANGE_REQUESTS_TOOLTIP_LOADING } from "../../../hooks/useChangeRequests.hooks";
-import icons from "../../../uswds/img/sprite.svg";
 import Tooltip from "../../UI/USWDS/Tooltip";
 import { DISABLED_ICON_CLASSES } from "./DisabledChangeIcons.constants";
 
@@ -19,8 +18,6 @@ import { DISABLED_ICON_CLASSES } from "./DisabledChangeIcons.constants";
  * @param {function} props.handleDeleteItem - The function to delete the row.
  * @param {function} [props.handleDuplicateItem] - The function to duplicate the row.
  * @param {boolean} [props.duplicateIcon] - Whether to show the duplicate icon.
- * @param {boolean} [props.sendToReviewIcon] - Whether to show the send to review icon.
- * @param {function} [props.handleSubmitItemForApproval] - The function to submit the item for approval.
  * @returns {JSX.Element} - The rendered component.
  **/
 
@@ -32,9 +29,7 @@ const ChangeIcons = ({
     isItemDeletable = isItemEditable,
     handleDeleteItem = () => {},
     handleDuplicateItem = () => {},
-    duplicateIcon = true,
-    sendToReviewIcon = false,
-    handleSubmitItemForApproval = () => {}
+    duplicateIcon = true
 }) => {
     const disabledClasses = `text-primary height-2 width-2 margin-right-1 cursor-pointer ${DISABLED_ICON_CLASSES}`;
 
@@ -196,60 +191,6 @@ const ChangeIcons = ({
                                 className={disabledClasses}
                                 aria-hidden="true"
                             />
-                        </button>
-                    </Tooltip>
-                )}
-                {isItemEditable && sendToReviewIcon && (
-                    <Tooltip
-                        position="top"
-                        label="Submit for approval"
-                        className="line-height-body-1"
-                    >
-                        <button
-                            type="button"
-                            id={`submit-for-approval-${item.id}`}
-                            title="Submit for approval"
-                            aria-label="Submit for approval"
-                            data-cy="submit-row"
-                            data-testid="submit-row"
-                            onClick={() => handleSubmitItemForApproval(item.id)}
-                        >
-                            <svg
-                                className="usa-icon text-primary height-205 width-205 cursor-pointer margin-left-0"
-                                aria-hidden="true"
-                                focusable="false"
-                            >
-                                <use href={`${icons}#send`}></use>
-                            </svg>
-                        </button>
-                    </Tooltip>
-                )}
-                {!isItemEditable && sendToReviewIcon && (
-                    <Tooltip
-                        position="left"
-                        label={`${
-                            lockedMessage
-                                ? lockedMessage
-                                : "Only team members on this agreement can edit, delete, or send to approval"
-                        }`}
-                        className="line-height-body-1"
-                    >
-                        <button
-                            type="button"
-                            id={`submit-for-approval-${item?.id}`}
-                            title="Submit for Approval"
-                            aria-label="Submit for Approval"
-                            data-cy="submit-row"
-                            data-testid="submit-row"
-                            disabled={true}
-                        >
-                            <svg
-                                className={`usa-icon text-primary height-205 width-205 cursor-pointer margin-left-0 ${DISABLED_ICON_CLASSES}`}
-                                aria-hidden="true"
-                                focusable="false"
-                            >
-                                <use href={`${icons}#send`}></use>
-                            </svg>
                         </button>
                     </Tooltip>
                 )}

--- a/frontend/src/components/BudgetLineItems/ChangeIcons/ChangeIcons.test.jsx
+++ b/frontend/src/components/BudgetLineItems/ChangeIcons/ChangeIcons.test.jsx
@@ -41,8 +41,7 @@ describe("ChangeIcons", () => {
         isItemEditable: true,
         handleSetItemForEditing: vi.fn(),
         handleDeleteItem: vi.fn(),
-        handleDuplicateItem: vi.fn(),
-        handleSubmitItemForApproval: vi.fn()
+        handleDuplicateItem: vi.fn()
     };
 
     const getEditTooltip = () =>
@@ -198,29 +197,5 @@ describe("ChangeIcons", () => {
 
         await user.click(screen.getByTestId("duplicate-row"));
         expect(defaultProps.handleDuplicateItem).toHaveBeenCalledWith(123);
-    });
-
-    it("renders send to review icon when sendToReviewIcon prop is true", () => {
-        render(
-            <ChangeIcons
-                {...defaultProps}
-                sendToReviewIcon={true}
-            />
-        );
-
-        expect(screen.getByTestId("submit-row")).toBeInTheDocument();
-    });
-
-    it("calls handleSubmitItemForApproval when send to review button is clicked", async () => {
-        const user = userEvent.setup();
-        render(
-            <ChangeIcons
-                {...defaultProps}
-                sendToReviewIcon={true}
-            />
-        );
-
-        await user.click(screen.getByTestId("submit-row"));
-        expect(defaultProps.handleSubmitItemForApproval).toHaveBeenCalledWith(123);
     });
 });

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIAndSCs.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIAndSCs.test.js
@@ -1,3 +1,7 @@
+/* eslint-disable testing-library/no-node-access */
+// Note: reaching from the accordion button to its enclosing .usa-accordion__heading via
+// .closest() is necessary to assert error-border classes on the header, which has no
+// accessible query of its own.
 import { render, screen, waitFor } from "@testing-library/react";
 import { test, describe, expect, vi } from "vitest";
 import { Provider } from "react-redux";
@@ -26,6 +30,13 @@ vi.mock("../../GrantNumbers", () => ({
 vi.mock("../BudgetLinesForm", () => ({
     __esModule: true,
     default: () => <div data-testid="budget-lines-form" />
+}));
+
+// Stub the budget-lines table: its rows use RTK-Query hooks that need the API
+// middleware, which the lightweight test store here doesn't wire up.
+vi.mock("../BudgetLinesTable", () => ({
+    __esModule: true,
+    default: () => <div data-testid="budget-lines-table" />
 }));
 
 const wizardSteps = ["Project", "Agreement", "Budget Lines"];
@@ -527,5 +538,106 @@ describe("CreateBLIsAndSCs", () => {
 
         // Restore the default mock so other tests aren't affected.
         vi.mocked(useCreateBLIsAndSCs).mockImplementation(origImpl);
+    });
+
+    describe("unassociated services component error state (review mode)", () => {
+        const contractAgreement = { ...agreement, agreement_type: AgreementType.CONTRACT };
+
+        const renderWithUnassociatedGroup = async ({ isReviewMode, servicesComponentNumber, budgetLines }) => {
+            const mockStore = createMockStore();
+            const useCreateBLIsAndSCs = (await import("./CreateBLIsAndSCs.hooks")).default;
+            const origImpl = vi.mocked(useCreateBLIsAndSCs).getMockImplementation();
+            vi.mocked(useCreateBLIsAndSCs).mockImplementation((...args) => ({
+                ...origImpl(...args),
+                isReviewMode,
+                groupedBudgetLinesByServicesComponent: [
+                    {
+                        serviceComponentGroupingLabel: String(servicesComponentNumber),
+                        servicesComponentNumber,
+                        budgetLines
+                    }
+                ]
+            }));
+
+            const utils = render(
+                <Provider store={mockStore}>
+                    <BrowserRouter>
+                        <CreateBLIsAndSCs
+                            budgetLines={budgetLines}
+                            selectedResearchProject={contractAgreement}
+                            selectedAgreement={contractAgreement}
+                            selectedProcurementShop={contractAgreement.procurement_shop}
+                            isEditMode={true}
+                            continueBtnText="Save Changes"
+                            wizardSteps={wizardSteps}
+                            workflow="agreement"
+                            currentStep={1}
+                            isReviewMode={isReviewMode}
+                            canUserEditBudgetLines={true}
+                            setIsEditMode={setIsEditMode}
+                            includeDrafts={true}
+                            setIncludeDrafts={setIncludeDrafts}
+                            hideFooterButtons={true}
+                        />
+                    </BrowserRouter>
+                </Provider>
+            );
+
+            return { ...utils, restore: () => vi.mocked(useCreateBLIsAndSCs).mockImplementation(origImpl) };
+        };
+
+        test("shows the required-info message and red header border for the unassociated bucket in review mode", async () => {
+            const bli = { ...agreement.budget_line_items[0], services_component_id: null };
+            const { restore } = await renderWithUnassociatedGroup({
+                isReviewMode: true,
+                servicesComponentNumber: 0,
+                budgetLines: [bli]
+            });
+
+            expect(screen.getByText("This is required information")).toBeInTheDocument();
+            const heading = screen
+                .getByRole("button", { name: /BLs not associated with a Services Component/ })
+                .closest(".usa-accordion__heading");
+            expect(heading).toHaveClass("border-2px");
+            expect(heading).toHaveClass("border-secondary-dark");
+
+            restore();
+        });
+
+        test("does not flag a bucket that has a real services component in review mode", async () => {
+            const bli = { ...agreement.budget_line_items[0], services_component_id: 5 };
+            const { restore } = await renderWithUnassociatedGroup({
+                isReviewMode: true,
+                servicesComponentNumber: 1,
+                budgetLines: [bli]
+            });
+
+            expect(screen.queryByText("This is required information")).not.toBeInTheDocument();
+            // The accordion heading is the one wrapping the expand/collapse button.
+            const heading = screen
+                .getByRole("button", { name: /Services Component 1/ })
+                .closest(".usa-accordion__heading");
+            expect(heading).not.toHaveClass("border-2px");
+            expect(heading).not.toHaveClass("border-secondary-dark");
+
+            restore();
+        });
+
+        test("does not flag the unassociated bucket outside review mode (create wizard in progress)", async () => {
+            const bli = { ...agreement.budget_line_items[0], services_component_id: null };
+            const { restore } = await renderWithUnassociatedGroup({
+                isReviewMode: false,
+                servicesComponentNumber: 0,
+                budgetLines: [bli]
+            });
+
+            const heading = screen
+                .getByRole("button", { name: /BLs not associated with a Services Component/ })
+                .closest(".usa-accordion__heading");
+            expect(heading).not.toHaveClass("border-2px");
+            expect(heading).not.toHaveClass("border-secondary-dark");
+
+            restore();
+        });
     });
 });

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIAndSCs.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIAndSCs.test.js
@@ -2,6 +2,7 @@
 // Note: reaching from the accordion button to its enclosing .usa-accordion__heading via
 // .closest() is necessary to assert error-border classes on the header, which has no
 // accessible query of its own.
+import { createRef } from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { test, describe, expect, vi } from "vitest";
 import { Provider } from "react-redux";
@@ -638,6 +639,96 @@ describe("CreateBLIsAndSCs", () => {
             expect(heading).not.toHaveClass("border-secondary-dark");
 
             restore();
+        });
+    });
+
+    describe("getSlice bundle export", () => {
+        const contractAgreement = { ...agreement, agreement_type: AgreementType.CONTRACT };
+
+        // Render CreateBLIsAndSCs with the hook overridden to supply a specific
+        // servicesComponents/tempBudgetLines state, then return the getSlice() output the
+        // review-flow edit page reads on Save.
+        const getSliceFor = async ({ servicesComponents, tempBudgetLines, budgetLines }) => {
+            const mockStore = createMockStore();
+            const useCreateBLIsAndSCs = (await import("./CreateBLIsAndSCs.hooks")).default;
+            const origImpl = vi.mocked(useCreateBLIsAndSCs).getMockImplementation();
+            vi.mocked(useCreateBLIsAndSCs).mockImplementation((...args) => ({
+                ...origImpl(...args),
+                isEditMode: true,
+                servicesComponents,
+                tempBudgetLines
+            }));
+
+            const bundleSliceRef = createRef();
+            render(
+                <Provider store={mockStore}>
+                    <BrowserRouter>
+                        <CreateBLIsAndSCs
+                            budgetLines={budgetLines}
+                            selectedResearchProject={contractAgreement}
+                            selectedAgreement={contractAgreement}
+                            selectedProcurementShop={contractAgreement.procurement_shop}
+                            isEditMode={true}
+                            continueBtnText="Save Changes"
+                            wizardSteps={wizardSteps}
+                            workflow="agreement"
+                            currentStep={1}
+                            isReviewMode={true}
+                            canUserEditBudgetLines={true}
+                            setIsEditMode={setIsEditMode}
+                            includeDrafts={true}
+                            setIncludeDrafts={setIncludeDrafts}
+                            bundleSliceRef={bundleSliceRef}
+                            hideFooterButtons={true}
+                        />
+                    </BrowserRouter>
+                </Provider>
+            );
+
+            const slice = bundleSliceRef.current.getSlice();
+            vi.mocked(useCreateBLIsAndSCs).mockImplementation(origImpl);
+            return slice;
+        };
+
+        // Regression: resolving a missing SC (services_component_id null/0) by picking a
+        // services component. The edit form only stamps services_component_number, so the
+        // dirty check must resolve the SC link BEFORE comparing — otherwise the newly-assigned
+        // SC looks unchanged and the BLI is silently dropped from budget_line_items.update.
+        test("includes a BLI whose only change is a newly-assigned services component", async () => {
+            const baseline = { ...agreement.budget_line_items[0], id: 42, services_component_id: null };
+            // The in-progress edit: SC number now points at persisted SC id 7, but
+            // services_component_id is still null (handleEditBLI never stamps it).
+            const edited = {
+                ...baseline,
+                services_component_number: 3,
+                serviceComponentGroupingLabel: "3"
+            };
+            const servicesComponents = [{ id: 7, number: 3, created_on: "2024-05-27T19:20:46.105099Z" }];
+
+            const slice = await getSliceFor({
+                servicesComponents,
+                tempBudgetLines: [edited],
+                budgetLines: [baseline]
+            });
+
+            const updated = slice.budget_line_items.update;
+            expect(updated).toHaveLength(1);
+            expect(updated[0]).toMatchObject({ id: 42, services_component_id: 7 });
+        });
+
+        test("drops a genuinely unchanged BLI from the update bucket", async () => {
+            const baseline = { ...agreement.budget_line_items[0], id: 42, services_component_id: 7 };
+            const servicesComponents = [{ id: 7, number: 3, created_on: "2024-05-27T19:20:46.105099Z" }];
+            // Same SC assignment as the baseline, expressed via the UI-only number field.
+            const edited = { ...baseline, services_component_number: 3, serviceComponentGroupingLabel: "3" };
+
+            const slice = await getSliceFor({
+                servicesComponents,
+                tempBudgetLines: [edited],
+                budgetLines: [baseline]
+            });
+
+            expect(slice.budget_line_items.update).toHaveLength(0);
         });
     });
 });

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
@@ -232,9 +232,26 @@ const useCreateBLIsAndSCs = (
             currentLocation.pathname !== nextLocation.pathname
     );
 
-    React.useEffect(() => {
-        setGroupedBudgetLinesByServicesComponent(groupByServicesComponent(tempBudgetLines));
+    // Attach each BLI's current services-component PoP window (sc_period_start/sc_period_end)
+    // for the "Obligate By must fall within PoP" validation (row error + tooltip in BLIRow, and
+    // the suite rule that gates Save). Derived live from the current servicesComponents rather
+    // than baked into editor state, so it stays correct when the user edits an SC's PoP dates,
+    // deletes an SC, or reassigns a BLI to a different SC in the same session. Grant BLIs have no
+    // SC, so they get null and the PoP rule skips them.
+    const budgetLinesWithScPeriod = React.useMemo(() => {
+        return tempBudgetLines.map((bli) => {
+            const sc = servicesComponents.find((sc) => sc.id === bli.services_component_id);
+            return {
+                ...bli,
+                sc_period_start: sc?.period_start ?? null,
+                sc_period_end: sc?.period_end ?? null
+            };
+        });
     }, [tempBudgetLines, servicesComponents]);
+
+    React.useEffect(() => {
+        setGroupedBudgetLinesByServicesComponent(groupByServicesComponent(budgetLinesWithScPeriod));
+    }, [budgetLinesWithScPeriod]);
 
     React.useEffect(() => {
         // Don't pass grantNumbers here — that would pre-populate an empty-budgetLines
@@ -253,7 +270,8 @@ const useCreateBLIsAndSCs = (
         ? suite.run({
               // Exclude in-review BLIs from validation — they are locked (not editable) and
               // won't be included in the save payload, so their TBD fields should not block saving.
-              budgetLines: tempBudgetLines.filter((bli) => !bli.in_review)
+              // Use the SC-period-enriched lines so the Obligate-By-within-PoP rule can evaluate.
+              budgetLines: budgetLinesWithScPeriod.filter((bli) => !bli.in_review)
           })
         : pageSuiteResult;
     const pageErrors = res.getErrors();

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
@@ -238,9 +238,20 @@ const useCreateBLIsAndSCs = (
     // than baked into editor state, so it stays correct when the user edits an SC's PoP dates,
     // deletes an SC, or reassigns a BLI to a different SC in the same session. Grant BLIs have no
     // SC, so they get null and the PoP rule skips them.
+    //
+    // Prefer services_component_number over services_component_id when resolving the SC — the same
+    // precedence groupByServicesComponent uses — so the validated PoP window always matches the SC
+    // the BLI is grouped under and will be saved to. handleEditBLI keeps the number in sync on
+    // reassignment but leaves services_component_id stale until save time (getSlice resolves the id
+    // via linkBliToSc, also keyed by number); matching on the stale id here would validate against
+    // the BLI's OLD SC window while it's grouped under the new one, producing a spurious
+    // "outside PoP" error. Fall back to the id only when no number is present (e.g. undecorated data).
     const budgetLinesWithScPeriod = React.useMemo(() => {
         return tempBudgetLines.map((bli) => {
-            const sc = servicesComponents.find((sc) => sc.id === bli.services_component_id);
+            const sc =
+                bli.services_component_number != null
+                    ? servicesComponents.find((sc) => sc.number === bli.services_component_number)
+                    : servicesComponents.find((sc) => sc.id === bli.services_component_id);
             return {
                 ...bli,
                 sc_period_start: sc?.period_start ?? null,

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
@@ -282,7 +282,9 @@ const useCreateBLIsAndSCs = (
               // Exclude in-review BLIs from validation — they are locked (not editable) and
               // won't be included in the save payload, so their TBD fields should not block saving.
               // Use the SC-period-enriched lines so the Obligate-By-within-PoP rule can evaluate.
-              budgetLines: budgetLinesWithScPeriod.filter((bli) => !bli.in_review)
+              budgetLines: budgetLinesWithScPeriod.filter((bli) => !bli.in_review),
+              // Grant agreements have no SC/PoP window; the suite skips the PoP-range rule for them.
+              agreement_type: selectedAgreement?.agreement_type
           })
         : pageSuiteResult;
     const pageErrors = res.getErrors();

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.js
@@ -288,8 +288,24 @@ const useCreateBLIsAndSCs = (
           })
         : pageSuiteResult;
     const pageErrors = res.getErrors();
-    // Filter page errors to only include "Budget line item" errors and consolidate into single message
-    const budgetLineErrors = Object.entries(pageErrors).filter((error) => error[0].includes("Budget line item"));
+    // BLIs with no services component / grant number fall into the "unassociated" (0) bucket, which
+    // already renders its own "This is required information" message and red border above its accordion
+    // in review mode. Exclude those BLIs' errors here so the same BLI doesn't surface two identical
+    // messages (page-level + per-accordion) (OPS-6094). Derive the ids from the SAME grouped array the
+    // accordion renders from, so the suppression always stays in lockstep with what shows the bucket-0
+    // message (both read the same state, so there's no transient mismatch).
+    const unassociatedGroup = isGrant
+        ? groupedBudgetLinesByGrantNumber.find((group) => group.grantNumberNumber === 0)
+        : groupedBudgetLinesByServicesComponent.find((group) => group.servicesComponentNumber === 0);
+    const unassociatedBliIds = new Set(
+        isReviewMode ? (unassociatedGroup?.budgetLines ?? []).map((bli) => String(bli.id)) : []
+    );
+    const bliIdFromErrorKey = (key) => key.match(/^Budget line item \((.+)\)$/)?.[1] ?? null;
+    // Filter page errors to only include "Budget line item" errors (from associated BLIs) and
+    // consolidate into a single message.
+    const budgetLineErrors = Object.entries(pageErrors).filter(
+        (error) => error[0].includes("Budget line item") && !unassociatedBliIds.has(bliIdFromErrorKey(error[0]))
+    );
 
     const budgetLinePageErrors = budgetLineErrors.length > 0 ? [["This is required information"]] : [];
     const budgetLinePageErrorsExist = budgetLinePageErrors.length > 0;

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
@@ -663,6 +663,67 @@ describe("useCreateBLIsAndSCs", () => {
         });
     });
 
+    it("resolves the PoP window by services_component_number when it disagrees with a stale services_component_id", async () => {
+        const suiteModule = await import("./suite");
+        suiteModule.default.run.mockImplementation(() => ({
+            getErrors: () => ({}),
+            hasErrors: () => false,
+            isValid: () => true
+        }));
+
+        // Reassignment case: handleEditBLI stamps services_component_number to the NEW SC (2) but
+        // leaves services_component_id pointing at the OLD SC (1) until save time. The PoP window
+        // must follow the number (SC 2's window), not the stale id — otherwise the BLI is validated
+        // against the wrong SC while it's grouped under the new one.
+        useEditAgreementMock.mockReturnValue({
+            ...editAgreementMockData,
+            services_components: [
+                { id: 1, number: 1, period_start: "2044-01-01", period_end: "2044-06-30" },
+                { id: 2, number: 2, period_start: "2044-07-01", period_end: "2044-12-31" }
+            ],
+            budget_line_items: [
+                {
+                    id: "bli-1",
+                    services_component_id: 1,
+                    services_component_number: 2,
+                    date_needed: "2044-08-15",
+                    can_id: 5,
+                    amount: 100,
+                    in_review: false
+                }
+            ]
+        });
+
+        renderHook(() =>
+            useCreateBLIsAndSCs(
+                true,
+                true,
+                [],
+                vi.fn(),
+                goBackMock,
+                vi.fn(),
+                { id: 1, agreement_type: "CONTRACT", display_name: "AGR-1" },
+                { fee_percentage: 5, abbr: "PSC" },
+                setIsEditModeMock,
+                "agreement",
+                true,
+                true,
+                "Save & Exit",
+                1
+            )
+        );
+
+        expect(suiteModule.default.run).toHaveBeenCalledWith({
+            budgetLines: [
+                expect.objectContaining({
+                    id: "bli-1",
+                    sc_period_start: "2044-07-01",
+                    sc_period_end: "2044-12-31"
+                })
+            ]
+        });
+    });
+
     it("does not send UI-only fields in services_components when creating a new agreement", async () => {
         useEditAgreementMock.mockReturnValue({
             agreement: { team_members: [] },

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
@@ -607,6 +607,90 @@ describe("useCreateBLIsAndSCs", () => {
         expect(result.current.budgetLinePageErrorsExist).toBe(true);
     });
 
+    it("suppresses the page-level error for a BLI in the unassociated (bucket-0) accordion (covered by its own message)", async () => {
+        const suiteModule = await import("./suite");
+        const helpers = await import("../../../helpers/budgetLines.helpers");
+        // The bucket-0 accordion already surfaces its own message and red border for unassociated BLIs,
+        // so the page-level message must not double up. Drive the real bucket-0 grouping path: group the
+        // BLI under servicesComponentNumber 0, mirroring groupByServicesComponent's "unassociated" bucket.
+        const defaultGroupBySc = helpers.groupByServicesComponent.getMockImplementation();
+        helpers.groupByServicesComponent.mockImplementation((blis) =>
+            blis.length ? [{ budgetLines: blis, servicesComponentNumber: 0, serviceComponentGroupingLabel: "0" }] : []
+        );
+        useEditAgreementMock.mockReturnValue({
+            ...editAgreementMockData,
+            budget_line_items: [{ id: 99, services_component_number: 0 }],
+            deleted_budget_line_items_ids: []
+        });
+        suiteModule.default.run.mockImplementation(() => ({
+            getErrors: () => ({ "Budget line item (99)": ["This is required information"] }),
+            hasErrors: () => true,
+            isValid: () => false
+        }));
+
+        try {
+            const { result } = renderHook(() =>
+                useCreateBLIsAndSCs(
+                    true,
+                    true,
+                    [],
+                    vi.fn(),
+                    goBackMock,
+                    vi.fn(),
+                    { id: 1, agreement_type: "CONTRACT", display_name: "AGR-1" },
+                    { fee_percentage: 5, abbr: "PSC" },
+                    setIsEditModeMock,
+                    "agreement",
+                    true,
+                    true,
+                    "Save & Exit",
+                    1
+                )
+            );
+
+            expect(result.current.budgetLinePageErrorsExist).toBe(false);
+        } finally {
+            // Restore the shared factory mock so the override doesn't leak to later tests
+            // (vi.clearAllMocks in beforeEach clears calls, not implementations).
+            helpers.groupByServicesComponent.mockImplementation(defaultGroupBySc);
+        }
+    });
+
+    it("keeps the page-level error for an associated BLI with invalid fields", async () => {
+        const suiteModule = await import("./suite");
+        useEditAgreementMock.mockReturnValue({
+            ...editAgreementMockData,
+            budget_line_items: [{ id: 99, services_component_number: 1, services_component_id: 11 }],
+            deleted_budget_line_items_ids: []
+        });
+        suiteModule.default.run.mockImplementation(() => ({
+            getErrors: () => ({ "Budget line item (99)": ["This is required information"] }),
+            hasErrors: () => true,
+            isValid: () => false
+        }));
+
+        const { result } = renderHook(() =>
+            useCreateBLIsAndSCs(
+                true,
+                true,
+                [],
+                vi.fn(),
+                goBackMock,
+                vi.fn(),
+                { id: 1, agreement_type: "CONTRACT", display_name: "AGR-1" },
+                { fee_percentage: 5, abbr: "PSC" },
+                setIsEditModeMock,
+                "agreement",
+                true,
+                true,
+                "Save & Exit",
+                1
+            )
+        );
+
+        expect(result.current.budgetLinePageErrorsExist).toBe(true);
+    });
+
     it("validates each BLI against its current services component's PoP window (derived live)", async () => {
         const suiteModule = await import("./suite");
         suiteModule.default.run.mockImplementation(() => ({

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
@@ -607,6 +607,62 @@ describe("useCreateBLIsAndSCs", () => {
         expect(result.current.budgetLinePageErrorsExist).toBe(true);
     });
 
+    it("validates each BLI against its current services component's PoP window (derived live)", async () => {
+        const suiteModule = await import("./suite");
+        suiteModule.default.run.mockImplementation(() => ({
+            getErrors: () => ({}),
+            hasErrors: () => false,
+            isValid: () => true
+        }));
+
+        // A BLI linked to SC id 11, which carries a PoP window on the current services components.
+        useEditAgreementMock.mockReturnValue({
+            ...editAgreementMockData,
+            services_components: [{ id: 11, number: 1, period_start: "2044-01-01", period_end: "2044-12-31" }],
+            budget_line_items: [
+                {
+                    id: "bli-1",
+                    services_component_id: 11,
+                    date_needed: "2044-06-15",
+                    can_id: 5,
+                    amount: 100,
+                    in_review: false
+                }
+            ]
+        });
+
+        renderHook(() =>
+            useCreateBLIsAndSCs(
+                true,
+                true,
+                [],
+                vi.fn(),
+                goBackMock,
+                vi.fn(),
+                { id: 1, agreement_type: "CONTRACT", display_name: "AGR-1" },
+                { fee_percentage: 5, abbr: "PSC" },
+                setIsEditModeMock,
+                "agreement",
+                true,
+                true,
+                "Save & Exit",
+                1
+            )
+        );
+
+        // The suite must receive the BLI enriched with its SC's PoP window, derived live from
+        // the current services components (not baked into editor state) so SC edits stay in sync.
+        expect(suiteModule.default.run).toHaveBeenCalledWith({
+            budgetLines: [
+                expect.objectContaining({
+                    id: "bli-1",
+                    sc_period_start: "2044-01-01",
+                    sc_period_end: "2044-12-31"
+                })
+            ]
+        });
+    });
+
     it("does not send UI-only fields in services_components when creating a new agreement", async () => {
         useEditAgreementMock.mockReturnValue({
             agreement: { team_members: [] },

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.hooks.test.js
@@ -603,7 +603,7 @@ describe("useCreateBLIsAndSCs", () => {
             )
         );
 
-        expect(suiteModule.default.run).toHaveBeenCalledWith({ budgetLines: [] });
+        expect(suiteModule.default.run).toHaveBeenCalledWith({ budgetLines: [], agreement_type: "GRANT" });
         expect(result.current.budgetLinePageErrorsExist).toBe(true);
     });
 
@@ -659,7 +659,8 @@ describe("useCreateBLIsAndSCs", () => {
                     sc_period_start: "2044-01-01",
                     sc_period_end: "2044-12-31"
                 })
-            ]
+            ],
+            agreement_type: "CONTRACT"
         });
     });
 
@@ -720,7 +721,8 @@ describe("useCreateBLIsAndSCs", () => {
                     sc_period_start: "2044-07-01",
                     sc_period_end: "2044-12-31"
                 })
-            ]
+            ],
+            agreement_type: "CONTRACT"
         });
     });
 

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
@@ -327,13 +327,18 @@ export const CreateBLIsAndSCs = ({
                     .map((bli) => {
                         const baseline = budgetLines.find((b) => b.id === bli.id);
                         const { id, data: cleaned } = cleanBudgetLineItemForApi(bli);
+                        // Resolve the SC/grant link BEFORE the dirty check. The edit form only
+                        // stamps services_component_number (a UI-only field clean() strips), not
+                        // services_component_id — so comparing the pre-link payload would treat a
+                        // newly-assigned SC as "unchanged" and silently drop it from the update.
+                        const linked = applyBliLink(cleaned, bli);
                         if (baseline) {
                             const { data: cleanedBaseline } = cleanBudgetLineItemForApi(baseline);
-                            if (JSON.stringify(cleaned) === JSON.stringify(cleanedBaseline)) {
+                            if (JSON.stringify(linked) === JSON.stringify(cleanedBaseline)) {
                                 return null;
                             }
                         }
-                        return { id, ...applyBliLink(cleaned, bli) };
+                        return { id, ...linked };
                     })
                     .filter(Boolean);
 

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
@@ -559,23 +559,43 @@ export const CreateBLIsAndSCs = ({
 
             {isGrant ? (
                 groupedBudgetLinesByGrantNumber.length > 0 ? (
-                    groupedBudgetLinesByGrantNumber.map((group, index) => (
-                        <GrantNumberAccordion
-                            key={`${group.grantNumberNumber}-${index}`}
-                            grantNumberNumber={group.grantNumberNumber}
-                            totalGrantNumbers={grantNumbers.length}
-                        >
-                            <BudgetLinesTable
-                                budgetLines={group.budgetLines}
-                                handleSetBudgetLineForEditing={handleSetBudgetLineForEditingById}
-                                handleDeleteBudgetLine={handleDeleteBudgetLine}
-                                handleDuplicateBudgetLine={handleDuplicateBudgetLine}
-                                isEditable={isAgreementWorkflowOrCanEditBudgetLines}
-                                isReviewMode={isReviewMode}
-                                isGrant={true}
-                            />
-                        </GrantNumberAccordion>
-                    ))
+                    groupedBudgetLinesByGrantNumber.map((group, index) => {
+                        // The "BLs not associated with a Grant Number" bucket (number 0) is an
+                        // error state in review mode — every BL in it still needs a grant number.
+                        // Surface it with a required-info message above the accordion and a red
+                        // border on its header, mirroring the services-component path below.
+                        const isUnassociatedError =
+                            isReviewMode && group.grantNumberNumber === 0 && group.budgetLines.length > 0;
+                        return (
+                            <div key={`${group.grantNumberNumber}-${index}`}>
+                                {isUnassociatedError && (
+                                    <div className="font-12px usa-form-group usa-form-group--error margin-left-0 margin-bottom-2">
+                                        <span
+                                            className="usa-error-message text-normal margin-left-neg-1"
+                                            role="alert"
+                                        >
+                                            This is required information
+                                        </span>
+                                    </div>
+                                )}
+                                <GrantNumberAccordion
+                                    grantNumberNumber={group.grantNumberNumber}
+                                    totalGrantNumbers={grantNumbers.length}
+                                    isError={isUnassociatedError}
+                                >
+                                    <BudgetLinesTable
+                                        budgetLines={group.budgetLines}
+                                        handleSetBudgetLineForEditing={handleSetBudgetLineForEditingById}
+                                        handleDeleteBudgetLine={handleDeleteBudgetLine}
+                                        handleDuplicateBudgetLine={handleDuplicateBudgetLine}
+                                        isEditable={isAgreementWorkflowOrCanEditBudgetLines}
+                                        isReviewMode={isReviewMode}
+                                        isGrant={true}
+                                    />
+                                </GrantNumberAccordion>
+                            </div>
+                        );
+                    })
                 ) : (
                     <p className="text-center margin-y-7">You have not added any Budget Lines yet.</p>
                 )

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
@@ -579,24 +579,42 @@ export const CreateBLIsAndSCs = ({
                     const budgetLineScGroupingLabel = group.serviceComponentGroupingLabel
                         ? group.serviceComponentGroupingLabel
                         : group.servicesComponentNumber;
+                    // The "BLs not associated with a Services Component" bucket (number 0) is an
+                    // error state in review mode — every BL in it still needs a services component.
+                    // Surface it with a required-info message above the accordion and a red border
+                    // on its header.
+                    const isUnassociatedError =
+                        isReviewMode && group.servicesComponentNumber === 0 && group.budgetLines.length > 0;
                     return (
-                        <ServicesComponentAccordion
-                            key={`${group.servicesComponentNumber}-${index}`}
-                            servicesComponentNumber={group.servicesComponentNumber}
-                            serviceComponentGroupingLabel={group.serviceComponentGroupingLabel}
-                            serviceRequirementType={selectedAgreement.service_requirement_type}
-                            optional={findIfOptional(servicesComponents, budgetLineScGroupingLabel)}
-                            description={findDescription(servicesComponents, budgetLineScGroupingLabel)}
-                        >
-                            <BudgetLinesTable
-                                budgetLines={group.budgetLines}
-                                handleSetBudgetLineForEditing={handleSetBudgetLineForEditingById}
-                                handleDeleteBudgetLine={handleDeleteBudgetLine}
-                                handleDuplicateBudgetLine={handleDuplicateBudgetLine}
-                                isEditable={isAgreementWorkflowOrCanEditBudgetLines}
-                                isReviewMode={isReviewMode}
-                            />
-                        </ServicesComponentAccordion>
+                        <div key={`${group.servicesComponentNumber}-${index}`}>
+                            {isUnassociatedError && (
+                                <div className="font-12px usa-form-group usa-form-group--error margin-left-0 margin-bottom-2">
+                                    <span
+                                        className="usa-error-message text-normal margin-left-neg-1"
+                                        role="alert"
+                                    >
+                                        This is required information
+                                    </span>
+                                </div>
+                            )}
+                            <ServicesComponentAccordion
+                                servicesComponentNumber={group.servicesComponentNumber}
+                                serviceComponentGroupingLabel={group.serviceComponentGroupingLabel}
+                                serviceRequirementType={selectedAgreement.service_requirement_type}
+                                optional={findIfOptional(servicesComponents, budgetLineScGroupingLabel)}
+                                description={findDescription(servicesComponents, budgetLineScGroupingLabel)}
+                                isError={isUnassociatedError}
+                            >
+                                <BudgetLinesTable
+                                    budgetLines={group.budgetLines}
+                                    handleSetBudgetLineForEditing={handleSetBudgetLineForEditingById}
+                                    handleDeleteBudgetLine={handleDeleteBudgetLine}
+                                    handleDuplicateBudgetLine={handleDuplicateBudgetLine}
+                                    isEditable={isAgreementWorkflowOrCanEditBudgetLines}
+                                    isReviewMode={isReviewMode}
+                                />
+                            </ServicesComponentAccordion>
+                        </div>
                     );
                 })
             ) : (

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/suite.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/suite.js
@@ -25,11 +25,14 @@ const suite = create((data) => {
             const dateOnly = isNaN(y) || isNaN(mo) || isNaN(d) ? new Date(0) : new Date(y, mo - 1, d);
             enforce(dateOnly.getTime()).greaterThan(todayOnly.getTime());
         });
-        // Obligate By date must fall within its services component's PoP window. Only Contract/IAA
-        // BLIs carry sc_period_start/sc_period_end (attached by decorateBudgetLinesForEditor); grant
-        // BLIs have no SC, so the presence guard skips them. Skip (rather than fail) when the date or
-        // the SC period is missing — those cases already fail the required-info rule above.
-        if (item.date_needed && item.sc_period_start && item.sc_period_end) {
+        // Obligate By date must fall within its services component's PoP window. This rule only
+        // applies to Contract/IAA BLIs — grant agreements have no SC/PoP window. The explicit
+        // agreement_type guard mirrors pages/agreements/review/suite.js; the sc_period presence
+        // checks are a second line of defense (locally-created BLIs carry only a partial agreement
+        // stub, so the per-BLI agreement_type is not reliable here — hence the suite-level type).
+        // Skip (rather than fail) when the date or the SC period is missing — those cases already
+        // fail the required-info rule above.
+        if (data.agreement_type !== "GRANT" && item.date_needed && item.sc_period_start && item.sc_period_end) {
             test(
                 `Budget line item (${item.id})`,
                 "Obligate By date is outside the agreement's Period of Performance",

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/suite.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/suite.js
@@ -25,6 +25,21 @@ const suite = create((data) => {
             const dateOnly = isNaN(y) || isNaN(mo) || isNaN(d) ? new Date(0) : new Date(y, mo - 1, d);
             enforce(dateOnly.getTime()).greaterThan(todayOnly.getTime());
         });
+        // Obligate By date must fall within its services component's PoP window. Only Contract/IAA
+        // BLIs carry sc_period_start/sc_period_end (attached by decorateBudgetLinesForEditor); grant
+        // BLIs have no SC, so the presence guard skips them. Skip (rather than fail) when the date or
+        // the SC period is missing — those cases already fail the required-info rule above.
+        if (item.date_needed && item.sc_period_start && item.sc_period_end) {
+            test(
+                `Budget line item (${item.id})`,
+                "Obligate By date is outside the agreement's Period of Performance",
+                () => {
+                    enforce(
+                        item.date_needed >= item.sc_period_start && item.date_needed <= item.sc_period_end
+                    ).isTruthy();
+                }
+            );
+        }
     });
 });
 

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/suite.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/suite.test.js
@@ -52,4 +52,15 @@ describe("CreateBLIsAndSCs suite — PoP range rule", () => {
             "Obligate By date is outside the agreement's Period of Performance"
         );
     });
+
+    it("skips the PoP rule for GRANT agreements even when SC period fields are present", () => {
+        const result = suite.run({
+            agreement_type: "GRANT",
+            // date_needed is outside the window — the rule would fail if it ran.
+            budgetLines: [{ ...validBase, sc_period_start: "2044-07-01", sc_period_end: "2044-12-31" }]
+        });
+        expect(result.getErrors("Budget line item (1)")).not.toContain(
+            "Obligate By date is outside the agreement's Period of Performance"
+        );
+    });
 });

--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/suite.test.js
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/suite.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import suite from "./suite";
+
+// A far-future date so the "Need by date must be in the future" rule always passes,
+// isolating the PoP-range rule under test.
+const validBase = {
+    id: 1,
+    date_needed: "2044-06-15",
+    can_id: 5,
+    amount: 100
+};
+
+describe("CreateBLIsAndSCs suite — PoP range rule", () => {
+    beforeEach(() => {
+        suite.reset();
+    });
+
+    it("passes when date_needed falls within the SC PoP window (inclusive)", () => {
+        const result = suite.run({
+            budgetLines: [{ ...validBase, sc_period_start: "2044-06-15", sc_period_end: "2044-12-31" }]
+        });
+        expect(result.isValid()).toBe(true);
+    });
+
+    it("fails when date_needed is before the SC PoP start", () => {
+        const result = suite.run({
+            budgetLines: [{ ...validBase, sc_period_start: "2044-07-01", sc_period_end: "2044-12-31" }]
+        });
+        expect(result.isValid()).toBe(false);
+        expect(result.getErrors("Budget line item (1)")).toContain(
+            "Obligate By date is outside the agreement's Period of Performance"
+        );
+    });
+
+    it("fails when date_needed is after the SC PoP end", () => {
+        const result = suite.run({
+            budgetLines: [{ ...validBase, sc_period_start: "2044-01-01", sc_period_end: "2044-05-31" }]
+        });
+        expect(result.isValid()).toBe(false);
+        expect(result.getErrors("Budget line item (1)")).toContain(
+            "Obligate By date is outside the agreement's Period of Performance"
+        );
+    });
+
+    it("skips the PoP rule when the SC period is missing (e.g. grant BLIs)", () => {
+        const result = suite.run({
+            budgetLines: [{ ...validBase }]
+        });
+        // No PoP fields → rule is skipped; the remaining rules still pass.
+        expect(result.isValid()).toBe(true);
+        expect(result.getErrors("Budget line item (1)")).not.toContain(
+            "Obligate By date is outside the agreement's Period of Performance"
+        );
+    });
+});

--- a/frontend/src/components/GrantNumbers/GrantNumberAccordion/GrantNumberAccordion.jsx
+++ b/frontend/src/components/GrantNumbers/GrantNumberAccordion/GrantNumberAccordion.jsx
@@ -8,10 +8,11 @@ import Accordion from "../../UI/Accordion";
  * @param {number} props.grantNumberNumber - The grant number.
  * @param {number} [props.totalGrantNumbers] - The total count of grant numbers on the agreement (optional).
  *   When omitted, the heading falls back to "Grant {number}" with no "of {total}" suffix.
+ * @param {boolean} [props.isError] - When true, renders a red error border around the accordion.
  * @param {React.ReactNode} props.children - The child elements to be wrapped in the Accordion.
  * @returns {JSX.Element} - The rendered component.
  */
-function GrantNumberAccordion({ grantNumberNumber, totalGrantNumbers, children }) {
+function GrantNumberAccordion({ grantNumberNumber, totalGrantNumbers, isError = false, children }) {
     const grantNumberDisplayTitle =
         grantNumberNumber === 0
             ? "BLs not associated with a Grant Number"
@@ -23,6 +24,7 @@ function GrantNumberAccordion({ grantNumberNumber, totalGrantNumbers, children }
         <Accordion
             heading={grantNumberDisplayTitle}
             level={3}
+            isError={isError}
         >
             {children}
         </Accordion>

--- a/frontend/src/components/GrantNumbers/GrantNumberAccordion/GrantNumberAccordion.test.jsx
+++ b/frontend/src/components/GrantNumbers/GrantNumberAccordion/GrantNumberAccordion.test.jsx
@@ -45,4 +45,29 @@ describe("GrantNumberAccordion", () => {
         );
         expect(screen.getByText("BLs not associated with a Grant Number")).toBeInTheDocument();
     });
+
+    it("renders the error border on the heading when isError is true", () => {
+        render(
+            <GrantNumberAccordion
+                grantNumberNumber={0}
+                isError={true}
+            >
+                <div>child content</div>
+            </GrantNumberAccordion>
+        );
+        const heading = screen.getByRole("heading", { level: 3 });
+        expect(heading).toHaveClass("border-2px");
+        expect(heading).toHaveClass("border-secondary-dark");
+    });
+
+    it("does not render the error border by default", () => {
+        render(
+            <GrantNumberAccordion grantNumberNumber={0}>
+                <div>child content</div>
+            </GrantNumberAccordion>
+        );
+        const heading = screen.getByRole("heading", { level: 3 });
+        expect(heading).not.toHaveClass("border-2px");
+        expect(heading).not.toHaveClass("border-secondary-dark");
+    });
 });

--- a/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.jsx
+++ b/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.jsx
@@ -14,6 +14,7 @@ import styles from "./ServicesComponentAccordion.module.css";
  * @param {string} [props.description] - The description of the services component.
  * @param {string} [props.serviceComponentGroupingLabel] - The serviceComponentGroupingLabel of the services component.
  * @param {boolean} [props.optional] - Whether the services component is optional.
+ * @param {boolean} [props.isError] - When true, renders a red error border around the accordion.
  * @param {React.ReactNode} props.children - The child elements to be wrapped in the Accordion.
  * @returns {JSX.Element} - The rendered component.
  */
@@ -26,6 +27,7 @@ function ServicesComponentAccordion({
     description = "",
     optional = false,
     serviceComponentGroupingLabel = "",
+    isError = false,
     children
 }) {
     const servicesComponentDisplayTitle =
@@ -54,6 +56,7 @@ function ServicesComponentAccordion({
         <Accordion
             heading={heading}
             level={3}
+            isError={isError}
         >
             {withMetadata && (
                 <ServicesComponentMetadata

--- a/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.test.jsx
+++ b/frontend/src/components/ServicesComponents/ServicesComponentAccordion/ServicesComponentAccordion.test.jsx
@@ -201,4 +201,37 @@ describe("ServicesComponentAccordion special cases", () => {
         );
         expect(screen.getByRole("heading", { level: 3 })).toBeInTheDocument();
     });
+
+    it("renders the error border on the heading when isError is true", () => {
+        render(
+            <ServicesComponentAccordion
+                servicesComponentNumber={0}
+                serviceRequirementType="NON_SEVERABLE"
+                withMetadata={false}
+                description=""
+                isError={true}
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const heading = screen.getByRole("heading", { level: 3 });
+        expect(heading).toHaveClass("border-2px");
+        expect(heading).toHaveClass("border-secondary-dark");
+    });
+
+    it("does not render the error border by default", () => {
+        render(
+            <ServicesComponentAccordion
+                servicesComponentNumber={0}
+                serviceRequirementType="NON_SEVERABLE"
+                withMetadata={false}
+                description=""
+            >
+                <div>child</div>
+            </ServicesComponentAccordion>
+        );
+        const heading = screen.getByRole("heading", { level: 3 });
+        expect(heading).not.toHaveClass("border-2px");
+        expect(heading).not.toHaveClass("border-secondary-dark");
+    });
 });

--- a/frontend/src/components/UI/Accordion/Accordion.jsx
+++ b/frontend/src/components/UI/Accordion/Accordion.jsx
@@ -19,82 +19,87 @@ import accordion from "@uswds/uswds/js/usa-accordion";
  * @param {string} [props.id] - Optional id for anchor linking.
  * @param {string} [props.dataCy] - Data attribute for testing.
  * @param {(isOpen: boolean) => void} [props.onToggle] - Optional callback fired on toggle.
+ * @param {boolean} [props.isError=false] - When true, renders a red error border around the accordion.
  * @param {React.Ref} ref - Forwarded ref to the accordion container div.
  * @returns {JSX.Element} - The rendered accordion component.
  */
-const Accordion = React.forwardRef(({ heading, children, level = 4, isClosed = false, id, dataCy, onToggle }, ref) => {
-    const accordionId = React.useId();
-    const AccordionHeading = `h${level}`;
-    const [isOpen, setIsOpen] = React.useState(!isClosed);
+const Accordion = React.forwardRef(
+    ({ heading, children, level = 4, isClosed = false, id, dataCy, onToggle, isError = false }, ref) => {
+        const accordionId = React.useId();
+        const AccordionHeading = `h${level}`;
+        const [isOpen, setIsOpen] = React.useState(!isClosed);
 
-    // Ensure accordion JS is loaded
-    const accordionRef = React.useRef(null);
-    React.useEffect(() => {
-        const accordionElement = accordionRef.current;
-        /* v8 ignore else */
-        if (accordionElement) {
-            accordionElement.querySelectorAll("button").forEach((elem) => {
-                accordion.on(elem);
-            });
-        }
-
-        // Ensure cleanup after the effect
-        return () => {
+        // Ensure accordion JS is loaded
+        const accordionRef = React.useRef(null);
+        React.useEffect(() => {
+            const accordionElement = accordionRef.current;
             /* v8 ignore else */
             if (accordionElement) {
                 accordionElement.querySelectorAll("button").forEach((elem) => {
-                    accordion.off(elem);
+                    accordion.on(elem);
                 });
             }
-        };
-    });
 
-    if (typeof level !== "number" || level < 1 || level > 6) {
-        throw new Error(`Unrecognized heading level: ${level}`);
-    }
-
-    return (
-        <div
-            id={id}
-            className={`usa-accordion ${isOpen ? "padding-bottom-6" : ""}`}
-            style={{ lineHeight: "inherit" }}
-            ref={(node) => {
-                accordionRef.current = node;
-                if (typeof ref === "function") {
-                    ref(node);
-                } else if (ref) {
-                    ref.current = node;
+            // Ensure cleanup after the effect
+            return () => {
+                /* v8 ignore else */
+                if (accordionElement) {
+                    accordionElement.querySelectorAll("button").forEach((elem) => {
+                        accordion.off(elem);
+                    });
                 }
-            }}
-            data-cy={dataCy}
-        >
-            <AccordionHeading className="usa-accordion__heading">
-                <button
-                    type="button"
-                    className="usa-accordion__button bg-brand-base-light-variant"
-                    aria-expanded={isOpen}
-                    aria-controls={accordionId}
-                    onClick={() =>
-                        setIsOpen((prevIsOpen) => {
-                            const nextIsOpen = !prevIsOpen;
-                            onToggle?.(nextIsOpen);
-                            return nextIsOpen;
-                        })
-                    }
-                >
-                    {heading}
-                </button>
-            </AccordionHeading>
+            };
+        });
+
+        if (typeof level !== "number" || level < 1 || level > 6) {
+            throw new Error(`Unrecognized heading level: ${level}`);
+        }
+
+        return (
             <div
-                id={accordionId}
-                className="usa-accordion__content padding-x-0 overflow-visible"
-                hidden={!isOpen}
+                id={id}
+                className={`usa-accordion ${isOpen ? "padding-bottom-6" : ""}`.trim()}
+                style={{ lineHeight: "inherit" }}
+                ref={(node) => {
+                    accordionRef.current = node;
+                    if (typeof ref === "function") {
+                        ref(node);
+                    } else if (ref) {
+                        ref.current = node;
+                    }
+                }}
+                data-cy={dataCy}
             >
-                {children}
+                <AccordionHeading
+                    className={`usa-accordion__heading ${isError ? "border-2px border-secondary-dark" : ""}`.trim()}
+                >
+                    <button
+                        type="button"
+                        className="usa-accordion__button bg-brand-base-light-variant"
+                        aria-expanded={isOpen}
+                        aria-controls={accordionId}
+                        onClick={() =>
+                            setIsOpen((prevIsOpen) => {
+                                const nextIsOpen = !prevIsOpen;
+                                onToggle?.(nextIsOpen);
+                                return nextIsOpen;
+                            })
+                        }
+                    >
+                        {heading}
+                    </button>
+                </AccordionHeading>
+                <div
+                    id={accordionId}
+                    className="usa-accordion__content padding-x-0 overflow-visible"
+                    hidden={!isOpen}
+                >
+                    {children}
+                </div>
             </div>
-        </div>
-    );
-});
+        );
+    }
+);
 
 Accordion.displayName = "Accordion";
 

--- a/frontend/src/components/UI/Accordion/Accordion.test.jsx
+++ b/frontend/src/components/UI/Accordion/Accordion.test.jsx
@@ -356,6 +356,43 @@ describe("Accordion Component", () => {
             expect(accordion).not.toHaveClass("padding-bottom-6");
         });
 
+        it("applies the error border classes to the heading when isError is true", () => {
+            render(
+                <Accordion
+                    {...defaultProps}
+                    isError={true}
+                />
+            );
+
+            const heading = screen.getByRole("heading");
+
+            expect(heading).toHaveClass("border-2px");
+            expect(heading).toHaveClass("border-secondary-dark");
+        });
+
+        it("does not apply the error border classes when isError is false", () => {
+            render(
+                <Accordion
+                    {...defaultProps}
+                    isError={false}
+                />
+            );
+
+            const heading = screen.getByRole("heading");
+
+            expect(heading).not.toHaveClass("border-2px");
+            expect(heading).not.toHaveClass("border-secondary-dark");
+        });
+
+        it("does not apply the error border classes by default", () => {
+            render(<Accordion {...defaultProps} />);
+
+            const heading = screen.getByRole("heading");
+
+            expect(heading).not.toHaveClass("border-2px");
+            expect(heading).not.toHaveClass("border-secondary-dark");
+        });
+
         it("applies correct USWDS classes", () => {
             const { container } = render(<Accordion {...defaultProps} />);
 

--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -382,6 +382,11 @@ export const cleanBudgetLineItemForApi = (data) => {
     delete cleanData.display_title;
     delete cleanData.services_component_number;
     delete cleanData.grant_number_number;
+    // UI-only PoP window that may be attached to the BLI for the Obligate By within-PoP
+    // validation. Not a backend field — strip it so it never leaks into the API payload
+    // (defensive; the edit flow derives it live and doesn't persist it on the BLI).
+    delete cleanData.sc_period_start;
+    delete cleanData.sc_period_end;
     delete cleanData._meta;
     delete cleanData.tempChangeRequest;
     delete cleanData.financialSnapshot;

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
@@ -106,7 +106,7 @@ const AgreementBudgetLines = ({
             case allBudgetLinesInReview:
                 return "Budget lines In Review Status cannot be sent for status changes";
             default:
-                return "Only team members on this agreement can send to approval";
+                return "Only team members listed on this agreement can change a BL status";
         }
     };
 

--- a/frontend/src/pages/agreements/review/ReviewAgreement.hooks.js
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.hooks.js
@@ -334,7 +334,7 @@ const useReviewAgreement = (agreementId) => {
                         type: "success",
                         heading: "Agreement Updated",
                         message: `The agreement ${agreement?.name} has been successfully updated.`,
-                        redirectUrl: "/agreements"
+                        redirectUrl: `/agreements/${agreement?.id}/budget-lines`
                     });
                 } else {
                     setAlert({
@@ -346,7 +346,7 @@ const useReviewAgreement = (agreementId) => {
                             `${statusChangeMessages}\n\n` +
                             `${notes ? `<strong>Notes:</strong> ${notes}` : ""}`,
 
-                        redirectUrl: "/agreements"
+                        redirectUrl: `/agreements/${agreement?.id}/budget-lines`
                     });
                 }
             });

--- a/frontend/src/pages/agreements/review/ReviewAgreement.hooks.test.js
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.hooks.test.js
@@ -264,8 +264,8 @@ describe("useReviewAgreement", () => {
         });
 
         expect(result.current.pageErrors[POP_RANGE_ERROR_KEY]).toEqual([
-            "Budget Line 101 Obligate By date is outside the agreement’s Period of Performance",
-            "Budget Line 202 Obligate By date is outside the agreement’s Period of Performance"
+            "Budget Line 101 Obligate By date",
+            "Budget Line 202 Obligate By date"
         ]);
     });
 

--- a/frontend/src/pages/agreements/review/ReviewAgreement.hooks.test.js
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.hooks.test.js
@@ -347,7 +347,7 @@ describe("useReviewAgreement", () => {
                 expect.objectContaining({
                     type: "success",
                     heading: "Changes Sent to Approval",
-                    redirectUrl: "/agreements"
+                    redirectUrl: "/agreements/77/budget-lines"
                 })
             );
         });
@@ -509,7 +509,7 @@ describe("useReviewAgreement", () => {
                 expect.objectContaining({
                     type: "success",
                     heading: "Agreement Updated",
-                    redirectUrl: "/agreements"
+                    redirectUrl: "/agreements/77/budget-lines"
                 })
             );
         });

--- a/frontend/src/pages/agreements/review/ReviewAgreement.hooks.test.js
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.hooks.test.js
@@ -264,8 +264,8 @@ describe("useReviewAgreement", () => {
         });
 
         expect(result.current.pageErrors[POP_RANGE_ERROR_KEY]).toEqual([
-            "Budget Line 101 Obligate By date",
-            "Budget Line 202 Obligate By date"
+            "Budget Line 101 Obligate By date is outside the agreement’s Period of Performance",
+            "Budget Line 202 Obligate By date is outside the agreement’s Period of Performance"
         ]);
     });
 

--- a/frontend/src/pages/agreements/review/ReviewAgreement.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.jsx
@@ -217,11 +217,15 @@ export const ReviewAgreement = () => {
                         // with the plain grant-number BLI table (no SC metadata / requirement type).
                         if (isGrant) {
                             const groupKey = group.grantNumberNumber;
+                            // The "not associated" bucket (key 0) is an error state once one of its
+                            // BLs is selected — surface it as a red border on the accordion.
+                            const isUnassociatedError = groupKey === 0 && group.budgetLines.some((bli) => bli.selected);
                             return (
                                 <GrantNumberAccordion
                                     key={`${groupKey}-${index}`}
                                     grantNumberNumber={groupKey}
                                     totalGrantNumbers={(grantNumbers ?? []).length}
+                                    isError={isUnassociatedError}
                                 >
                                     {group.budgetLines.length > 0 ? (
                                         <AgreementBLIReviewTable
@@ -251,6 +255,11 @@ export const ReviewAgreement = () => {
                         const budgetLineScGroupingLabel = group.serviceComponentGroupingLabel
                             ? group.serviceComponentGroupingLabel
                             : group.servicesComponentNumber;
+                        // The "BLs not associated with a Services Component" bucket (number 0) is an
+                        // error state once one of its BLs is selected — surface it as a red border
+                        // on the accordion.
+                        const isUnassociatedError =
+                            group.servicesComponentNumber === 0 && group.budgetLines.some((bli) => bli.selected);
                         return (
                             <ServicesComponentAccordion
                                 key={`${group.servicesComponentNumber}-${index}`}
@@ -262,6 +271,7 @@ export const ReviewAgreement = () => {
                                 description={findDescription(servicesComponents, budgetLineScGroupingLabel)}
                                 optional={findIfOptional(servicesComponents, budgetLineScGroupingLabel)}
                                 serviceRequirementType={agreement?.service_requirement_type}
+                                isError={isUnassociatedError}
                             >
                                 {group.budgetLines.length > 0 ? (
                                     <AgreementBLIReviewTable

--- a/frontend/src/pages/agreements/review/ReviewAgreement.test.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.test.jsx
@@ -142,3 +142,59 @@ describe("ReviewAgreement error banner", () => {
         expect(screen.queryByRole("list", { hidden: true })).toBeNull();
     });
 });
+
+/* eslint-disable testing-library/no-node-access */
+// The error border lives on the accordion heading (h3); reach it from the heading button.
+describe("ReviewAgreement unassociated services component error border", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const makeBudgetLine = (selected) => ({
+        id: 16096,
+        status: "DRAFT",
+        actionable: true,
+        selected,
+        in_review: false,
+        amount: 112233,
+        fees: 0,
+        total: 112233,
+        date_needed: "2026-08-31",
+        services_component_id: null,
+        services_component_number: 0,
+        can: { number: "G994426" }
+    });
+
+    const unassociatedGroup = (selected) => [
+        {
+            serviceComponentGroupingLabel: "0",
+            servicesComponentNumber: 0,
+            budgetLines: [makeBudgetLine(selected)]
+        }
+    ];
+
+    const getUnassociatedHeading = () =>
+        screen
+            .getByRole("button", { name: /BLs not associated with a Services Component/ })
+            .closest(".usa-accordion__heading");
+
+    it("adds the red error border to the unassociated accordion heading when a BL in it is selected", () => {
+        renderComponent({
+            groupedBudgetLinesByServicesComponent: unassociatedGroup(true)
+        });
+
+        const heading = getUnassociatedHeading();
+        expect(heading).toHaveClass("border-2px");
+        expect(heading).toHaveClass("border-secondary-dark");
+    });
+
+    it("does not add the error border to the unassociated accordion heading when no BL in it is selected", () => {
+        renderComponent({
+            groupedBudgetLinesByServicesComponent: unassociatedGroup(false)
+        });
+
+        const heading = getUnassociatedHeading();
+        expect(heading).not.toHaveClass("border-2px");
+        expect(heading).not.toHaveClass("border-secondary-dark");
+    });
+});

--- a/frontend/src/pages/agreements/review/suite.js
+++ b/frontend/src/pages/agreements/review/suite.js
@@ -104,12 +104,16 @@ const budgetLineSuite = create((budgetLine = {}, fieldName) => {
         budgetLine.sc_period_start &&
         budgetLine.sc_period_end
     ) {
-        test("Budget Line Obligate By Date must be within PoP", `Budget Line ${budgetLine.id} Obligate By date`, () => {
-            enforce(
-                budgetLine.date_needed >= budgetLine.sc_period_start &&
-                    budgetLine.date_needed <= budgetLine.sc_period_end
-            ).isTruthy();
-        });
+        test(
+            "Budget Line Obligate By Date must be within PoP",
+            `Budget Line ${budgetLine.id} Obligate By date is outside the agreement’s Period of Performance`,
+            () => {
+                enforce(
+                    budgetLine.date_needed >= budgetLine.sc_period_start &&
+                        budgetLine.date_needed <= budgetLine.sc_period_end
+                ).isTruthy();
+            }
+        );
     }
 });
 

--- a/frontend/src/pages/agreements/review/suite.js
+++ b/frontend/src/pages/agreements/review/suite.js
@@ -104,16 +104,12 @@ const budgetLineSuite = create((budgetLine = {}, fieldName) => {
         budgetLine.sc_period_start &&
         budgetLine.sc_period_end
     ) {
-        test(
-            "Budget Line Obligate By Date must be within PoP",
-            `Budget Line ${budgetLine.id} Obligate By date is outside the agreement’s Period of Performance`,
-            () => {
-                enforce(
-                    budgetLine.date_needed >= budgetLine.sc_period_start &&
-                        budgetLine.date_needed <= budgetLine.sc_period_end
-                ).isTruthy();
-            }
-        );
+        test("Budget Line Obligate By Date must be within PoP", `Budget Line ${budgetLine.id} Obligate By date`, () => {
+            enforce(
+                budgetLine.date_needed >= budgetLine.sc_period_start &&
+                    budgetLine.date_needed <= budgetLine.sc_period_end
+            ).isTruthy();
+        });
     }
 });
 

--- a/frontend/src/pages/agreements/review/suite.test.js
+++ b/frontend/src/pages/agreements/review/suite.test.js
@@ -252,17 +252,13 @@ describe("Budget Line Suite", () => {
         it("fails when date_needed is before the PoP start date", () => {
             const result = validateBudgetLineItem({ ...withPop, id: 42, date_needed: isoDate(2) });
             expect(result.isValid).toBe(false);
-            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe(
-                "Budget Line 42 Obligate By date is outside the agreement’s Period of Performance"
-            );
+            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 42 Obligate By date");
         });
 
         it("fails when date_needed is after the PoP end date", () => {
             const result = validateBudgetLineItem({ ...withPop, id: 42, date_needed: isoDate(200) });
             expect(result.isValid).toBe(false);
-            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe(
-                "Budget Line 42 Obligate By date is outside the agreement’s Period of Performance"
-            );
+            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 42 Obligate By date");
         });
 
         it("skips the rule (no error) when sc_period_start/sc_period_end are missing", () => {
@@ -293,13 +289,9 @@ describe("Budget Line Suite", () => {
             ]);
             expect(results).toHaveLength(2);
             expect(results[0].isValid).toBe(false);
-            expect(results[0].errors[POP_RANGE_ERROR_KEY][0]).toBe(
-                "Budget Line 5 Obligate By date is outside the agreement’s Period of Performance"
-            );
+            expect(results[0].errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 5 Obligate By date");
             expect(results[1].isValid).toBe(false);
-            expect(results[1].errors[POP_RANGE_ERROR_KEY][0]).toBe(
-                "Budget Line 2 Obligate By date is outside the agreement’s Period of Performance"
-            );
+            expect(results[1].errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 2 Obligate By date");
         });
     });
 });

--- a/frontend/src/pages/agreements/review/suite.test.js
+++ b/frontend/src/pages/agreements/review/suite.test.js
@@ -252,13 +252,17 @@ describe("Budget Line Suite", () => {
         it("fails when date_needed is before the PoP start date", () => {
             const result = validateBudgetLineItem({ ...withPop, id: 42, date_needed: isoDate(2) });
             expect(result.isValid).toBe(false);
-            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 42 Obligate By date");
+            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe(
+                "Budget Line 42 Obligate By date is outside the agreement’s Period of Performance"
+            );
         });
 
         it("fails when date_needed is after the PoP end date", () => {
             const result = validateBudgetLineItem({ ...withPop, id: 42, date_needed: isoDate(200) });
             expect(result.isValid).toBe(false);
-            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 42 Obligate By date");
+            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe(
+                "Budget Line 42 Obligate By date is outside the agreement’s Period of Performance"
+            );
         });
 
         it("skips the rule (no error) when sc_period_start/sc_period_end are missing", () => {
@@ -289,9 +293,13 @@ describe("Budget Line Suite", () => {
             ]);
             expect(results).toHaveLength(2);
             expect(results[0].isValid).toBe(false);
-            expect(results[0].errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 5 Obligate By date");
+            expect(results[0].errors[POP_RANGE_ERROR_KEY][0]).toBe(
+                "Budget Line 5 Obligate By date is outside the agreement’s Period of Performance"
+            );
             expect(results[1].isValid).toBe(false);
-            expect(results[1].errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 2 Obligate By date");
+            expect(results[1].errors[POP_RANGE_ERROR_KEY][0]).toBe(
+                "Budget Line 2 Obligate By date is outside the agreement’s Period of Performance"
+            );
         });
     });
 });


### PR DESCRIPTION
## What changed

Resolves UX feedback items on the "Skip Change Request review for Draft→Planned and in-Planned budget edits" work (#6094):

- Clarify the disabled **Change BL Status** button tooltip for non-team members — now reads "Only team members listed on this agreement can change a BL status" (previously "...can send to approval").
- Remove the send-to-review icon from agreements list rows.
- Skip the procurement-shop change request under `SKIP_CR_FOR_DRAFT_PLANNED`.
- Add Obligate By date validation against the SC PoP window (with tests).
- Update history title for budget line status changes.
- Resolve SC link before the dirty check so a newly-assigned SC saves.
- Add top margin to the Product Service Code field.
- Flag unassociated BLs on Edit/Review Agreement with an error border and message.

## Issue

https://github.com/HHS/OPRE-OPS/issues/6094

## How to test

1. Open an agreement's Budget Lines tab as a user who is **not** a team member on that agreement.
2. Hover over the disabled **Change BL Status** button.
3. Confirm the tooltip reads: "Only team members listed on this agreement can change a BL status".
4. Verify the other UX changes above against their respective flows (agreements list icon, SC PoP validation, history title, SC link save, unassociated BL error borders).

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Screenshots

_N/A_

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated


## Links

_N/A_
