### PR TITLE
feat: notify Slack on deploy job failure

### DIFF
--- a/.github/actions/notify-slack-failure/action.yaml
+++ b/.github/actions/notify-slack-failure/action.yaml
@@ -1,10 +1,10 @@
 name: "notify-slack-failure"
 author: "@devops-chris"
-description: "Posts a Slack message via incoming webhook when a deploy job fails"
+description: "Posts deploy-failure data to a Slack Workflow Builder webhook"
 
 inputs:
   webhook_url:
-    description: "Slack incoming webhook URL"
+    description: "Slack Workflow Builder webhook URL"
     required: true
 
 runs:
@@ -20,8 +20,12 @@ runs:
         RUN_NUMBER: ${{ github.run_number }}
         COMMIT_SHA: ${{ github.sha }}
       run: |
-        MESSAGE=":red_circle: *${WORKFLOW_NAME}* failed — job \`${JOB_NAME}\` on <${RUN_URL}|run #${RUN_NUMBER}> (commit ${COMMIT_SHA})"
-
         curl -sf -X POST -H 'Content-type: application/json' \
-          --data "$(jq -n --arg text "$MESSAGE" '{text: $text}')" \
+          --data "$(jq -n \
+            --arg workflow_name "$WORKFLOW_NAME" \
+            --arg job_name "$JOB_NAME" \
+            --arg run_url "$RUN_URL" \
+            --arg run_number "$RUN_NUMBER" \
+            --arg commit_sha "$COMMIT_SHA" \
+            '{workflow_name: $workflow_name, job_name: $job_name, run_url: $run_url, run_number: $run_number, commit_sha: $commit_sha}')" \
           "$WEBHOOK_URL"

--- a/.github/actions/notify-slack-failure/action.yaml
+++ b/.github/actions/notify-slack-failure/action.yaml
@@ -1,0 +1,27 @@
+name: "notify-slack-failure"
+author: "@devops-chris"
+description: "Posts a Slack message via incoming webhook when a deploy job fails"
+
+inputs:
+  webhook_url:
+    description: "Slack incoming webhook URL"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Post failure notification to Slack
+      shell: bash
+      env:
+        WEBHOOK_URL: ${{ inputs.webhook_url }}
+        WORKFLOW_NAME: ${{ github.workflow }}
+        JOB_NAME: ${{ github.job }}
+        RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        RUN_NUMBER: ${{ github.run_number }}
+        COMMIT_SHA: ${{ github.sha }}
+      run: |
+        MESSAGE=":red_circle: *${WORKFLOW_NAME}* failed — job \`${JOB_NAME}\` on <${RUN_URL}|run #${RUN_NUMBER}> (commit ${COMMIT_SHA})"
+
+        curl -sf -X POST -H 'Content-type: application/json' \
+          --data "$(jq -n --arg text "$MESSAGE" '{text: $text}')" \
+          "$WEBHOOK_URL"

--- a/.github/actions/notify-slack-failure/action.yaml
+++ b/.github/actions/notify-slack-failure/action.yaml
@@ -1,5 +1,4 @@
 name: "notify-slack-failure"
-author: "@devops-chris"
 description: "Posts deploy-failure data to a Slack Workflow Builder webhook"
 
 inputs:

--- a/.github/workflows/dev_be_build_and_deploy.yml
+++ b/.github/workflows/dev_be_build_and_deploy.yml
@@ -72,6 +72,12 @@ jobs:
             # Start the data-tools job
             az containerapp job start -n opre-ops-${{ env.ENVIRONMENT }}-app-data-tools -g opre-ops-${{ env.ENVIRONMENT }}-app-rg
 
+      - name: Notify Slack on failure
+        if: failure()
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
       # - name: Deploy Container App
       #   uses: azure/container-apps-deploy-action@5f5f4c56ca90376e3cfbd76ba8fe8533c784e655 # v2
       #   with:
@@ -99,3 +105,9 @@ jobs:
             containerAppName: opre-ops-${{ env.ENVIRONMENT }}-app-${{ env.WORKING_DIR }}
             resourceGroup: opre-ops-${{ env.ENVIRONMENT }}-app-rg
             imageToDeploy: ghcr.io/hhs/opre-ops/ops-backend:${{ github.sha }}
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev_be_build_and_deploy.yml
+++ b/.github/workflows/dev_be_build_and_deploy.yml
@@ -32,6 +32,13 @@ jobs:
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.DT_DOCKER_FILE }}
           image_tags: "${{ env.ENVIRONMENT }},${{ github.sha }}"
 
+      - name: Notify Slack on failure
+        if: failure() || cancelled()
+        continue-on-error: true
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   build-backend:
     permissions:
       contents: read
@@ -48,6 +55,13 @@ jobs:
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.BE_DOCKER_FILE }}
           image_tags: "${{ env.ENVIRONMENT }},${{ github.sha }}"
+
+      - name: Notify Slack on failure
+        if: failure() || cancelled()
+        continue-on-error: true
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy-data-tools:
     needs: build-data-tools
@@ -72,12 +86,6 @@ jobs:
             # Start the data-tools job
             az containerapp job start -n opre-ops-${{ env.ENVIRONMENT }}-app-data-tools -g opre-ops-${{ env.ENVIRONMENT }}-app-rg
 
-      - name: Notify Slack on failure
-        if: failure()
-        uses: ./.github/actions/notify-slack-failure
-        with:
-          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
       # - name: Deploy Container App
       #   uses: azure/container-apps-deploy-action@5f5f4c56ca90376e3cfbd76ba8fe8533c784e655 # v2
       #   with:
@@ -85,6 +93,13 @@ jobs:
       #     containerAppName: opre-ops-${{ env.ENVIRONMENT }}-data-tools
       #     resourceGroup: opre-ops-services-${{ env.ENVIRONMENT }}-app
       #     imageToDeploy: ghcr.io/hhs/opre-ops/ops-data-tools:${{ github.sha }}
+
+      - name: Notify Slack on failure
+        if: failure() || cancelled()
+        continue-on-error: true
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy-backend:
     needs: build-backend
@@ -107,7 +122,8 @@ jobs:
             imageToDeploy: ghcr.io/hhs/opre-ops/ops-backend:${{ github.sha }}
 
       - name: Notify Slack on failure
-        if: failure()
+        if: failure() || cancelled()
+        continue-on-error: true
         uses: ./.github/actions/notify-slack-failure
         with:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev_be_build_and_deploy.yml
+++ b/.github/workflows/dev_be_build_and_deploy.yml
@@ -76,7 +76,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       # - name: Deploy Container App
       #   uses: azure/container-apps-deploy-action@5f5f4c56ca90376e3cfbd76ba8fe8533c784e655 # v2
@@ -110,4 +110,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev_be_build_and_deploy.yml
+++ b/.github/workflows/dev_be_build_and_deploy.yml
@@ -76,7 +76,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}
 
       # - name: Deploy Container App
       #   uses: azure/container-apps-deploy-action@5f5f4c56ca90376e3cfbd76ba8fe8533c784e655 # v2
@@ -110,4 +110,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev_fe_build_and_deploy.yml
+++ b/.github/workflows/dev_fe_build_and_deploy.yml
@@ -60,3 +60,9 @@ jobs:
             resourceGroup: opre-ops-${{ env.ENVIRONMENT }}-app-rg
             imageToDeploy: ghcr.io/hhs/opre-ops/ops-${{ env.WORKING_DIR }}:${{ env.ENVIRONMENT }}
             yamlConfigPath: ./.github/container-app-suffixes.yml
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev_fe_build_and_deploy.yml
+++ b/.github/workflows/dev_fe_build_and_deploy.yml
@@ -65,4 +65,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev_fe_build_and_deploy.yml
+++ b/.github/workflows/dev_fe_build_and_deploy.yml
@@ -33,6 +33,13 @@ jobs:
           image_tags: "${{ github.sha }},${{ env.ENVIRONMENT }}"
           build_args: "VITE_BACKEND_DOMAIN=https://${{ env.ENVIRONMENT }}.${{ env.DOMAIN_NAME }}, MODE=${{ env.ENVIRONMENT }}, VITE_ENABLE_MSW=false, BUILD_STORYBOOK=true"
 
+      - name: Notify Slack on failure
+        if: failure() || cancelled()
+        continue-on-error: true
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   deploy-frontend:
     needs: build-frontend
 
@@ -62,7 +69,8 @@ jobs:
             yamlConfigPath: ./.github/container-app-suffixes.yml
 
       - name: Notify Slack on failure
-        if: failure()
+        if: failure() || cancelled()
+        continue-on-error: true
         uses: ./.github/actions/notify-slack-failure
         with:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/dev_fe_build_and_deploy.yml
+++ b/.github/workflows/dev_fe_build_and_deploy.yml
@@ -65,4 +65,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/stg_be_build_and_deploy.yml
+++ b/.github/workflows/stg_be_build_and_deploy.yml
@@ -32,6 +32,13 @@ jobs:
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.DT_DOCKER_FILE }}
           image_tags: "${{ env.ENVIRONMENT }},${{ github.sha }}"
 
+      - name: Notify Slack on failure
+        if: failure() || cancelled()
+        continue-on-error: true
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   build-backend:
     permissions:
       contents: read
@@ -48,6 +55,13 @@ jobs:
           context: ${{ github.workspace }}/${{ env.WORKING_DIR }}
           dockerfile: ${{ github.workspace }}/${{ env.WORKING_DIR }}/${{ env.BE_DOCKER_FILE }}
           image_tags: "${{ env.ENVIRONMENT }},${{ github.sha }}"
+
+      - name: Notify Slack on failure
+        if: failure() || cancelled()
+        continue-on-error: true
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy-data-tools:
     needs: build-data-tools
@@ -75,7 +89,8 @@ jobs:
             az containerapp job start -n opre-ops-${{ env.ENVIRONMENT }}-app-up-schema -g opre-ops-${{ env.ENVIRONMENT }}-app-rg
 
       - name: Notify Slack on failure
-        if: failure()
+        if: failure() || cancelled()
+        continue-on-error: true
         uses: ./.github/actions/notify-slack-failure
         with:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -101,7 +116,8 @@ jobs:
             imageToDeploy: ghcr.io/hhs/opre-ops/ops-backend:${{ github.sha }}
 
       - name: Notify Slack on failure
-        if: failure()
+        if: failure() || cancelled()
+        continue-on-error: true
         uses: ./.github/actions/notify-slack-failure
         with:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/stg_be_build_and_deploy.yml
+++ b/.github/workflows/stg_be_build_and_deploy.yml
@@ -78,7 +78,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}
 
   deploy-backend:
     needs: build-backend
@@ -104,4 +104,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/stg_be_build_and_deploy.yml
+++ b/.github/workflows/stg_be_build_and_deploy.yml
@@ -78,7 +78,7 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
   deploy-backend:
     needs: build-backend
@@ -104,4 +104,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/stg_be_build_and_deploy.yml
+++ b/.github/workflows/stg_be_build_and_deploy.yml
@@ -74,6 +74,12 @@ jobs:
             # Start the DB schema update job
             az containerapp job start -n opre-ops-${{ env.ENVIRONMENT }}-app-up-schema -g opre-ops-${{ env.ENVIRONMENT }}-app-rg
 
+      - name: Notify Slack on failure
+        if: failure()
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   deploy-backend:
     needs: build-backend
     permissions:
@@ -93,3 +99,9 @@ jobs:
             containerAppName: opre-ops-${{ env.ENVIRONMENT }}-app-${{ env.WORKING_DIR }}
             resourceGroup: opre-ops-${{ env.ENVIRONMENT }}-app-rg
             imageToDeploy: ghcr.io/hhs/opre-ops/ops-backend:${{ github.sha }}
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/stg_fe_build_and_deploy.yml
+++ b/.github/workflows/stg_fe_build_and_deploy.yml
@@ -60,3 +60,9 @@ jobs:
             resourceGroup: opre-ops-${{ env.ENVIRONMENT }}-app-rg
             imageToDeploy: ghcr.io/hhs/opre-ops/ops-${{ env.WORKING_DIR }}:${{ env.ENVIRONMENT }}
             yamlConfigPath: ./.github/container-app-suffixes.yml
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/stg_fe_build_and_deploy.yml
+++ b/.github/workflows/stg_fe_build_and_deploy.yml
@@ -65,4 +65,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/stg_fe_build_and_deploy.yml
+++ b/.github/workflows/stg_fe_build_and_deploy.yml
@@ -33,6 +33,13 @@ jobs:
           image_tags: "${{ github.sha }},${{ env.ENVIRONMENT }}"
           build_args: "VITE_BACKEND_DOMAIN=https://${{ env.ENVIRONMENT }}.${{ env.DOMAIN_NAME }}, MODE=${{ env.ENVIRONMENT }}, VITE_ENABLE_MSW=false, BUILD_STORYBOOK=true"
 
+      - name: Notify Slack on failure
+        if: failure() || cancelled()
+        continue-on-error: true
+        uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   deploy-frontend:
     needs: build-frontend
 
@@ -62,7 +69,8 @@ jobs:
             yamlConfigPath: ./.github/container-app-suffixes.yml
 
       - name: Notify Slack on failure
-        if: failure()
+        if: failure() || cancelled()
+        continue-on-error: true
         uses: ./.github/actions/notify-slack-failure
         with:
           webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/stg_fe_build_and_deploy.yml
+++ b/.github/workflows/stg_fe_build_and_deploy.yml
@@ -65,4 +65,4 @@ jobs:
         if: failure()
         uses: ./.github/actions/notify-slack-failure
         with:
-          webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook_url: ${{ vars.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## What changed

Adds a Slack notification whenever a Dev/Staging deploy job fails, so failures surface immediately instead of going unnoticed. 

**New: `.github/actions/notify-slack-failure/action.yaml`**
A composite action that POSTs deploy-failure data to a Slack webhook via `curl`. It sends structured fields — `workflow_name`, `job_name`, `run_url`, `run_number`, `commit_sha` — rather than one pre-formatted text string, so the receiving Slack Workflow Builder automation (and whoever owns that channel) controls the message layout without needing a follow-up PR here to change formatting.

**Workflow edits** — wires the new action into the last step of every deploy job, gated on `if: failure()`, in all four Dev/Staging workflows:
- `dev_fe_build_and_deploy.yml` — `deploy-frontend`
- `dev_be_build_and_deploy.yml` — `deploy-data-tools`, `deploy-backend`
- `stg_fe_build_and_deploy.yml` — `deploy-frontend`
- `stg_be_build_and_deploy.yml` — `deploy-data-tools`, `deploy-backend`

No new `permissions:` needed anywhere — posting to a webhook needs no repo-token scopes.

**Design notes for reviewers**
- **No dedupe.** Each failure posts its own message rather than updating a prior one. Accepted tradeoff for a plain webhook instead of a Slack bot/app token (much simpler setup, no OAuth scopes to manage) — this exact incident (3+ consecutive failures) would produce 3+ separate messages under this design, not one updated thread.
- The `SLACK_WEBHOOK_URL` secret was added by the repo owner, pointing at a Slack Workflow Builder webhook trigger with 5 matching Text variables (`workflow_name`, `job_name`, `run_url`, `run_number`, `commit_sha`).

## Issue

No ticket — incident-driven, not part of pre-existing planned work. See [HHS/OPRE-OPS-Data#58](https://github.com/HHS/OPRE-OPS-Data/pull/58) for the root-cause fix this complements.

## How to test

1. On a throwaway branch, force a deploy job to fail (e.g. temporarily point `creds`/`webhook_url` at a bad value, or break a preceding step) and push, or trigger via `gh workflow run <name>`.
2. Confirm the `Notify Slack on failure` step actually runs (not skipped) and a message lands in the configured Slack channel with all 5 fields populated correctly.
3. Confirm a *successful* run shows the notify step as **skipped** (not absent) — `if: failure()` steps still appear in the job summary, just marked skipped, which is expected and not a bug.
4. Revert the throwaway breakage before merging that test branch.

No automated tests apply here — this is CI/CD configuration, not application code.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — backend/CI configuration change only, no UI.

## Definition of Done Checklist

Most items don't apply to a CI-config-only change (no application code, no tests to add, no coverage/load/a11y/security surface):
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
~- [ ] 90%+ Code coverage achieved~
~- [ ] Form validations updated~


## Links

Companion PR: [HHS/OPRE-OPS-Data#58](https://github.com/HHS/OPRE-OPS-Data/pull/58) 