### PR TITLE
style: fix editing indicator alignment in GrantNumberForm

### DIFF
--- a/frontend/src/components/GrantNumbers/GrantNumberForm/GrantNumberForm.jsx
+++ b/frontend/src/components/GrantNumbers/GrantNumberForm/GrantNumberForm.jsx
@@ -74,7 +74,7 @@ function GrantNumberForm({
                     />
                 </div>
                 {isEditMode && (
-                    <div className="margin-left-auto">
+                    <div className="margin-left-auto display-flex flex-align-center flex-no-wrap">
                         <FontAwesomeIcon
                             icon={faPen}
                             size="2x"


### PR DESCRIPTION
## What changed

Fixes a layout bug in the Edit Grant Numbers form where the pencil icon and "Editing..." text were wrapping onto separate lines.

**`frontend/src/components/GrantNumbers/GrantNumberForm/GrantNumberForm.jsx`**
- Added `display-flex flex-align-center flex-no-wrap` to the editing indicator container so the icon and text remain on a single line.

## Issue

https://github.com/HHS/OPRE-OPS/issues/6013

## How to test

1. Open the Edit Grant Numbers form (edit mode) for any agreement.
2. Confirm the pencil icon and "Editing..." text appear on the same line in the top-right of the form header.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots
<img width="1109" height="396" alt="image" src="https://github.com/user-attachments/assets/6a678f61-c0be-4644-b163-68b0c9fc503a" />


<img width="2116" height="874" alt="image" src="https://github.com/user-attachments/assets/e88472b5-e75b-4051-82f6-57bcf34722ff" />

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A