### PR TITLE
fix: show a single PoP-range error for the Obligate By date regardless of BLI count

### DIFF
--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -152,9 +152,8 @@ export const codesToDisplayText = {
         services_component: "Services Component",
         grant_number: "Grant Number",
         date_needed: "Obligate By Date",
-        // POP_RANGE_ERROR_KEY (see suite.js) — ReviewAgreement.jsx bypasses this and renders
-        // the per-BL messages directly, but keep a label here so the key isn't undefined if
-        // ever displayed generically (e.g. a future caller, or a page without the bypass).
+        // POP_RANGE_ERROR_KEY (see suite.js) — shown as a single generic line regardless
+        // of how many budget lines violate the PoP window.
         date_needed_pop_range: "Obligate By Date Outside Period of Performance"
     },
     classNameLabels: {

--- a/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.js
+++ b/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.js
@@ -17,7 +17,7 @@ import {
 } from "../../../components/Agreements/Documents/Document";
 import { PROCUREMENT_STEP_STATUS } from "../../../components/Agreements/ProcurementTracker/ProcurementTracker.constants";
 import usePreAwardApprovalData from "./usePreAwardApprovalData";
-import agreementSuite, { POP_RANGE_ERROR_KEY, validateBudgetLineItems } from "./suite";
+import agreementSuite, { validateBudgetLineItems } from "./suite";
 import { VALIDATABLE_BLI_STATUSES } from "./constants";
 
 /**
@@ -134,18 +134,9 @@ export default function useRequestPreAwardApproval(agreementId) {
 
         if (hasBLIError) {
             const seen = new Set();
-            // Sort by ascending BL id so, if this ever fires, POP_RANGE_ERROR_KEY messages
-            // read in a stable order — mirrors ReviewAgreement.hooks.js's aggregation.
-            const sortedBliValidationResults = [...bliValidationResults].sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
-            sortedBliValidationResults.forEach(({ isValid, errors }) => {
+            bliValidationResults.forEach(({ isValid, errors }) => {
                 if (isValid) return;
                 Object.entries(errors).forEach(([fieldName, messages]) => {
-                    // Accumulate rather than dedupe for POP_RANGE_ERROR_KEY, matching
-                    // ReviewAgreement.hooks.js, so the two hooks can't silently drift.
-                    if (fieldName === POP_RANGE_ERROR_KEY) {
-                        aggregated[fieldName] = [...(aggregated[fieldName] ?? []), ...messages];
-                        return;
-                    }
                     if (seen.has(fieldName)) return;
                     seen.add(fieldName);
                     aggregated[fieldName] = messages;

--- a/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.test.js
+++ b/frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.test.js
@@ -4,6 +4,7 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setupStore } from "../../../store";
 import useRequestPreAwardApproval from "./RequestPreAwardApproval.hooks";
+import { POP_RANGE_ERROR_KEY } from "./suite";
 
 vi.mock("../../../api/opsAPI", () => ({
     useGetAgreementByIdQuery: vi.fn(),
@@ -336,6 +337,44 @@ describe("useRequestPreAwardApproval — validation wiring", () => {
         const { result } = setup(agreement);
         await waitFor(() => expect(result.current).toBeDefined());
         expect(result.current.hasBLIError).toBe(false);
+    });
+
+    it("shows a single POP-range message no matter how many BLs violate it", async () => {
+        const isoDaysFromNow = (days) => {
+            const d = new Date();
+            d.setDate(d.getDate() + days);
+            return d.toISOString().slice(0, 10);
+        };
+
+        const agreement = buildAgreement({
+            budget_line_items: [
+                {
+                    id: 101,
+                    status: "PLANNED",
+                    amount: 1500,
+                    can_id: 1,
+                    services_component_id: 1,
+                    date_needed: isoDaysFromNow(2), // before PoP start
+                    sc_period_start: isoDaysFromNow(10),
+                    sc_period_end: isoDaysFromNow(100)
+                },
+                {
+                    id: 102,
+                    status: "IN_EXECUTION",
+                    amount: 800,
+                    can_id: 1,
+                    services_component_id: 1,
+                    date_needed: isoDaysFromNow(200), // after PoP end
+                    sc_period_start: isoDaysFromNow(10),
+                    sc_period_end: isoDaysFromNow(100)
+                }
+            ]
+        });
+
+        const { result } = setup(agreement);
+        await waitFor(() => expect(result.current.isAlertActive).toBe(true));
+
+        expect(result.current.pageErrors[POP_RANGE_ERROR_KEY]).toEqual(["Budget Line Obligate By"]);
     });
 
     it("exposes the filtered validatable budget lines list", async () => {

--- a/frontend/src/pages/agreements/review/ReviewAgreement.hooks.js
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.hooks.js
@@ -14,7 +14,7 @@ import useGetUserFullNameFromId from "../../../hooks/user.hooks";
 import useToggle from "../../../hooks/useToggle";
 import { actionOptions, selectedAction } from "./ReviewAgreement.constants";
 import { anyBudgetLinesByStatus, getSelectedBudgetLines } from "./ReviewAgreement.helpers";
-import agreementSuite, { POP_RANGE_ERROR_KEY, validateBudgetLineItems } from "./suite";
+import agreementSuite, { validateBudgetLineItems } from "./suite";
 
 /**
  * Custom hook for the Review Agreement page
@@ -230,20 +230,11 @@ const useReviewAgreement = (agreementId) => {
 
         if (hasBLIError && Array.isArray(bliValidationResults)) {
             const seenBudgetLineErrors = new Set();
-            // Sort by ascending BL id so POP_RANGE_ERROR_KEY messages read in a stable,
-            // predictable order regardless of the order BLs were selected in.
-            const sortedBliValidationResults = [...bliValidationResults].sort((a, b) => (a.id ?? 0) - (b.id ?? 0));
-            sortedBliValidationResults.forEach(({ isValid, errors }) => {
+            bliValidationResults.forEach(({ isValid, errors }) => {
                 if (isValid) {
                     return;
                 }
                 Object.entries(errors).forEach(([fieldName, messages]) => {
-                    // POP_RANGE_ERROR_KEY shows one alert line per violating BL, so accumulate
-                    // every BL's messages instead of deduping to the first (as other keys do).
-                    if (fieldName === POP_RANGE_ERROR_KEY) {
-                        aggregatedErrors[fieldName] = [...(aggregatedErrors[fieldName] ?? []), ...messages];
-                        return;
-                    }
                     const errorKey = `${fieldName}`;
                     if (seenBudgetLineErrors.has(errorKey)) {
                         return;

--- a/frontend/src/pages/agreements/review/ReviewAgreement.hooks.js
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.hooks.js
@@ -235,12 +235,11 @@ const useReviewAgreement = (agreementId) => {
                     return;
                 }
                 Object.entries(errors).forEach(([fieldName, messages]) => {
-                    const errorKey = `${fieldName}`;
-                    if (seenBudgetLineErrors.has(errorKey)) {
+                    if (seenBudgetLineErrors.has(fieldName)) {
                         return;
                     }
-                    seenBudgetLineErrors.add(errorKey);
-                    aggregatedErrors[errorKey] = messages;
+                    seenBudgetLineErrors.add(fieldName);
+                    aggregatedErrors[fieldName] = messages;
                 });
             });
         }

--- a/frontend/src/pages/agreements/review/ReviewAgreement.hooks.test.js
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.hooks.test.js
@@ -201,7 +201,7 @@ describe("useReviewAgreement", () => {
         expect(result.current.isSubmissionReady).toBe(true);
     });
 
-    it("accumulates one POP-range message per violating BL, sorted ascending by BL id", async () => {
+    it("shows a single POP-range message no matter how many BLs violate it", async () => {
         const isoDaysFromNow = (days) => {
             const d = new Date();
             d.setDate(d.getDate() + days);
@@ -216,8 +216,6 @@ describe("useReviewAgreement", () => {
             data: makeAgreement({
                 budget_line_items: [
                     {
-                        // Higher id, but placed/selected first — proves ordering comes from
-                        // an explicit sort, not selection order or array position.
                         id: 202,
                         amount: 800,
                         can_id: "CAN-002",
@@ -263,10 +261,7 @@ describe("useReviewAgreement", () => {
             expect(result.current.isAlertActive).toBe(true);
         });
 
-        expect(result.current.pageErrors[POP_RANGE_ERROR_KEY]).toEqual([
-            "Budget Line Obligate By",
-            "Budget Line Obligate By"
-        ]);
+        expect(result.current.pageErrors[POP_RANGE_ERROR_KEY]).toEqual(["Budget Line Obligate By"]);
     });
 
     it("bypasses agreement and budget line validation for grant agreements (OPS-6013)", async () => {

--- a/frontend/src/pages/agreements/review/ReviewAgreement.hooks.test.js
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.hooks.test.js
@@ -264,8 +264,8 @@ describe("useReviewAgreement", () => {
         });
 
         expect(result.current.pageErrors[POP_RANGE_ERROR_KEY]).toEqual([
-            "Budget Line 101 Obligate By date",
-            "Budget Line 202 Obligate By date"
+            "Budget Line Obligate By",
+            "Budget Line Obligate By"
         ]);
     });
 

--- a/frontend/src/pages/agreements/review/ReviewAgreement.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.jsx
@@ -26,7 +26,6 @@ import { scrollToTop } from "../../../helpers/scrollToTop.helper";
 import { convertCodeForDisplay } from "../../../helpers/utils";
 import { actionOptions } from "./ReviewAgreement.constants";
 import useReviewAgreement from "./ReviewAgreement.hooks";
-import { POP_RANGE_ERROR_KEY } from "./suite";
 
 /**
  * @component - Renders a page for reviewing an Agreement and sending Status Changes to approval.
@@ -142,25 +141,14 @@ export const ReviewAgreement = () => {
                             setIsAlertVisible={setIsAlertActive}
                         >
                             <ul data-cy="error-list">
-                                {Object.entries(pageErrors).map(([key, messages]) =>
-                                    key === POP_RANGE_ERROR_KEY ? (
-                                        messages.map((message, index) => (
-                                            <li
-                                                key={`${key}-${index}`}
-                                                data-cy="error-item"
-                                            >
-                                                {message}
-                                            </li>
-                                        ))
-                                    ) : (
-                                        <li
-                                            key={key}
-                                            data-cy="error-item"
-                                        >
-                                            {convertCodeForDisplay("validation", key)}
-                                        </li>
-                                    )
-                                )}
+                                {Object.entries(pageErrors).map(([key]) => (
+                                    <li
+                                        key={key}
+                                        data-cy="error-item"
+                                    >
+                                        {convertCodeForDisplay("validation", key)}
+                                    </li>
+                                ))}
                             </ul>
                         </SimpleAlert>
                     </div>

--- a/frontend/src/pages/agreements/review/ReviewAgreement.test.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.test.jsx
@@ -85,11 +85,11 @@ describe("ReviewAgreement error banner", () => {
         vi.clearAllMocks();
     });
 
-    it("renders a single <li> for the POP_RANGE_ERROR_KEY key no matter how many BLs violate the PoP window", () => {
+    it("renders a single <li> for the POP_RANGE_ERROR_KEY key", () => {
         renderComponent({
             isAlertActive: true,
             pageErrors: {
-                [POP_RANGE_ERROR_KEY]: ["Budget Line Obligate By", "Budget Line Obligate By", "Budget Line Obligate By"]
+                [POP_RANGE_ERROR_KEY]: ["Budget Line Obligate By"]
             }
         });
 

--- a/frontend/src/pages/agreements/review/ReviewAgreement.test.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.test.jsx
@@ -85,25 +85,19 @@ describe("ReviewAgreement error banner", () => {
         vi.clearAllMocks();
     });
 
-    it("renders one <li> per POP_RANGE_ERROR_KEY message when multiple BLs violate the PoP window", () => {
-        const popMessages = [
-            "BL 101: Obligate By Date must be within PoP",
-            "BL 202: Obligate By Date must be within PoP",
-            "BL 303: Obligate By Date must be within PoP"
-        ];
-
+    it("renders a single <li> for the POP_RANGE_ERROR_KEY key no matter how many BLs violate the PoP window", () => {
         renderComponent({
             isAlertActive: true,
-            pageErrors: { [POP_RANGE_ERROR_KEY]: popMessages }
+            pageErrors: {
+                [POP_RANGE_ERROR_KEY]: ["Budget Line Obligate By", "Budget Line Obligate By", "Budget Line Obligate By"]
+            }
         });
 
         const errorList = screen.getByRole("list", { hidden: true });
         const errorItems = within(errorList).getAllByRole("listitem");
-        expect(errorItems).toHaveLength(3);
-        popMessages.forEach((msg, i) => {
-            expect(errorItems[i]).toHaveTextContent(msg);
-            expect(errorItems[i]).toHaveAttribute("data-cy", "error-item");
-        });
+        expect(errorItems).toHaveLength(1);
+        expect(errorItems[0]).toHaveAttribute("data-cy", "error-item");
+        expect(errorItems[0]).toHaveTextContent("Obligate By Date Outside Period of Performance");
     });
 
     it("renders a single <li> for each non-POP_RANGE_ERROR_KEY error key", () => {
@@ -123,14 +117,14 @@ describe("ReviewAgreement error banner", () => {
             isAlertActive: true,
             pageErrors: {
                 cor: ["COR is required"],
-                [POP_RANGE_ERROR_KEY]: ["BL 101: date out of range", "BL 202: date out of range"]
+                [POP_RANGE_ERROR_KEY]: ["Budget Line Obligate By"]
             }
         });
 
         const errorList = screen.getByRole("list", { hidden: true });
         const errorItems = within(errorList).getAllByRole("listitem");
-        // 1 for cor + 2 for POP_RANGE_ERROR_KEY
-        expect(errorItems).toHaveLength(3);
+        // 1 for cor + 1 for POP_RANGE_ERROR_KEY
+        expect(errorItems).toHaveLength(2);
     });
 
     it("does not render the error banner when isAlertActive is false", () => {

--- a/frontend/src/pages/agreements/review/suite.js
+++ b/frontend/src/pages/agreements/review/suite.js
@@ -120,9 +120,8 @@ const budgetLineSuite = create((budgetLine = {}, fieldName) => {
  * and registered in the validation display map in src/helpers/utils.js.
  */
 /**
- * Normalized id for the PoP-range rule. Unlike other BLI rule keys (which show a single
- * generic message deduped across all selected BLIs), this one accumulates one message per
- * violating BL id — see the aggregation logic in ReviewAgreement.hooks.js.
+ * Normalized id for the PoP-range rule. Like other BLI rule keys, this shows a single
+ * generic message deduped across all selected BLIs, regardless of how many violate it.
  */
 export const POP_RANGE_ERROR_KEY = "date_needed_pop_range";
 

--- a/frontend/src/pages/agreements/review/suite.js
+++ b/frontend/src/pages/agreements/review/suite.js
@@ -104,7 +104,7 @@ const budgetLineSuite = create((budgetLine = {}, fieldName) => {
         budgetLine.sc_period_start &&
         budgetLine.sc_period_end
     ) {
-        test("Budget Line Obligate By Date must be within PoP", `Budget Line ${budgetLine.id} Obligate By date`, () => {
+        test("Budget Line Obligate By Date must be within PoP", `Budget Line Obligate By`, () => {
             enforce(
                 budgetLine.date_needed >= budgetLine.sc_period_start &&
                     budgetLine.date_needed <= budgetLine.sc_period_end

--- a/frontend/src/pages/agreements/review/suite.test.js
+++ b/frontend/src/pages/agreements/review/suite.test.js
@@ -279,19 +279,16 @@ describe("Budget Line Suite", () => {
             expect(result.errors).not.toHaveProperty(POP_RANGE_ERROR_KEY);
         });
 
-        it("produces a distinct message per violating BL when validating multiple budget lines together", () => {
-            // This is the building block the callers' aggregation (which accumulates one
-            // message per violating BL instead of deduping) relies on: each BL's own message
-            // must embed its own id, not the first offending BL's.
+        it("fails each violating BL independently when validating multiple budget lines together", () => {
             const results = validateBudgetLineItems([
                 { ...withPop, id: 5, date_needed: isoDate(2) }, // before PoP start
                 { ...withPop, id: 2, date_needed: isoDate(200) } // after PoP end
             ]);
             expect(results).toHaveLength(2);
             expect(results[0].isValid).toBe(false);
-            expect(results[0].errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 5 Obligate By date");
+            expect(results[0].errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line Obligate By");
             expect(results[1].isValid).toBe(false);
-            expect(results[1].errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 2 Obligate By date");
+            expect(results[1].errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line Obligate By");
         });
     });
 });

--- a/frontend/src/pages/agreements/review/suite.test.js
+++ b/frontend/src/pages/agreements/review/suite.test.js
@@ -252,13 +252,13 @@ describe("Budget Line Suite", () => {
         it("fails when date_needed is before the PoP start date", () => {
             const result = validateBudgetLineItem({ ...withPop, id: 42, date_needed: isoDate(2) });
             expect(result.isValid).toBe(false);
-            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 42 Obligate By date");
+            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line Obligate By");
         });
 
         it("fails when date_needed is after the PoP end date", () => {
             const result = validateBudgetLineItem({ ...withPop, id: 42, date_needed: isoDate(200) });
             expect(result.isValid).toBe(false);
-            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line 42 Obligate By date");
+            expect(result.errors[POP_RANGE_ERROR_KEY][0]).toBe("Budget Line Obligate By");
         });
 
         it("skips the rule (no error) when sc_period_start/sc_period_end are missing", () => {


### PR DESCRIPTION
## What changed

Fixes the "Obligate By Date" validation error in the BLI status-change review flow (Review Agreement / Request Pre-Award Approval pages) so that any nonzero number of budget lines violating the "Obligate By within the services component's Period of Performance" rule surfaces as **one** line in the error banner, instead of one duplicated line per violating budget line.

**`frontend/src/pages/agreements/review/suite.js`**
- Simplified the PoP-range Vest test message to a generic string (no longer embeds the budget line id).
- Updated the `POP_RANGE_ERROR_KEY` comment: it now dedupes like every other BLI validation key instead of accumulating one message per violating BLI.

**`frontend/src/pages/agreements/review/ReviewAgreement.jsx`**
- Removed the special-case rendering branch that mapped one `<li>` per PoP-range message. The key now renders identically to every other error key via `convertCodeForDisplay`.

**`frontend/src/pages/agreements/review/ReviewAgreement.hooks.js`** and **`frontend/src/pages/agreements/pre-award-approval/RequestPreAwardApproval.hooks.js`**
- Removed the accumulate-instead-of-dedupe branch (and the now-unneeded ascending-BLI-id sort) for `POP_RANGE_ERROR_KEY`. It now dedupes to a single message across all selected budget lines, matching every other error key.

**`frontend/src/helpers/utils.js`**
- Updated a stale comment describing the old per-BLI bypass behavior.

**Tests**
- Updated `suite.test.js`, `ReviewAgreement.hooks.test.js`, and `ReviewAgreement.test.jsx` to assert the new single-message behavior (previously they explicitly asserted the old per-BLI duplicated-message behavior).

## Issue

https://github.com/HHS/OPRE-OPS/issues/5772

## How to test

1. `cd frontend && bun run test --watch=false -- src/pages/agreements/review/suite.test.js src/pages/agreements/review/ReviewAgreement.hooks.test.js src/pages/agreements/review/ReviewAgreement.test.jsx` — all pass.
2. Manually: open the "Change Budget Line Status" (Review Agreement) page for an agreement with 2+ budget lines whose Obligate By date falls outside their services component's period of performance. Select those budget lines and attempt to change their status. Confirm the error banner shows exactly one "Obligate By Date Outside Period of Performance" line, not one per budget line.

## A11y impact

- [ ] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — the visible change is that a previously duplicated error line now appears once; no new UI.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A