### PR TITLE
feat: enable skipping CR for Draft->Planned status changes on prod

### DIFF
--- a/backend/ops_api/ops/environment/azure/prod.py
+++ b/backend/ops_api/ops/environment/azure/prod.py
@@ -43,4 +43,4 @@ SQLALCHEMY_MAX_OVERFLOW = 20
 
 # Skip Change Request for Draft->Planned status changes and in-Planned budget edits.
 # Disabled in production (Change Request review remains required).
-SKIP_CR_FOR_DRAFT_PLANNED = False
+SKIP_CR_FOR_DRAFT_PLANNED = True


### PR DESCRIPTION
## Summary

- Enables the `SKIP_CR_FOR_DRAFT_PLANNED` feature flag in the production environment config
- Allows users to move Budget Line Items from Draft → Planned and make in-Planned edits without requiring a Change Request
- Previously enabled in non-prod environments; this PR extends it to prod

## Changes

- `backend/ops_api/ops/environment/azure/prod.py`: `SKIP_CR_FOR_DRAFT_PLANNED = False` → `True`

## Test plan

- [ ] Verify Draft → Planned BLI status changes on prod no longer require a Change Request
- [ ] Verify in-Planned budget edits on prod no longer require a Change Request
- [ ] Confirm no regression in other status transitions that still require CR (e.g. Planned → Executing)

## Validation

- [ ] All tests pass (unit + integration)
- [ ] Pre-commit hooks pass
- [ ] Feature verified in staging environment prior to prod deploy