### PR TITLE
Sort agreements list alphabetically by name ascending on default load

### DIFF
--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
@@ -5,7 +5,6 @@ import AgreementsTable from "./AgreementsTable";
 import { configureStore } from "@reduxjs/toolkit";
 import { vi } from "vitest";
 import { opsApi } from "../../../api/opsAPI";
-import { tableSortCodes } from "../../../helpers/utils";
 
 // Mock API calls
 vi.mock("../../../api/opsAPI", async () => {
@@ -122,60 +121,6 @@ it("renders without crashing", () => {
     expect(screen.getByText("End")).toBeInTheDocument();
     expect(screen.getByText("Total")).toBeInTheDocument();
     expect(screen.getByText("FY25 Obligated")).toBeInTheDocument();
-});
-
-it("sets aria-sort='ascending' on the Agreement column when it is the active sort, ascending", () => {
-    render(
-        <Provider store={store}>
-            <BrowserRouter>
-                <AgreementsTable
-                    agreements={agreements}
-                    selectedFiscalYear="2025"
-                    sortConditions={tableSortCodes.agreementCodes.AGREEMENT}
-                    sortDescending={false}
-                />
-            </BrowserRouter>
-        </Provider>
-    );
-
-    const agreementHeader = screen.getByRole("columnheader", { name: /^Agreement$/ });
-    expect(agreementHeader).toHaveAttribute("aria-sort", "ascending");
-});
-
-it("sets aria-sort='descending' on the Agreement column when it is the active sort, descending", () => {
-    render(
-        <Provider store={store}>
-            <BrowserRouter>
-                <AgreementsTable
-                    agreements={agreements}
-                    selectedFiscalYear="2025"
-                    sortConditions={tableSortCodes.agreementCodes.AGREEMENT}
-                    sortDescending={true}
-                />
-            </BrowserRouter>
-        </Provider>
-    );
-
-    const agreementHeader = screen.getByRole("columnheader", { name: /^Agreement$/ });
-    expect(agreementHeader).toHaveAttribute("aria-sort", "descending");
-});
-
-it("sets aria-sort='none' on a non-active column when Agreement is the active sort", () => {
-    render(
-        <Provider store={store}>
-            <BrowserRouter>
-                <AgreementsTable
-                    agreements={agreements}
-                    selectedFiscalYear="2025"
-                    sortConditions={tableSortCodes.agreementCodes.AGREEMENT}
-                    sortDescending={false}
-                />
-            </BrowserRouter>
-        </Provider>
-    );
-
-    const typeHeader = screen.getByRole("columnheader", { name: /^Type$/ });
-    expect(typeHeader).toHaveAttribute("aria-sort", "none");
 });
 
 it("does not render contract-only expanded fields for a GRANT agreement row", () => {

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
@@ -5,6 +5,7 @@ import AgreementsTable from "./AgreementsTable";
 import { configureStore } from "@reduxjs/toolkit";
 import { vi } from "vitest";
 import { opsApi } from "../../../api/opsAPI";
+import { tableSortCodes } from "../../../helpers/utils";
 
 // Mock API calls
 vi.mock("../../../api/opsAPI", async () => {
@@ -121,6 +122,60 @@ it("renders without crashing", () => {
     expect(screen.getByText("End")).toBeInTheDocument();
     expect(screen.getByText("Total")).toBeInTheDocument();
     expect(screen.getByText("FY25 Obligated")).toBeInTheDocument();
+});
+
+it("sets aria-sort='ascending' on the Agreement column when it is the active sort, ascending", () => {
+    render(
+        <Provider store={store}>
+            <BrowserRouter>
+                <AgreementsTable
+                    agreements={agreements}
+                    selectedFiscalYear="2025"
+                    sortConditions={tableSortCodes.agreementCodes.AGREEMENT}
+                    sortDescending={false}
+                />
+            </BrowserRouter>
+        </Provider>
+    );
+
+    const agreementHeader = screen.getByRole("columnheader", { name: /^Agreement$/ });
+    expect(agreementHeader).toHaveAttribute("aria-sort", "ascending");
+});
+
+it("sets aria-sort='descending' on the Agreement column when it is the active sort, descending", () => {
+    render(
+        <Provider store={store}>
+            <BrowserRouter>
+                <AgreementsTable
+                    agreements={agreements}
+                    selectedFiscalYear="2025"
+                    sortConditions={tableSortCodes.agreementCodes.AGREEMENT}
+                    sortDescending={true}
+                />
+            </BrowserRouter>
+        </Provider>
+    );
+
+    const agreementHeader = screen.getByRole("columnheader", { name: /^Agreement$/ });
+    expect(agreementHeader).toHaveAttribute("aria-sort", "descending");
+});
+
+it("sets aria-sort='none' on a non-active column when Agreement is the active sort", () => {
+    render(
+        <Provider store={store}>
+            <BrowserRouter>
+                <AgreementsTable
+                    agreements={agreements}
+                    selectedFiscalYear="2025"
+                    sortConditions={tableSortCodes.agreementCodes.AGREEMENT}
+                    sortDescending={false}
+                />
+            </BrowserRouter>
+        </Provider>
+    );
+
+    const typeHeader = screen.getByRole("columnheader", { name: /^Type$/ });
+    expect(typeHeader).toHaveAttribute("aria-sort", "none");
 });
 
 it("does not render contract-only expanded fields for a GRANT agreement row", () => {

--- a/frontend/src/pages/agreements/list/AgreementsList.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.jsx
@@ -27,7 +27,7 @@ import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
 import { USER_ROLES } from "../../../components/Users/User.constants";
 import { ITEMS_PER_PAGE } from "../../../constants";
 import { exportTableToXlsx } from "../../../helpers/tableExport.helpers";
-import { convertCodeForDisplay, formatDate, getCurrentFiscalYear } from "../../../helpers/utils";
+import { convertCodeForDisplay, formatDate, getCurrentFiscalYear, tableSortCodes } from "../../../helpers/utils";
 import icons from "../../../uswds/img/sprite.svg";
 import AgreementsFilterButton from "./AgreementsFilterButton/AgreementsFilterButton";
 import AgreementsFilterTags from "./AgreementsFilterTags/AgreementsFilterTags";
@@ -55,7 +55,10 @@ const AgreementsList = () => {
         contractNumber: [],
         awardType: []
     });
-    const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions();
+    const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions(
+        tableSortCodes.agreementCodes.AGREEMENT,
+        false
+    );
     const [currentPage, setCurrentPage] = useState(1); // 1-indexed for UI
     const [pageSize] = useState(ITEMS_PER_PAGE);
     const [selectedFiscalYear, setSelectedFiscalYear] = React.useState(getCurrentFiscalYear());

--- a/frontend/src/pages/agreements/list/AgreementsList.sort.test.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.sort.test.jsx
@@ -1,107 +1,39 @@
-import { render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
     useGetAgreementsQuery,
     useGetAgreementsFilterOptionsQuery,
     useLazyGetUserQuery,
-    useLazyGetAgreementsQuery,
-    useGetChangeRequestsListQuery
+    useLazyGetAgreementsQuery
 } from "../../../api/opsAPI";
 import { tableSortCodes } from "../../../helpers/utils";
 import store from "../../../store";
 import AgreementsList from "./AgreementsList";
 
 // Deliberately do NOT mock Table.hooks here (contrast with AgreementsList.test.jsx),
-// so the real useSetSortConditions initialization is exercised. This is the
-// regression guard for issue #6147 — the default (no-click) sort sent to the API.
+// so the real useSetSortConditions initialization is exercised.
 vi.mock("../../../api/opsAPI");
-
-vi.mock("../../../helpers/tableExport.helpers", () => ({
-    exportTableToXlsx: vi.fn()
-}));
 
 vi.mock("../../../App", () => ({
     default: ({ children }) => <div data-testid="app-mock">{children}</div>
-}));
-
-vi.mock("../../../components/Agreements/AgreementsTable", () => ({
-    default: () => <div data-testid="agreements-table" />
 }));
 
 vi.mock("./AgreementsTabs", () => ({
     default: () => <div data-testid="agreement-tabs">All Agreements</div>
 }));
 
-vi.mock("./AgreementsFilterButton/AgreementsFilterButton", () => ({
-    default: () => <button data-testid="filter-button">Filter</button>
-}));
-
-vi.mock("./AgreementsFilterTags/AgreementsFilterTags", () => ({
-    default: () => <div data-testid="filter-tags">Filter Tags</div>
-}));
-
-vi.mock("../../../components/UI/PaginationNav/PaginationNav", () => ({
-    default: () => <nav data-testid="pagination-nav" />
-}));
-
-vi.mock("../../../components/UI/FiscalYear", () => ({
-    default: () => <div data-testid="fiscal-year-select" />
-}));
-
-vi.mock("react-router-dom", async (importOriginal) => {
-    const actual = await importOriginal();
-    return {
-        ...actual,
-        useSearchParams: vi.fn(() => [new URLSearchParams(), vi.fn()]),
-        useNavigate: vi.fn(() => vi.fn())
-    };
-});
-
-const mockAgreementsResponse = {
-    agreements: [],
-    count: 0,
-    limit: 10,
-    offset: 0
-};
-
 describe("AgreementsList - default sort on initial load", () => {
-    beforeEach(() => {
+    it("requests agreements sorted alphabetically by name, ascending, before any header click", () => {
         useLazyGetUserQuery.mockReturnValue([vi.fn(), {}]);
         useLazyGetAgreementsQuery.mockReturnValue([vi.fn(), {}]);
-
-        useGetChangeRequestsListQuery.mockReturnValue({
-            data: { data: [], count: 0, limit: 10, offset: 0 },
+        useGetAgreementsFilterOptionsQuery.mockReturnValue({ data: {} });
+        useGetAgreementsQuery.mockReturnValue({
+            data: { agreements: [], count: 0, limit: 10, offset: 0 },
             error: undefined,
-            isLoading: false
-        });
-
-        useGetAgreementsFilterOptionsQuery.mockReturnValue({
-            data: {
-                fiscal_years: [2023, 2024, 2025],
-                portfolios: [],
-                project_titles: [],
-                agreement_types: [],
-                agreement_names: [],
-                contract_numbers: [],
-                research_types: []
-            },
-            error: undefined,
-            isLoading: false
-        });
-    });
-
-    it("requests agreements sorted alphabetically by name, ascending, before any header click", async () => {
-        const mockQuery = vi.fn();
-        useGetAgreementsQuery.mockImplementation((params) => {
-            mockQuery(params);
-            return {
-                data: mockAgreementsResponse,
-                error: undefined,
-                isLoading: false,
-                isFetching: false
-            };
+            isLoading: false,
+            isFetching: false
         });
 
         render(
@@ -112,11 +44,8 @@ describe("AgreementsList - default sort on initial load", () => {
             </Provider>
         );
 
-        await waitFor(() => {
-            expect(mockQuery).toHaveBeenCalled();
-        });
-
-        const initialCall = mockQuery.mock.calls[0];
+        expect(useGetAgreementsQuery).toHaveBeenCalled();
+        const initialCall = useGetAgreementsQuery.mock.calls[0];
         expect(initialCall[0].sortConditions).toBe(tableSortCodes.agreementCodes.AGREEMENT);
         expect(initialCall[0].sortDescending).toBe(false);
     });

--- a/frontend/src/pages/agreements/list/AgreementsList.sort.test.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.sort.test.jsx
@@ -1,0 +1,123 @@
+import { render, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { BrowserRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+    useGetAgreementsQuery,
+    useGetAgreementsFilterOptionsQuery,
+    useLazyGetUserQuery,
+    useLazyGetAgreementsQuery,
+    useGetChangeRequestsListQuery
+} from "../../../api/opsAPI";
+import { tableSortCodes } from "../../../helpers/utils";
+import store from "../../../store";
+import AgreementsList from "./AgreementsList";
+
+// Deliberately do NOT mock Table.hooks here (contrast with AgreementsList.test.jsx),
+// so the real useSetSortConditions initialization is exercised. This is the
+// regression guard for issue #6147 — the default (no-click) sort sent to the API.
+vi.mock("../../../api/opsAPI");
+
+vi.mock("../../../helpers/tableExport.helpers", () => ({
+    exportTableToXlsx: vi.fn()
+}));
+
+vi.mock("../../../App", () => ({
+    default: ({ children }) => <div data-testid="app-mock">{children}</div>
+}));
+
+vi.mock("../../../components/Agreements/AgreementsTable", () => ({
+    default: () => <div data-testid="agreements-table" />
+}));
+
+vi.mock("./AgreementsTabs", () => ({
+    default: () => <div data-testid="agreement-tabs">All Agreements</div>
+}));
+
+vi.mock("./AgreementsFilterButton/AgreementsFilterButton", () => ({
+    default: () => <button data-testid="filter-button">Filter</button>
+}));
+
+vi.mock("./AgreementsFilterTags/AgreementsFilterTags", () => ({
+    default: () => <div data-testid="filter-tags">Filter Tags</div>
+}));
+
+vi.mock("../../../components/UI/PaginationNav/PaginationNav", () => ({
+    default: () => <nav data-testid="pagination-nav" />
+}));
+
+vi.mock("../../../components/UI/FiscalYear", () => ({
+    default: () => <div data-testid="fiscal-year-select" />
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+        ...actual,
+        useSearchParams: vi.fn(() => [new URLSearchParams(), vi.fn()]),
+        useNavigate: vi.fn(() => vi.fn())
+    };
+});
+
+const mockAgreementsResponse = {
+    agreements: [],
+    count: 0,
+    limit: 10,
+    offset: 0
+};
+
+describe("AgreementsList - default sort on initial load", () => {
+    beforeEach(() => {
+        useLazyGetUserQuery.mockReturnValue([vi.fn(), {}]);
+        useLazyGetAgreementsQuery.mockReturnValue([vi.fn(), {}]);
+
+        useGetChangeRequestsListQuery.mockReturnValue({
+            data: { data: [], count: 0, limit: 10, offset: 0 },
+            error: undefined,
+            isLoading: false
+        });
+
+        useGetAgreementsFilterOptionsQuery.mockReturnValue({
+            data: {
+                fiscal_years: [2023, 2024, 2025],
+                portfolios: [],
+                project_titles: [],
+                agreement_types: [],
+                agreement_names: [],
+                contract_numbers: [],
+                research_types: []
+            },
+            error: undefined,
+            isLoading: false
+        });
+    });
+
+    it("requests agreements sorted alphabetically by name, ascending, before any header click", async () => {
+        const mockQuery = vi.fn();
+        useGetAgreementsQuery.mockImplementation((params) => {
+            mockQuery(params);
+            return {
+                data: mockAgreementsResponse,
+                error: undefined,
+                isLoading: false,
+                isFetching: false
+            };
+        });
+
+        render(
+            <Provider store={store}>
+                <BrowserRouter>
+                    <AgreementsList />
+                </BrowserRouter>
+            </Provider>
+        );
+
+        await waitFor(() => {
+            expect(mockQuery).toHaveBeenCalled();
+        });
+
+        const initialCall = mockQuery.mock.calls[0];
+        expect(initialCall[0].sortConditions).toBe(tableSortCodes.agreementCodes.AGREEMENT);
+        expect(initialCall[0].sortDescending).toBe(false);
+    });
+});

--- a/frontend/src/pages/agreements/list/AgreementsList.test.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.test.jsx
@@ -10,7 +10,7 @@ import {
     useGetChangeRequestsListQuery
 } from "../../../api/opsAPI";
 import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
-import { getCurrentFiscalYear } from "../../../helpers/utils";
+import { getCurrentFiscalYear, tableSortCodes } from "../../../helpers/utils";
 import store from "../../../store";
 import AgreementsList from "./AgreementsList";
 
@@ -200,7 +200,7 @@ describe("AgreementsList - Pagination", () => {
         // Mock the sort conditions hook
         useSetSortConditions.mockReturnValue({
             sortDescending: false,
-            sortCondition: null,
+            sortCondition: tableSortCodes.agreementCodes.AGREEMENT,
             setSortConditions: vi.fn()
         });
     });
@@ -617,7 +617,7 @@ describe("AgreementsList - Fiscal Year Filtering", () => {
         // Mock the sort conditions hook
         useSetSortConditions.mockReturnValue({
             sortDescending: false,
-            sortCondition: null,
+            sortCondition: tableSortCodes.agreementCodes.AGREEMENT,
             setSortConditions: vi.fn()
         });
 


### PR DESCRIPTION
## What changed

Fixes the Agreements list not being sorted alphabetically by name on default (no-click) page load.

- **`frontend/src/pages/agreements/list/AgreementsList.jsx`**: initializes `useSetSortConditions` with `tableSortCodes.agreementCodes.AGREEMENT` / ascending instead of calling it with no arguments (which defaulted to `null`). This mirrors the existing Projects list page pattern (`useSetSortConditions(PROJECT_SORT_CODES.TITLE, false)`). As a result, the default request to the API is now sorted A→Z by name, and the "Agreement Name" column header shows the ascending sort indicator on load — no backend change was needed, since the backend's `AGREEMENT`-ascending sort path already existed and was already covered by an existing test.
- **`frontend/src/pages/agreements/list/AgreementsList.sort.test.jsx`** (new): regression test that renders the real `useSetSortConditions` hook (not mocked, unlike the sibling test file) and asserts the initial call to `useGetAgreementsQuery` carries `sortConditions: "AGREEMENT"` and `sortDescending: false`.
- **`frontend/src/pages/agreements/list/AgreementsList.test.jsx`**: updated the shared mocked default for `useSetSortConditions` from `sortCondition: null` to `tableSortCodes.agreementCodes.AGREEMENT`, since `null` is no longer a state the component can actually produce post-fix.

## Issue

https://github.com/HHS/OPRE-OPS/issues/6147

## How to test

- Unit tests: `cd frontend && bun run test --watch=false src/pages/agreements/list/AgreementsList.sort.test.jsx src/pages/agreements/list/AgreementsList.test.jsx` (or the full suite: `bun run test --watch=false`)
- Manual verification:
  1. `docker compose up db data-import backend frontend --build`
  2. Visit `/agreements` and do **not** click any column header
  3. Confirm agreement names are ordered A→Z and the "Agreement Name" header already shows the ascending arrow
  4. Click "Agreement Name" once and confirm it toggles to Z→A (descending)

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — this change affects default row order and header sort-indicator state, not layout/visual design.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated


## Links

N/A