### PR TITLE
feat: show CLIN column on awarded contract budget lines and export

### DIFF
--- a/.claude/stories/6138-clin-column-awarded-agreements.md
+++ b/.claude/stories/6138-clin-column-awarded-agreements.md
@@ -1,0 +1,292 @@
+---
+issue: 6138
+branch: OPS-6138/clin-column-awarded-agreements
+---
+
+# Feature Story: View CLINs on Awarded Agreements
+
+## Story Overview
+
+**Ticket:** #6138
+**Title:** View CLINs on Awarded Agreements
+
+## Background
+
+### Current State
+- `BudgetLinesTable` (used in the "SCs & Budget Lines" tab at `/agreements/:id/budget-lines`) has no CLIN column
+- `AgreementBLIReviewTable` (used in "Change BL Status" at `/agreements/review/:id`) already has a `showCLINColumn` prop but it defaults to `false`
+- The backend API already returns `clin: { id, number, name }` nested on every BLI response
+- `BudgetLine` TypeScript type already declares `clin_id` and `clin` fields
+
+### Desired State
+- A CLIN column appears in the "SCs & Budget Lines" tab for awarded contract agreements
+- The same column is enabled in the "Change BL Status" review page for awarded contract agreements
+- Draft BLIs show "N/A"; non-draft BLIs show their CLIN number (or "—" if unassigned)
+- The Budget Lines list page (`/budget-lines`) is unaffected
+
+### User Story
+As an OPS user, I want to view CLINs on an awarded agreement so that I know what CLIN each budget line is assigned to in the award document.
+
+### Acceptance Criteria
+- [x] CLIN column only appears for CONTRACT agreement type
+- [x] CLIN column only appears when agreement is in awarded status
+- [x] Draft BLIs display "N/A" in the CLIN cell
+- [x] Non-draft BLIs with an assigned CLIN display the CLIN number (raw integer, e.g. `42`)
+- [x] Non-draft BLIs with no CLIN display "—" (em-dash)
+- [x] Column appears after "BL ID #", before "Obligate By"
+- [x] CLIN column does NOT appear on the Budget Lines list page
+- [x] `clin.number = 0` renders as `0`, not "—" (null-check, not truthy check)
+
+## Technical Context
+
+### Related Components
+- `frontend/src/components/BudgetLineItems/BudgetLinesTable/BudgetLinesTable.jsx`
+- `frontend/src/components/BudgetLineItems/BudgetLinesTable/BudgetLinesTable.constants.js`
+- `frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.jsx`
+- `frontend/src/pages/agreements/details/AgreementBudgetLines.jsx`
+- `frontend/src/pages/agreements/review/ReviewAgreement.jsx`
+- `frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewTable.jsx` (already has pattern)
+- `frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.jsx` (reference for CLIN rendering)
+
+### Dependencies
+- No backend changes needed — API already returns `clin` on BLI responses
+- `AgreementType` constant from `frontend/src/pages/agreements/agreements.constants.js`
+
+### Assumptions
+- "Draft" means `budgetLine.status === "DRAFT"` only
+- CLIN number displays as a raw integer without the "CLIN " prefix (the column header already says "CLIN")
+- Grants can never be contracts, so the grant accordion path in `AgreementBudgetLines.jsx` will always have `showClinColumn={false}` at runtime
+
+## Implementation Plan
+
+### Files to Modify
+
+- `BudgetLinesTable.constants.js` — add new awarded-contract header constant
+- `BudgetLinesTable.jsx` — add `showClinColumn` prop, update header selection, pass prop to row
+- `BLIRow.jsx` — add `showClinColumn` prop, add CLIN cell, update `ExpandedData` colSpan
+- `AgreementBudgetLines.jsx` — derive `isContract`, pass `showClinColumn` to table, pass `includeClin` to export
+- `ReviewAgreement.jsx` — add `AgreementType` import, derive `isContract`, pass `showCLINColumn` + `clinReadOnly`
+- `budgetLines.helpers.js` — add optional `includeClin` param to `handleExport`
+- `BLIReviewRow.jsx` — add `clinReadOnly` prop: render "—"/no-error for missing non-draft CLIN (shared with Award Approval, which must keep "TBD"+error)
+- `BLIReviewTable.jsx` (`AgreementBLIReviewTable`) — thread new `clinReadOnly` prop to `BLIReviewRow`
+
+### Implementation Steps
+
+1. **`BudgetLinesTable.constants.js`** — add constant
+   ```js
+   export const AWARDED_CONTRACT_BUDGET_LINE_TABLE_HEADERS = [
+       { heading: "BL ID #",      value: tableSortCodes.budgetLineCodes.BL_ID_NUMBER },
+       { heading: "CLIN",         value: "" },
+       { heading: "Obligate By",  value: tableSortCodes.budgetLineCodes.OBLIGATE_BY },
+       { heading: "FY",           value: tableSortCodes.budgetLineCodes.FISCAL_YEAR },
+       { heading: "CAN",          value: tableSortCodes.budgetLineCodes.CAN_NUMBER },
+       { heading: "Amount",       value: tableSortCodes.budgetLineCodes.AMOUNT },
+       { heading: "Fee",          value: tableSortCodes.budgetLineCodes.FEES },
+       { heading: "Total",        value: tableSortCodes.budgetLineCodes.TOTAL },
+       { heading: "Status",       value: tableSortCodes.budgetLineCodes.STATUS }
+   ];
+   ```
+   (9 entries — no trailing empty expand-column entry, matching existing pattern)
+
+2. **`BudgetLinesTable.jsx`** — add prop and 3-way header ternary
+   ```jsx
+   // Prop (default false):
+   showClinColumn = false
+
+   // Header selection (preserve isGrant as outer guard):
+   tableHeadings={isGrant
+       ? GRANT_BUDGET_LINE_TABLE_HEADERS
+       : showClinColumn
+           ? AWARDED_CONTRACT_BUDGET_LINE_TABLE_HEADERS
+           : BUDGET_LINE_TABLE_HEADERS
+   }
+
+   // Pass to BLIRow:
+   <BLIRow ... showClinColumn={showClinColumn} />
+   ```
+
+3. **`BLIRow.jsx`** — add CLIN cell and update colSpan
+   ```jsx
+   // After BL ID # <td>, add:
+   {showClinColumn && (
+       <td>
+           {budgetLine.status === "DRAFT"
+               ? "N/A"
+               : budgetLine.clin?.number != null
+                   ? budgetLine.clin.number
+                   : "—"}
+       </td>
+   )}
+
+   // ExpandedData colSpan (was: isGrant ? 7 : 9):
+   colSpan={isGrant ? 7 : (showClinColumn ? 10 : 9)}
+   ```
+   Also add `@property {boolean} [showClinColumn]` to JSDoc `BLIRowProps` typedef.
+
+4. **`AgreementBudgetLines.jsx`** — derive and pass
+   ```js
+   const isContract = agreement?.agreement_type === AgreementType.CONTRACT;
+   // Pass to both BudgetLinesTable calls:
+   showClinColumn={isContract && isAgreementAwarded}
+   ```
+
+5. **`budgetLines.helpers.js`** — add optional `includeClin` parameter to `handleExport`
+
+   Add `includeClin = false` as the 9th (last) argument. When `true`:
+   - Insert `"CLIN"` header after `"SC"` (index 6 in the new order)
+   - Insert CLIN value in the row mapper after the SC value:
+     ```js
+     budgetLine.status === "DRAFT"
+         ? "N/A"
+         : budgetLine.clin?.number != null
+             ? budgetLine.clin.number
+             : "—"
+     ```
+   - Shift `currencyColumns` from `[11, 13]` → `[12, 14]` (SubTotal and Procurement shop fee each shift right by 1)
+
+   Current column order → new order when `includeClin=true`:
+
+   | idx | Without CLIN     | idx | With CLIN        |
+   |-----|------------------|-----|------------------|
+   | 0   | BL ID #          | 0   | BL ID #          |
+   | 1   | Portfolio        | 1   | Portfolio        |
+   | 2   | Project          | 2   | Project          |
+   | 3   | Project Type     | 3   | Project Type     |
+   | 4   | Agreement        | 4   | Agreement        |
+   | 5   | SC               | 5   | SC               |
+   | 6   | Agreement Type   | **6**   | **CLIN**     |
+   | 7   | Description      | 7   | Agreement Type   |
+   | 8   | Obligate By      | 8   | Description      |
+   | 9   | FY               | 9   | Obligate By      |
+   | 10  | CAN              | 10  | FY               |
+   | **11** | **SubTotal** (currency) | 11  | CAN     |
+   | 12  | Procurement shop | **12** | **SubTotal** (currency) |
+   | **13** | **Proc shop fee** (currency) | 13 | Procurement shop |
+   | 14  | Fee rate         | **14** | **Proc shop fee** (currency) |
+   | 15  | Status           | 15  | Fee rate         |
+   | 16  | Comments         | 16  | Status           |
+   |     |                  | 17  | Comments         |
+
+6. **`BLIReviewRow.jsx`** — add `clinReadOnly` prop (default `false`)
+
+   `BLIReviewRow` is shared by three consumers: `RequestAwardApproval.jsx` and `ApproveAwardApproval.jsx` (Award Approval flow — `showCLINColumn={true}`, where a missing non-draft CLIN must stay "TBD" with red `table-item-error` styling because it gates award submission, see `RequestAwardApproval.jsx:126`), and `ReviewAgreement.jsx` (Change BL Status — where we want "—"/no-styling to match the detail page). Gate the difference behind a new prop so the Award Approval default is unchanged.
+
+   Current logic (lines ~186–201):
+   ```js
+   const assignedClinNumber = clinAssignments[budgetLine.id];
+   const isDraftStatus = budgetLine?.status === BUDGET_LINE_STATUSES.DRAFT;
+   const clinNumber = isDraftStatus
+       ? "N/A"
+       : assignedClinNumber
+         ? `CLIN ${assignedClinNumber}`
+         : (budgetLine?.clin?.number ?? NO_DATA);
+   const clinErrorClasses = !isDraftStatus ? `${addErrorClassIfNotFound(clinNumber, rowInReviewMode)}` : "";
+   const clinClasses = rowInReviewMode ? clinErrorClasses : budgetLine.selected ? clinErrorClasses : "";
+   ```
+
+   New logic:
+   ```js
+   const assignedClinNumber = clinAssignments[budgetLine.id];
+   const isDraftStatus = budgetLine?.status === BUDGET_LINE_STATUSES.DRAFT;
+   const backendClin = budgetLine?.clin?.number;
+   const clinNumber = isDraftStatus
+       ? "N/A"
+       : assignedClinNumber
+         ? `CLIN ${assignedClinNumber}`
+         : clinReadOnly
+           ? (backendClin != null ? backendClin : "—")   // detail-page spec: "—", not "TBD"; != null keeps CLIN 0
+           : (backendClin ?? NO_DATA);                     // Award Approval: "TBD" for missing
+   // Read-only display never flags a missing CLIN as an error.
+   const clinErrorClasses = !isDraftStatus && !clinReadOnly ? `${addErrorClassIfNotFound(clinNumber, rowInReviewMode)}` : "";
+   const clinClasses = clinReadOnly ? "" : rowInReviewMode ? clinErrorClasses : budgetLine.selected ? clinErrorClasses : "";
+   ```
+   Add `@property {boolean} [clinReadOnly]` to the `BLIReviewRowProps` JSDoc typedef.
+
+7. **`BLIReviewTable.jsx`** (`AgreementBLIReviewTable`) — add `clinReadOnly = false` prop, forward it to `<BLIReviewRow clinReadOnly={clinReadOnly} />`, and add the `@param` JSDoc line.
+
+8. **`ReviewAgreement.jsx`** — import and pass
+   ```js
+   // Add import (not currently in the file):
+   import { AgreementType } from "../agreements.constants";
+
+   // Derive after agreement is loaded:
+   const isContract = agreement?.agreement_type === AgreementType.CONTRACT;
+
+   // Pass to both AgreementBLIReviewTable calls:
+   showCLINColumn={isAgreementAwarded && isContract}
+   clinReadOnly={true}
+   ```
+
+### Key Decisions
+
+**CLIN display format:** Raw integer (`42`), not `"CLIN 42"`. The column header already reads "CLIN". `BLIReviewRow` uses `"CLIN N"` only for locally-assigned (in-progress award workflow) CLINs — that pattern does not apply to the read-only view here.
+
+**Null-check for `clin.number`:** Use `!= null`, not a truthy check. `clin.number = 0` is a valid CLIN 0 and must render as `0`. (Note: the existing Award Approval path in `BLIReviewRow` uses `?? NO_DATA` + `addErrorClassIfNotFound`, which treats CLIN 0 as falsy/missing and flags it red — a pre-existing edge left unchanged; the new `clinReadOnly` branch avoids it.)
+
+**Review page consistency (`clinReadOnly`):** The Change BL Status page must match the detail page ("—", no error styling), but `BLIReviewRow` is shared with the Award Approval flow, which intentionally shows "TBD"+red to force CLIN assignment before award. Resolved with a new `clinReadOnly` prop (default `false` = existing Award Approval behavior); `ReviewAgreement` passes `clinReadOnly={true}`. Award Approval pages are not touched.
+
+## Testing Strategy
+
+### Unit Tests
+
+#### `BudgetLinesTable.test.js`
+- [x] CLIN column absent when `showClinColumn` is not passed (default)
+- [x] CLIN column present when `showClinColumn={true}`
+
+#### `BLIRow.test.jsx`
+- [x] DRAFT BLI with `showClinColumn=true` renders "N/A" in CLIN cell
+- [x] Non-DRAFT BLI with `clin.number = 42` and `showClinColumn=true` renders `42`
+- [x] Non-DRAFT BLI with `clin = null` and `showClinColumn=true` renders "—"
+- [x] Non-DRAFT BLI with `clin.number = 0` and `showClinColumn=true` renders `0` (not "—")
+- **Cell index note:** when `showClinColumn=true`, Amount shifts from `cells[4]` → `cells[5]`, Fee `cells[5]` → `cells[6]`, Total `cells[6]` → `cells[7]`
+
+#### `AgreementBudgetLines.test.jsx`
+- [x] CLIN column absent for GRANT agreement (even if awarded)
+- [x] CLIN column absent for unawarderd CONTRACT
+- [x] CLIN column present for awarded CONTRACT
+- [x] Export button passes `includeClin=true` for awarded CONTRACT, `false` otherwise
+
+#### `budgetLines.helpers.test.js`
+- [x] Without `includeClin`: headers exclude "CLIN"; `currencyColumns` = `[11, 13]`
+- [x] With `includeClin=true`: "CLIN" header inserted after "SC"; `currencyColumns` = `[12, 14]`
+- [x] DRAFT BLI exports "N/A" in CLIN column
+- [x] Non-DRAFT BLI with `clin.number = 42` exports `42`
+- [x] Non-DRAFT BLI with `clin = null` exports "—"
+
+#### `BLIReviewRow.test.jsx`
+- [x] `clinReadOnly=true`, non-DRAFT, `clin=null` → renders "—" with **no** `table-item-error` class
+- [x] `clinReadOnly=true`, non-DRAFT, `clin.number=0` → renders `0` (not "—"), no error class
+- [x] `clinReadOnly=false` (default), non-DRAFT, `clin=null` → still renders "TBD" **with** `table-item-error` (Award Approval regression guard)
+- [x] `clinReadOnly=true`, DRAFT → still "N/A"
+
+#### `ReviewAgreement.test.jsx`
+- [x] `showCLINColumn={true}` and `clinReadOnly={true}` passed to `AgreementBLIReviewTable` for awarded contract
+- [x] `showCLINColumn={false}` for non-contract or non-awarded
+- **Pre-existing gap to fix:** add `submitButtonText: "Submit"` to `baseHookReturn` mock to prevent render errors in new assertions
+
+### Validation Checklist
+- [x] All tests pass (`bun run test --watch=false`)
+- [x] ESLint passes (`bun run lint`)
+- [x] Prettier applied (`bun run format`)
+- [x] 90% coverage gate passes
+- [x] CLIN column visible on an awarded contract agreement's SCs & BLs tab
+- [x] CLIN column visible on Change BL Status page for awarded contract, showing "—"/no-error for missing non-draft CLINs
+- [x] Award Approval pages (Request/Approve) still show "TBD"+red for missing non-draft CLINs (no regression)
+- [x] CLIN column absent on Budget Lines list page
+- [x] CLIN column absent on a grant agreement detail page
+- [x] Export for awarded contract includes CLIN column with correct values
+- [x] Export for non-contract or non-awarded agreement does NOT include CLIN column
+
+## Notes
+
+### Not in Scope
+- `AllBudgetLinesTable` / `AllBLIRow` — entirely separate components, no changes needed
+- `CreateBLIsAndSCs.jsx` callers of `BudgetLinesTable` — `showClinColumn` defaults to `false`, no changes needed
+- `BudgetLineItemList.jsx` export — calls `handleExport` without `includeClin`; stays unchanged
+- `RequestAwardApproval.jsx` / `ApproveAwardApproval.jsx` — must remain unchanged; they rely on `BLIReviewRow`'s default (`clinReadOnly=false`) "TBD"+error behavior to gate CLIN assignment before award
+- Backend — API already returns `clin` nested on BLI responses
+
+### References
+- GitHub Issue: https://github.com/HHS/OPRE-OPS/issues/6138
+- Design: SCs & BLs Tab - Awarded Agreement.pdf (attached to issue)
+- Reference implementation: `BLIReviewRow.jsx` (existing CLIN rendering pattern)

--- a/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.jsx
+++ b/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.jsx
@@ -29,6 +29,15 @@ import React, { memo } from "react";
  */
 
 /**
+ * @typedef {Object} BLIReviewClinConfig
+ * CLIN column display mode for the review table. All fields optional; an empty object hides the column.
+ * @property {boolean} [showColumn] - Whether to show the CLIN column (awarded contract agreements only).
+ * @property {Object} [assignments] - Map of budgetLineId to locally-assigned CLIN number (Award Approval flow).
+ * @property {Function} [onAddClick] - Callback when the "+ CLIN" button is clicked with budgetLine.id.
+ * @property {boolean} [readOnly] - Read-only CLIN display: missing non-draft CLIN renders "—" with no error styling (Change BL Status page). Default false keeps the Award Approval behavior ("TBD" + error styling to prompt CLIN assignment).
+ */
+
+/**
  * @typedef BLIReviewRowProps
  * @property {BudgetLine} budgetLine - The budget line object.
  * @property {boolean} [isReviewMode] - Whether the user is in review mode.
@@ -36,11 +45,8 @@ import React, { memo } from "react";
  * @property {Function} [setSelectedBLIs] - The function to set the selected budget line items.
  * @property {string} action
  * @property {boolean} [showCheckbox] - Whether to show the checkbox for selection.
- * @property {Function} [onAddCLINClick] - Callback when "+ CLIN" button is clicked with budgetLine.id
- * @property {boolean} [showCLINColumn] - Whether to show the CLIN column
- * @property {Object} [clinAssignments] - Map of budgetLineId to CLIN number assignments
  * @property {string[]} [errorStatuses] - When provided, inline error styling applies to rows whose status is in this list (regardless of row selection). When omitted, the original selection-gated behavior is preserved: errors only show when the row is selected (Review Agreement page behavior).
- * @property {boolean} [clinReadOnly] - Read-only CLIN display: missing non-draft CLIN renders "—" with no error styling (Change BL Status page). Default false keeps the Award Approval behavior ("TBD" + error styling to prompt CLIN assignment).
+ * @property {BLIReviewClinConfig} [clin] - CLIN column display configuration. Omit to hide the column.
  */
 
 /**
@@ -55,12 +61,16 @@ const BLIReviewRow = ({
     action,
     showCheckbox = true,
     readOnly = false,
-    onAddCLINClick = undefined,
-    showCLINColumn = false,
-    clinAssignments = {},
     errorStatuses,
-    clinReadOnly = false
+    clin = {}
 }) => {
+    const {
+        showColumn: showCLINColumn = false,
+        assignments: clinAssignments = {},
+        onAddClick: onAddCLINClick = undefined,
+        readOnly: clinReadOnly = false
+    } = clin;
+
     // When errorStatuses is provided, inline errors only apply to rows whose status is in the list.
     // Suppress by pretending we're not in review mode — the existing helpers gate all error styling on that flag.
     const rowInReviewMode = isReviewMode && (!errorStatuses || errorStatuses.includes(budgetLine?.status));

--- a/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.jsx
+++ b/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.jsx
@@ -40,6 +40,7 @@ import React, { memo } from "react";
  * @property {boolean} [showCLINColumn] - Whether to show the CLIN column
  * @property {Object} [clinAssignments] - Map of budgetLineId to CLIN number assignments
  * @property {string[]} [errorStatuses] - When provided, inline error styling applies to rows whose status is in this list (regardless of row selection). When omitted, the original selection-gated behavior is preserved: errors only show when the row is selected (Review Agreement page behavior).
+ * @property {boolean} [clinReadOnly] - Read-only CLIN display: missing non-draft CLIN renders "—" with no error styling (Change BL Status page). Default false keeps the Award Approval behavior ("TBD" + error styling to prompt CLIN assignment).
  */
 
 /**
@@ -57,7 +58,8 @@ const BLIReviewRow = ({
     onAddCLINClick = undefined,
     showCLINColumn = false,
     clinAssignments = {},
-    errorStatuses
+    errorStatuses,
+    clinReadOnly = false
 }) => {
     // When errorStatuses is provided, inline errors only apply to rows whose status is in the list.
     // Suppress by pretending we're not in review mode — the existing helpers gate all error styling on that flag.
@@ -186,19 +188,35 @@ const BLIReviewRow = ({
         // Use local assignment if available, otherwise fall back to backend clin.number
         const assignedClinNumber = clinAssignments[budgetLine.id];
         const isDraftStatus = budgetLine?.status === BUDGET_LINE_STATUSES.DRAFT;
+        const backendClinNumber = budgetLine?.clin?.number;
 
-        // Draft BLIs show "N/A", non-Draft show "CLIN X" or "TBD"
+        // Draft BLIs show "N/A". Non-Draft show "CLIN X" (local assignment), then:
+        //  - Read-only display (Change BL Status page): the CLIN number or "—" if unassigned
+        //    (!= null keeps a valid CLIN 0).
+        //  - Award Approval flow (default): the CLIN number or "TBD", which is flagged as an error
+        //    to prompt CLIN assignment before award.
         const clinNumber = isDraftStatus
             ? "N/A"
             : assignedClinNumber
               ? `CLIN ${assignedClinNumber}`
-              : (budgetLine?.clin?.number ?? NO_DATA);
+              : clinReadOnly
+                ? backendClinNumber != null
+                    ? backendClinNumber
+                    : "—"
+                : (backendClinNumber ?? NO_DATA);
 
-        // Only apply error styling to non-Draft BLIs with missing CLIN
-        const clinErrorClasses = !isDraftStatus ? `${addErrorClassIfNotFound(clinNumber, rowInReviewMode)}` : "";
+        // Read-only display never flags a missing CLIN as an error.
+        const clinErrorClasses =
+            !isDraftStatus && !clinReadOnly ? `${addErrorClassIfNotFound(clinNumber, rowInReviewMode)}` : "";
         // For CLIN column, show error in review mode regardless of selection (Award Approval page)
         // For other columns, only show error when selected (Review Agreement page)
-        const clinClasses = rowInReviewMode ? clinErrorClasses : budgetLine.selected ? clinErrorClasses : "";
+        const clinClasses = clinReadOnly
+            ? ""
+            : rowInReviewMode
+              ? clinErrorClasses
+              : budgetLine.selected
+                ? clinErrorClasses
+                : "";
 
         const canNumber = budgetLine?.can?.number ?? NO_DATA;
         const canNumberErrorClasses = `${addErrorClassIfNotFound(canNumber, rowInReviewMode)}`;

--- a/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.test.jsx
+++ b/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.test.jsx
@@ -309,7 +309,7 @@ describe("BLIReviewRow", () => {
                 clin_id: null,
                 clin: null
             };
-            renderComponent({ showCLINColumn: true, budgetLine: budgetLineWithoutCLIN });
+            renderComponent({ clin: { showColumn: true }, budgetLine: budgetLineWithoutCLIN });
 
             const clinCells = screen.getAllByText("TBD");
             expect(clinCells.length).toBeGreaterThan(0);
@@ -318,7 +318,7 @@ describe("BLIReviewRow", () => {
         });
 
         it("should not render CLIN column when showCLINColumn is false", () => {
-            renderComponent({ showCLINColumn: false });
+            renderComponent({ clin: { showColumn: false } });
 
             // CLIN column should not be present
             expect(screen.queryByText("TBD")).not.toBeInTheDocument();
@@ -333,7 +333,7 @@ describe("BLIReviewRow", () => {
                     clin: null
                 };
                 renderComponent({
-                    showCLINColumn: true,
+                    clin: { showColumn: true },
                     budgetLine: draftBLI
                 });
 
@@ -349,7 +349,7 @@ describe("BLIReviewRow", () => {
                     selected: true // Error classes only apply when selected
                 };
                 renderComponent({
-                    showCLINColumn: true,
+                    clin: { showColumn: true },
                     isReviewMode: true,
                     budgetLine: plannedBLI
                 });
@@ -366,9 +366,8 @@ describe("BLIReviewRow", () => {
                     status: "DRAFT"
                 };
                 renderComponent({
-                    showCLINColumn: true,
-                    budgetLine: draftBLI,
-                    onAddCLINClick: vi.fn()
+                    clin: { showColumn: true, onAddClick: vi.fn() },
+                    budgetLine: draftBLI
                 });
 
                 // Hover is tricky to test in unit tests - E2E will cover this
@@ -385,10 +384,10 @@ describe("BLIReviewRow", () => {
                     status: "PLANNED"
                 };
                 renderComponent({
-                    showCLINColumn: true,
+                    clin: { showColumn: true },
                     isReviewMode: true,
                     budgetLine: plannedBLI
-                    // onAddCLINClick intentionally omitted — mirrors the review page
+                    // onAddClick intentionally omitted — mirrors the review page
                 });
 
                 expect(screen.queryByTestId("add-clin-hover-button")).not.toBeInTheDocument();
@@ -405,8 +404,7 @@ describe("BLIReviewRow", () => {
                     selected: true
                 };
                 renderComponent({
-                    showCLINColumn: true,
-                    clinReadOnly: true,
+                    clin: { showColumn: true, readOnly: true },
                     isReviewMode: true,
                     budgetLine: plannedBLI
                 });
@@ -425,8 +423,7 @@ describe("BLIReviewRow", () => {
                     clin: { id: 9, number: 0 }
                 };
                 renderComponent({
-                    showCLINColumn: true,
-                    clinReadOnly: true,
+                    clin: { showColumn: true, readOnly: true },
                     isReviewMode: true,
                     budgetLine: plannedBLI
                 });
@@ -443,8 +440,7 @@ describe("BLIReviewRow", () => {
                     clin: null
                 };
                 renderComponent({
-                    showCLINColumn: true,
-                    clinReadOnly: true,
+                    clin: { showColumn: true, readOnly: true },
                     budgetLine: draftBLI
                 });
 

--- a/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.test.jsx
+++ b/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewRow.test.jsx
@@ -394,5 +394,62 @@ describe("BLIReviewRow", () => {
                 expect(screen.queryByTestId("add-clin-hover-button")).not.toBeInTheDocument();
             });
         });
+
+        describe("clinReadOnly (Change BL Status page)", () => {
+            it("renders an em-dash (not 'TBD') with no error styling for a non-Draft BLI without CLIN", () => {
+                const plannedBLI = {
+                    ...defaultBudgetLine,
+                    status: "PLANNED",
+                    clin_id: null,
+                    clin: null,
+                    selected: true
+                };
+                renderComponent({
+                    showCLINColumn: true,
+                    clinReadOnly: true,
+                    isReviewMode: true,
+                    budgetLine: plannedBLI
+                });
+
+                expect(screen.queryByText("TBD")).not.toBeInTheDocument();
+                const emDash = screen.getByText("—");
+                expect(emDash).toBeInTheDocument();
+                expect(emDash).not.toHaveClass("table-item-error");
+            });
+
+            it("renders CLIN 0 (not em-dash) for a non-Draft BLI assigned CLIN number 0", () => {
+                const plannedBLI = {
+                    ...defaultBudgetLine,
+                    status: "PLANNED",
+                    clin_id: 9,
+                    clin: { id: 9, number: 0 }
+                };
+                renderComponent({
+                    showCLINColumn: true,
+                    clinReadOnly: true,
+                    isReviewMode: true,
+                    budgetLine: plannedBLI
+                });
+
+                expect(screen.getByText("0")).toBeInTheDocument();
+                expect(screen.queryByText("—")).not.toBeInTheDocument();
+            });
+
+            it("still shows 'N/A' for a Draft BLI", () => {
+                const draftBLI = {
+                    ...defaultBudgetLine,
+                    status: "DRAFT",
+                    clin_id: null,
+                    clin: null
+                };
+                renderComponent({
+                    showCLINColumn: true,
+                    clinReadOnly: true,
+                    budgetLine: draftBLI
+                });
+
+                expect(screen.getByText("N/A")).toBeInTheDocument();
+            });
+        });
     });
 });

--- a/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewTable.jsx
+++ b/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewTable.jsx
@@ -21,11 +21,8 @@ import { BUDGET_LINE_TABLE_HEADERS_LIST } from "./BLIReviewTable.constants";
  * @param {Function} [props.setMainToggleSelected] - A function to set the main toggle selected.
  * @param {Number} props.servicesComponentNumber - The Number of the services component.
  * @param {string} props.action - The action of the review
- * @param {Function} [props.onAddCLINClick] - Callback when "+ CLIN" is clicked with budgetLine.id
- * @param {Boolean} [props.showCLINColumn] - Whether to show the CLIN column (Award page only)
- * @param {Object} [props.clinAssignments] - Map of budgetLineId to CLIN number assignments
  * @param {string[]} [props.errorStatuses] - When provided, inline error styling applies to rows whose status is in this list (regardless of row selection). When omitted, the original selection-gated behavior is preserved: errors only show when the row is selected (Review Agreement page behavior).
- * @param {Boolean} [props.clinReadOnly] - Read-only CLIN display: missing non-draft CLIN renders "—" with no error styling. Default false keeps the Award Approval behavior ("TBD" + error styling).
+ * @param {import('./BLIReviewRow').BLIReviewClinConfig} [props.clin] - CLIN column display configuration. Omit to hide the column.
  * @returns {React.ReactElement} - The rendered table component.
  */
 const AgreementBLIReviewTable = ({
@@ -38,12 +35,26 @@ const AgreementBLIReviewTable = ({
     servicesComponentNumber,
     action,
     readOnly = false,
-    onAddCLINClick,
-    showCLINColumn = false,
-    clinAssignments = {},
     errorStatuses,
-    clinReadOnly = false
+    clin = {}
 }) => {
+    const {
+        showColumn: showCLINColumn = false,
+        assignments: clinAssignments,
+        onAddClick: onAddCLINClick,
+        readOnly: clinReadOnly = false
+    } = clin;
+    // Stabilize the config object identity so the memoized BLIReviewRow can bail out of
+    // re-renders (callers pass an inline `clin={{...}}` literal on every parent render).
+    const rowClin = useMemo(
+        () => ({
+            showColumn: showCLINColumn,
+            assignments: clinAssignments,
+            onAddClick: onAddCLINClick,
+            readOnly: clinReadOnly
+        }),
+        [showCLINColumn, clinAssignments, onAddCLINClick, clinReadOnly]
+    );
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions();
 
     // Memoize initial sorting by creation date to avoid re-sorting on every render
@@ -119,11 +130,8 @@ const AgreementBLIReviewTable = ({
                         action={action}
                         showCheckbox={showCheckboxes}
                         readOnly={readOnly}
-                        onAddCLINClick={onAddCLINClick}
-                        showCLINColumn={showCLINColumn}
-                        clinAssignments={clinAssignments}
                         errorStatuses={errorStatuses}
-                        clinReadOnly={clinReadOnly}
+                        clin={rowClin}
                     />
                 ))}
             </Table>

--- a/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewTable.jsx
+++ b/frontend/src/components/BudgetLineItems/BLIReviewTable/BLIReviewTable.jsx
@@ -25,6 +25,7 @@ import { BUDGET_LINE_TABLE_HEADERS_LIST } from "./BLIReviewTable.constants";
  * @param {Boolean} [props.showCLINColumn] - Whether to show the CLIN column (Award page only)
  * @param {Object} [props.clinAssignments] - Map of budgetLineId to CLIN number assignments
  * @param {string[]} [props.errorStatuses] - When provided, inline error styling applies to rows whose status is in this list (regardless of row selection). When omitted, the original selection-gated behavior is preserved: errors only show when the row is selected (Review Agreement page behavior).
+ * @param {Boolean} [props.clinReadOnly] - Read-only CLIN display: missing non-draft CLIN renders "—" with no error styling. Default false keeps the Award Approval behavior ("TBD" + error styling).
  * @returns {React.ReactElement} - The rendered table component.
  */
 const AgreementBLIReviewTable = ({
@@ -40,7 +41,8 @@ const AgreementBLIReviewTable = ({
     onAddCLINClick,
     showCLINColumn = false,
     clinAssignments = {},
-    errorStatuses
+    errorStatuses,
+    clinReadOnly = false
 }) => {
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions();
 
@@ -121,6 +123,7 @@ const AgreementBLIReviewTable = ({
                         showCLINColumn={showCLINColumn}
                         clinAssignments={clinAssignments}
                         errorStatuses={errorStatuses}
+                        clinReadOnly={clinReadOnly}
                     />
                 ))}
             </Table>

--- a/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.jsx
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.jsx
@@ -5,6 +5,7 @@ import {
     BLILabel,
     canLabel,
     getBudgetLineCreatedDate,
+    getClinDisplayValue,
     getProcurementShopFeeTooltip,
     getProcurementShopLabel
 } from "../../../helpers/budgetLines.helpers";
@@ -96,15 +97,7 @@ const BLIRow = ({
                     BLILabel(budgetLine)
                 )}
             </td>
-            {showClinColumn && (
-                <td>
-                    {budgetLine?.status === "DRAFT"
-                        ? "N/A"
-                        : budgetLine?.clin?.number != null
-                          ? budgetLine.clin.number
-                          : "—"}
-                </td>
-            )}
+            {showClinColumn && <td>{getClinDisplayValue(budgetLine)}</td>}
             <td
                 className={`${futureDateErrorClass(
                     formatDateNeeded(budgetLine?.date_needed),

--- a/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.jsx
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.jsx
@@ -33,6 +33,7 @@ import { addErrorClassIfNotFound, futureDateErrorClass, isDateOutsidePopRange } 
  * @property {boolean} [isBLIInCurrentWorkflow] - Whether the budget line item is in the current workflow.
  * @property {boolean} [isAgreementAwarded] - Whether the agreement is awarded.
  * @property {boolean} [isGrant] - Whether this is a grant budget line (omits Fee/Total cells).
+ * @property {boolean} [showClinColumn] - Whether to show the CLIN cell (awarded contract agreements only).
  */
 
 /**
@@ -48,7 +49,8 @@ const BLIRow = ({
     handleDuplicateBudgetLine = () => {},
     readOnly = false,
     isBLIInCurrentWorkflow = false,
-    isGrant = false
+    isGrant = false,
+    showClinColumn = false
 }) => {
     const { isExpanded, isRowActive, setIsExpanded, setIsRowActive } = useTableRow();
     const budgetLineCreatorName = useGetUserFullNameFromId(budgetLine?.created_by);
@@ -94,6 +96,15 @@ const BLIRow = ({
                     BLILabel(budgetLine)
                 )}
             </td>
+            {showClinColumn && (
+                <td>
+                    {budgetLine?.status === "DRAFT"
+                        ? "N/A"
+                        : budgetLine?.clin?.number != null
+                          ? budgetLine.clin.number
+                          : "—"}
+                </td>
+            )}
             <td
                 className={`${futureDateErrorClass(
                     formatDateNeeded(budgetLine?.date_needed),
@@ -151,7 +162,7 @@ const BLIRow = ({
 
     const ExpandedData = (
         <td
-            colSpan={isGrant ? 7 : 9}
+            colSpan={isGrant ? 7 : showClinColumn ? 10 : 9}
             className="border-top-none"
             style={expandedRowBGColor}
         >

--- a/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.jsx
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.jsx
@@ -97,7 +97,7 @@ const BLIRow = ({
                     BLILabel(budgetLine)
                 )}
             </td>
-            {showClinColumn && <td>{getClinDisplayValue(budgetLine)}</td>}
+            {showClinColumn && !isGrant && <td>{getClinDisplayValue(budgetLine)}</td>}
             <td
                 className={`${futureDateErrorClass(
                     formatDateNeeded(budgetLine?.date_needed),

--- a/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.test.jsx
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesTable/BLIRow.test.jsx
@@ -35,7 +35,12 @@ const createMockStore = (userRoles = []) => {
     });
 };
 
-const renderComponent = (userRoles = [], canUserEditBudgetLines = true, budgetLineOverrides = {}) => {
+const renderComponent = (
+    userRoles = [],
+    canUserEditBudgetLines = true,
+    budgetLineOverrides = {},
+    showClinColumn = false
+) => {
     useGetUserByIdQuery.mockReturnValue({ data: { full_name: "John Doe" } });
     useGetAgreementByIdQuery.mockReturnValue({ data: agreement });
     useGetCansQuery.mockReturnValue({
@@ -71,6 +76,7 @@ const renderComponent = (userRoles = [], canUserEditBudgetLines = true, budgetLi
                     isReviewMode={false}
                     readOnly={false}
                     duplicateIcon={true}
+                    showClinColumn={showClinColumn}
                 />
             </Provider>
         </Router>
@@ -432,5 +438,61 @@ describe("BLIRow", () => {
         expect(amountCell).toHaveTextContent(/\$1,000,000\.00/);
         expect(feeCell).toHaveTextContent(/\$1\.23/);
         expect(totalCell).toHaveTextContent(/\$1,000,001\.23/);
+    });
+
+    describe("CLIN column", () => {
+        it("does not render a CLIN cell by default (showClinColumn omitted)", () => {
+            renderComponent();
+
+            const bliRow = screen.getByTestId("budget-line-row-1");
+            const cells = within(bliRow).getAllByRole("cell");
+            // Without the CLIN column: BL ID # | Obligate By | FY | CAN | Amount | Fee | Total | Status | (expand)
+            expect(cells[0]).toHaveTextContent("1");
+            expect(cells[1]).toHaveTextContent("6/13/2043");
+        });
+
+        it("renders 'N/A' for a DRAFT budget line when showClinColumn is true", () => {
+            renderComponent([], true, {}, true);
+
+            const bliRow = screen.getByTestId("budget-line-row-1");
+            const cells = within(bliRow).getAllByRole("cell");
+            // With the CLIN column, it is the second cell (after BL ID #).
+            expect(cells[1]).toHaveTextContent("N/A");
+        });
+
+        it("renders the CLIN number for a non-DRAFT budget line with an assigned CLIN", () => {
+            renderComponent([], true, { status: "PLANNED", clin: { id: 9, number: 42 } }, true);
+
+            const bliRow = screen.getByTestId("budget-line-row-1");
+            const cells = within(bliRow).getAllByRole("cell");
+            expect(cells[1]).toHaveTextContent("42");
+        });
+
+        it("renders an em-dash for a non-DRAFT budget line with no CLIN", () => {
+            renderComponent([], true, { status: "PLANNED", clin_id: null, clin: null }, true);
+
+            const bliRow = screen.getByTestId("budget-line-row-1");
+            const cells = within(bliRow).getAllByRole("cell");
+            expect(cells[1]).toHaveTextContent("—");
+        });
+
+        it("renders CLIN 0 (not em-dash) for a non-DRAFT budget line assigned CLIN number 0", () => {
+            renderComponent([], true, { status: "PLANNED", clin: { id: 9, number: 0 } }, true);
+
+            const bliRow = screen.getByTestId("budget-line-row-1");
+            const cells = within(bliRow).getAllByRole("cell");
+            expect(cells[1]).toHaveTextContent("0");
+            expect(cells[1]).not.toHaveTextContent("—");
+        });
+
+        it("shifts the Amount/Fee/Total cells right by one when the CLIN column is shown", () => {
+            renderComponent([], true, { status: "PLANNED", clin: { id: 9, number: 42 } }, true);
+
+            const bliRow = screen.getByTestId("budget-line-row-1");
+            const cells = within(bliRow).getAllByRole("cell");
+            // BL ID # | CLIN | Obligate By | FY | CAN | Amount | Fee | Total | Status
+            const amountCell = cells[5];
+            expect(amountCell).toHaveTextContent(/\$1,000,000\.00/);
+        });
     });
 });

--- a/frontend/src/components/BudgetLineItems/BudgetLinesTable/BudgetLinesTable.constants.js
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesTable/BudgetLinesTable.constants.js
@@ -19,3 +19,16 @@ export const GRANT_BUDGET_LINE_TABLE_HEADERS = [
     { heading: "Amount", value: tableSortCodes.budgetLineCodes.AMOUNT },
     { heading: "Status", value: tableSortCodes.budgetLineCodes.STATUS }
 ];
+
+// Awarded contract budget lines add a CLIN column (no sort) after BL ID #.
+export const AWARDED_CONTRACT_BUDGET_LINE_TABLE_HEADERS = [
+    { heading: "BL ID #", value: tableSortCodes.budgetLineCodes.BL_ID_NUMBER },
+    { heading: "CLIN", value: "" },
+    { heading: "Obligate By", value: tableSortCodes.budgetLineCodes.OBLIGATE_BY },
+    { heading: "FY", value: tableSortCodes.budgetLineCodes.FISCAL_YEAR },
+    { heading: "CAN", value: tableSortCodes.budgetLineCodes.CAN_NUMBER },
+    { heading: "Amount", value: tableSortCodes.budgetLineCodes.AMOUNT },
+    { heading: "Fee", value: tableSortCodes.budgetLineCodes.FEES },
+    { heading: "Total", value: tableSortCodes.budgetLineCodes.TOTAL },
+    { heading: "Status", value: tableSortCodes.budgetLineCodes.STATUS }
+];

--- a/frontend/src/components/BudgetLineItems/BudgetLinesTable/BudgetLinesTable.jsx
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesTable/BudgetLinesTable.jsx
@@ -3,7 +3,11 @@ import Table from "../../UI/Table";
 import BLIRow from "./BLIRow";
 import { useSetSortConditions } from "../../UI/Table/Table.hooks";
 import { SORT_TYPES, useSortData } from "../../../hooks/use-sortable-data.hooks";
-import { BUDGET_LINE_TABLE_HEADERS, GRANT_BUDGET_LINE_TABLE_HEADERS } from "./BudgetLinesTable.constants";
+import {
+    AWARDED_CONTRACT_BUDGET_LINE_TABLE_HEADERS,
+    BUDGET_LINE_TABLE_HEADERS,
+    GRANT_BUDGET_LINE_TABLE_HEADERS
+} from "./BudgetLinesTable.constants";
 import "./BudgetLinesTable.scss";
 
 /**
@@ -19,6 +23,7 @@ import "./BudgetLinesTable.scss";
  * @param {Boolean} [props.isEditable] - A flag to indicate that the user can edit the agreement.
  * @param {Array<number>} [props.budgetLineIdsInReview] - an array of budget line IDs that are in review.
  * @param {Boolean} [props.isGrant] - A flag to indicate grant budget lines, which omit the Fee and Total columns (grants have no procurement shop).
+ * @param {Boolean} [props.showClinColumn] - A flag to show the CLIN column (awarded contract agreements only).
  * @returns {React.ReactElement} - The rendered table component.
  */
 const BudgetLinesTable = ({
@@ -31,7 +36,8 @@ const BudgetLinesTable = ({
     isAgreementAwarded = false,
     budgetLineIdsInReview = [],
     isEditable = false,
-    isGrant = false
+    isGrant = false,
+    showClinColumn = false
 }) => {
     const { sortDescending, sortCondition, setSortConditions } = useSetSortConditions();
 
@@ -54,7 +60,13 @@ const BudgetLinesTable = ({
     );
     return (
         <Table
-            tableHeadings={isGrant ? GRANT_BUDGET_LINE_TABLE_HEADERS : BUDGET_LINE_TABLE_HEADERS}
+            tableHeadings={
+                isGrant
+                    ? GRANT_BUDGET_LINE_TABLE_HEADERS
+                    : showClinColumn
+                      ? AWARDED_CONTRACT_BUDGET_LINE_TABLE_HEADERS
+                      : BUDGET_LINE_TABLE_HEADERS
+            }
             selectedHeader={sortCondition}
             onClickHeader={setSortConditions}
             sortDescending={sortDescending}
@@ -72,6 +84,7 @@ const BudgetLinesTable = ({
                     isAgreementAwarded={isAgreementAwarded}
                     isEditable={isEditable}
                     isGrant={isGrant}
+                    showClinColumn={showClinColumn}
                 />
             ))}
         </Table>

--- a/frontend/src/components/BudgetLineItems/BudgetLinesTable/BudgetLinesTable.test.js
+++ b/frontend/src/components/BudgetLineItems/BudgetLinesTable/BudgetLinesTable.test.js
@@ -127,4 +127,30 @@ describe("PreviewTable", () => {
         expect(screen.getByText("Amount")).toBeInTheDocument();
         expect(screen.getByText("Status")).toBeInTheDocument();
     });
+
+    test("omits the CLIN column by default", () => {
+        customRender(
+            <BudgetLinesTable
+                budgetLines={mockBudgetLinesOne}
+                readOnly={true}
+            />,
+            store
+        );
+        expect(screen.queryByText("CLIN")).not.toBeInTheDocument();
+    });
+
+    test("renders the CLIN column when showClinColumn is true", () => {
+        customRender(
+            <BudgetLinesTable
+                budgetLines={mockBudgetLinesOne}
+                readOnly={true}
+                showClinColumn={true}
+            />,
+            store
+        );
+        expect(screen.getByText("CLIN")).toBeInTheDocument();
+        // Fee/Total are still present for non-grant awarded contracts
+        expect(screen.getByText("Fee")).toBeInTheDocument();
+        expect(screen.getByText("Total")).toBeInTheDocument();
+    });
 });

--- a/frontend/src/components/UI/Table/Table.jsx
+++ b/frontend/src/components/UI/Table/Table.jsx
@@ -64,44 +64,58 @@ const Table = ({
             <thead>
                 <tr>
                     {firstHeadingSlot && firstHeadingSlot}
-                    {tableHeadings.map((header, index) => (
-                        <th
-                            key={index}
-                            scope="col"
-                            style={setColumnWidth(header)}
-                            aria-sort={
-                                header.value === selectedHeader ? (sortDescending ? "descending" : "ascending") : "none"
-                            }
-                        >
-                            <button
-                                type="button"
-                                data-cy={header.value}
-                                className="usa-table__header__button cursor-pointer"
-                                title={`Click to sort by ${header.heading}`}
-                                onClick={() => {
-                                    onClickHeader?.(header.value, sortDescending == null ? true : !sortDescending);
-                                }}
+                    {tableHeadings.map((header, index) => {
+                        const isSortable = Boolean(header.value);
+                        return (
+                            <th
+                                key={index}
+                                scope="col"
+                                style={setColumnWidth(header)}
+                                aria-sort={
+                                    isSortable && header.value === selectedHeader
+                                        ? sortDescending
+                                            ? "descending"
+                                            : "ascending"
+                                        : "none"
+                                }
                             >
-                                {header.heading}
-                                {header.value === selectedHeader && (
-                                    <>
-                                        {!sortDescending && (
-                                            <FontAwesomeIcon
-                                                icon={faArrowUp}
-                                                className="margin-left-05 height-2 width-2 cursor-pointer"
-                                            />
+                                {isSortable ? (
+                                    <button
+                                        type="button"
+                                        data-cy={header.value}
+                                        className="usa-table__header__button cursor-pointer"
+                                        title={`Click to sort by ${header.heading}`}
+                                        onClick={() => {
+                                            onClickHeader?.(
+                                                header.value,
+                                                sortDescending == null ? true : !sortDescending
+                                            );
+                                        }}
+                                    >
+                                        {header.heading}
+                                        {header.value === selectedHeader && (
+                                            <>
+                                                {!sortDescending && (
+                                                    <FontAwesomeIcon
+                                                        icon={faArrowUp}
+                                                        className="margin-left-05 height-2 width-2 cursor-pointer"
+                                                    />
+                                                )}
+                                                {sortDescending && (
+                                                    <FontAwesomeIcon
+                                                        icon={faArrowDown}
+                                                        className="margin-left-05 height-2 width-2 cursor-pointer"
+                                                    />
+                                                )}
+                                            </>
                                         )}
-                                        {sortDescending && (
-                                            <FontAwesomeIcon
-                                                icon={faArrowDown}
-                                                className="margin-left-05 height-2 width-2 cursor-pointer"
-                                            />
-                                        )}
-                                    </>
+                                    </button>
+                                ) : (
+                                    header.heading
                                 )}
-                            </button>
-                        </th>
-                    ))}
+                            </th>
+                        );
+                    })}
                 </tr>
             </thead>
             <tbody>{children}</tbody>

--- a/frontend/src/components/UI/Table/Table.jsx
+++ b/frontend/src/components/UI/Table/Table.jsx
@@ -110,8 +110,10 @@ const Table = ({
                                             </>
                                         )}
                                     </button>
-                                ) : (
+                                ) : header.heading ? (
                                     header.heading
+                                ) : (
+                                    <span className="usa-sr-only">Expand row</span>
                                 )}
                             </th>
                         );

--- a/frontend/src/components/UI/Table/Table.test.jsx
+++ b/frontend/src/components/UI/Table/Table.test.jsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Table from "./Table";
+
+const headings = [
+    { heading: "BL ID #", value: "ID_NUMBER" },
+    { heading: "CLIN", value: "" }
+];
+
+describe("Table", () => {
+    it("does not render a sort button for a header with an empty value", () => {
+        render(<Table tableHeadings={headings} />);
+
+        expect(screen.getByRole("button", { name: /BL ID #/ })).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "CLIN" })).not.toBeInTheDocument();
+        expect(screen.getByText("CLIN")).toBeInTheDocument();
+    });
+
+    it("keeps aria-sort none on a non-sortable header even when selectedHeader matches its empty value", () => {
+        render(
+            <Table
+                tableHeadings={headings}
+                selectedHeader=""
+                sortDescending={false}
+            />
+        );
+
+        expect(screen.getByRole("columnheader", { name: "CLIN" })).toHaveAttribute("aria-sort", "none");
+    });
+
+    it("does not call onClickHeader when a non-sortable header is clicked", () => {
+        const onClickHeader = vi.fn();
+        render(
+            <Table
+                tableHeadings={headings}
+                onClickHeader={onClickHeader}
+            />
+        );
+
+        fireEvent.click(screen.getByText("CLIN"));
+
+        expect(onClickHeader).not.toHaveBeenCalled();
+    });
+
+    it("still supports sorting and shows the arrow on a sortable selected header", () => {
+        render(
+            <Table
+                tableHeadings={headings}
+                selectedHeader="ID_NUMBER"
+                sortDescending={false}
+                onClickHeader={vi.fn()}
+            />
+        );
+
+        expect(screen.getByRole("columnheader", { name: "BL ID #" })).toHaveAttribute("aria-sort", "ascending");
+    });
+});

--- a/frontend/src/components/UI/Table/Table.test.jsx
+++ b/frontend/src/components/UI/Table/Table.test.jsx
@@ -42,6 +42,14 @@ describe("Table", () => {
         expect(onClickHeader).not.toHaveBeenCalled();
     });
 
+    it("renders a screen-reader label for a non-sortable header with an empty heading", () => {
+        render(<Table tableHeadings={[...headings, { heading: "", value: "" }]} />);
+
+        // Guards the empty-table-header a11y violation: an empty <th> must still
+        // expose discernible text (the expand column) for screen readers.
+        expect(screen.getByRole("columnheader", { name: "Expand row" })).toBeInTheDocument();
+    });
+
     it("still supports sorting and shows the arrow on a sortable selected header", () => {
         render(
             <Table

--- a/frontend/src/helpers/budgetLines.helpers.js
+++ b/frontend/src/helpers/budgetLines.helpers.js
@@ -428,6 +428,8 @@ export const getProcurementShopLabel = (budgetLine) => {
  * @param {function} budgetLineTrigger - Function to fetch budget lines with pagination.
  * @param {function} serviceComponentTrigger - Function to fetch service component details by ID.
  * @param {function} portfolioTrigger - Function to fetch portfolio details by ID.
+ * @param {number} [bliCount] - Total budget line count (fallback when _meta is absent).
+ * @param {boolean} [includeClin] - Whether to include a CLIN column (awarded contract agreements only).
  */
 export const handleExport = async (
     exportTableToXlsx,
@@ -437,7 +439,8 @@ export const handleExport = async (
     budgetLineTrigger,
     serviceComponentTrigger,
     portfolioTrigger,
-    bliCount = 0
+    bliCount = 0,
+    includeClin = false
 ) => {
     try {
         if (!budgetLineItems || budgetLineItems.length === 0) {
@@ -494,6 +497,8 @@ export const handleExport = async (
             "Project Type",
             "Agreement",
             "SC",
+            // CLIN column (awarded contract agreements only) is inserted right after SC.
+            ...(includeClin ? ["CLIN"] : []),
             "Agreement Type",
             "Description",
             "Obligate By",
@@ -533,6 +538,16 @@ export const handleExport = async (
                             ? (budgetLine.grant_number?.display_title ??
                               (budgetLine.grant_number?.number ? `Grant ${budgetLine.grant_number.number}` : NO_DATA))
                             : budgetLinesDataMap[budgetLine.id]?.service_component_name,
+                        // CLIN column (awarded contract agreements only), inserted right after SC.
+                        ...(includeClin
+                            ? [
+                                  budgetLine.status === "DRAFT"
+                                      ? "N/A"
+                                      : budgetLine.clin?.number != null
+                                        ? budgetLine.clin.number
+                                        : "—"
+                              ]
+                            : []),
                         budgetLine.agreement?.agreement_type ?? NO_DATA,
                         budgetLine.line_description,
                         formatDateNeeded(budgetLine?.date_needed ?? ""),
@@ -547,7 +562,8 @@ export const handleExport = async (
                     ];
                 },
             filename: "budget_lines",
-            currencyColumns: [11, 13]
+            // A leading CLIN column shifts SubTotal and Procurement shop fee one column to the right.
+            currencyColumns: includeClin ? [12, 14] : [11, 13]
         });
     } catch (error) {
         console.error("Failed to export data:", error);

--- a/frontend/src/helpers/budgetLines.helpers.js
+++ b/frontend/src/helpers/budgetLines.helpers.js
@@ -305,6 +305,18 @@ export const canLabel = (budgetLine) =>
 export const BLILabel = (budgetLine) => (isBLIPermanent(budgetLine) ? budgetLine?.id : NO_DATA);
 
 /**
+ * Returns the display value for a budget line's CLIN column (awarded contract agreements only).
+ * @param {BudgetLine} budgetLine - The budget line to get the CLIN display value from.
+ * @returns {string|number} "N/A" for draft budget lines, the CLIN number if assigned, or an em dash.
+ */
+export const getClinDisplayValue = (budgetLine) => {
+    if (budgetLine?.status === "DRAFT") {
+        return "N/A";
+    }
+    return budgetLine?.clin?.number != null ? budgetLine.clin.number : "—";
+};
+
+/**
  * @typedef ItemCount
  * @property {string} type
  * @property {number} count
@@ -539,15 +551,7 @@ export const handleExport = async (
                               (budgetLine.grant_number?.number ? `Grant ${budgetLine.grant_number.number}` : NO_DATA))
                             : budgetLinesDataMap[budgetLine.id]?.service_component_name,
                         // CLIN column (awarded contract agreements only), inserted right after SC.
-                        ...(includeClin
-                            ? [
-                                  budgetLine.status === "DRAFT"
-                                      ? "N/A"
-                                      : budgetLine.clin?.number != null
-                                        ? budgetLine.clin.number
-                                        : "—"
-                              ]
-                            : []),
+                        ...(includeClin ? [getClinDisplayValue(budgetLine)] : []),
                         budgetLine.agreement?.agreement_type ?? NO_DATA,
                         budgetLine.line_description,
                         formatDateNeeded(budgetLine?.date_needed ?? ""),

--- a/frontend/src/helpers/budgetLines.helpers.test.js
+++ b/frontend/src/helpers/budgetLines.helpers.test.js
@@ -1,3 +1,4 @@
+import { vi } from "vitest";
 import {
     BLI_STATUS,
     getBudgetLineCreatedDate,
@@ -18,7 +19,8 @@ import {
     getTooltipLabel,
     getProcurementShopFeeTooltip,
     getProcurementShopLabel,
-    calculateProcShopFeePercentage
+    calculateProcShopFeePercentage,
+    handleExport
 } from "./budgetLines.helpers";
 import { budgetLine, agreement } from "../tests/data";
 
@@ -798,5 +800,98 @@ describe("findGrantPeriodStart / findGrantPeriodEnd / findGrantDescription", () 
         it("returns null (not undefined) when description is null on the matched grant", () => {
             expect(findGrantDescription(grantNumbers, 3)).toBeNull();
         });
+    });
+});
+
+describe("handleExport", () => {
+    /** Build a minimal fetched BLI shaped like the export's paginated response. */
+    const makeBli = (overrides = {}) => ({
+        id: 100,
+        status: "PLANNED",
+        services_component_id: 1,
+        portfolio_id: 1,
+        fiscal_year: 2044,
+        amount: 1000,
+        fees: 50,
+        proc_shop_fee_percentage: 5,
+        line_description: "desc",
+        comments: "note",
+        in_review: false,
+        date_needed: "2044-06-01",
+        can: { display_name: "CAN-1" },
+        clin: { id: 9, number: 42 },
+        agreement: {
+            name: "Agreement 1",
+            agreement_type: "CONTRACT",
+            project: { title: "Project 1", project_type: "RESEARCH" },
+            procurement_shop: { abbr: "GCS" }
+        },
+        ...overrides
+    });
+
+    /** Run handleExport with mocked triggers and return the object passed to exportTableToXlsx. */
+    const runExport = async (fetchedBlis, includeClin) => {
+        const exportTableToXlsx = vi.fn().mockResolvedValue(undefined);
+        const setIsExporting = vi.fn();
+        const budgetLineTrigger = vi.fn(() => Promise.resolve({ data: fetchedBlis }));
+        const serviceComponentTrigger = vi.fn((id) => ({
+            unwrap: () => Promise.resolve({ id, display_name: `SC ${id}` })
+        }));
+        const portfolioTrigger = vi.fn((id) => ({
+            unwrap: () => Promise.resolve({ id, name: `Portfolio ${id}` })
+        }));
+
+        await handleExport(
+            exportTableToXlsx,
+            setIsExporting,
+            { agreementIds: [1] },
+            fetchedBlis,
+            budgetLineTrigger,
+            serviceComponentTrigger,
+            portfolioTrigger,
+            fetchedBlis.length,
+            includeClin
+        );
+
+        expect(exportTableToXlsx).toHaveBeenCalledTimes(1);
+        return exportTableToXlsx.mock.calls[0][0];
+    };
+
+    it("omits the CLIN column and uses currencyColumns [11, 13] by default", async () => {
+        const args = await runExport([makeBli()], false);
+
+        expect(args.headers).not.toContain("CLIN");
+        expect(args.currencyColumns).toEqual([11, 13]);
+        // SubTotal / Procurement shop fee sit at the unshifted indices.
+        expect(args.headers[11]).toBe("SubTotal");
+        expect(args.headers[13]).toBe("Procurement shop fee");
+    });
+
+    it("inserts the CLIN column after SC and shifts currencyColumns to [12, 14] when includeClin is true", async () => {
+        const args = await runExport([makeBli()], true);
+
+        expect(args.headers[5]).toBe("SC");
+        expect(args.headers[6]).toBe("CLIN");
+        expect(args.currencyColumns).toEqual([12, 14]);
+        expect(args.headers[12]).toBe("SubTotal");
+        expect(args.headers[14]).toBe("Procurement shop fee");
+    });
+
+    it("exports 'N/A' in the CLIN column for a DRAFT budget line", async () => {
+        const args = await runExport([makeBli({ status: "DRAFT" })], true);
+        const row = args.rowMapper(makeBli({ status: "DRAFT" }));
+        expect(row[6]).toBe("N/A");
+    });
+
+    it("exports the CLIN number for a non-DRAFT budget line with an assigned CLIN", async () => {
+        const args = await runExport([makeBli()], true);
+        const row = args.rowMapper(makeBli({ clin: { id: 9, number: 42 } }));
+        expect(row[6]).toBe(42);
+    });
+
+    it("exports an em-dash for a non-DRAFT budget line with no CLIN", async () => {
+        const args = await runExport([makeBli()], true);
+        const row = args.rowMapper(makeBli({ clin: null }));
+        expect(row[6]).toBe("—");
     });
 });

--- a/frontend/src/pages/agreements/award-approval/RequestAwardApproval.jsx
+++ b/frontend/src/pages/agreements/award-approval/RequestAwardApproval.jsx
@@ -263,9 +263,11 @@ export const RequestAwardApproval = () => {
                                             isReviewMode={true}
                                             servicesComponentNumber={group.servicesComponentNumber}
                                             action=""
-                                            onAddCLINClick={setSelectedBudgetLineId}
-                                            showCLINColumn={true}
-                                            clinAssignments={clinAssignments}
+                                            clin={{
+                                                showColumn: true,
+                                                onAddClick: setSelectedBudgetLineId,
+                                                assignments: clinAssignments
+                                            }}
                                         />
                                     ) : (
                                         <p className="text-center margin-y-7">

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
@@ -338,7 +338,6 @@ const AgreementBudgetLines = ({
                                 readOnly={true}
                                 isEditable={agreement?._meta.isEditable}
                                 isGrant={true}
-                                showClinColumn={showClinColumn}
                             />
                         ) : (
                             <p className="text-center margin-y-7">

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
@@ -82,6 +82,9 @@ const AgreementBudgetLines = ({
     const { data: grantNumbers } = useGetGrantNumbersListQuery(agreement?.id, { skip: !agreement?.id });
     const allBudgetLinesInReview = areAllBudgetLinesInReview(agreement?.budget_line_items ?? []);
     const isGrant = agreement?.agreement_type === AgreementType.GRANT;
+    const isContract = agreement?.agreement_type === AgreementType.CONTRACT;
+    // CLIN column is contract-only and only meaningful once the agreement is awarded.
+    const showClinColumn = isContract && isAgreementAwarded;
 
     // Regular users must have permission and agreement must be in editable state
     const canRegularUserEdit = agreement?._meta.isEditable && !isAgreementNotDeveloped && !allBudgetLinesInReview;
@@ -259,7 +262,8 @@ const AgreementBudgetLines = ({
                                                 budgetLineTrigger,
                                                 serviceComponentTrigger,
                                                 portfolioTrigger,
-                                                blis.length
+                                                blis.length,
+                                                showClinColumn
                                             )
                                         }
                                     >
@@ -334,6 +338,7 @@ const AgreementBudgetLines = ({
                                 readOnly={true}
                                 isEditable={agreement?._meta.isEditable}
                                 isGrant={true}
+                                showClinColumn={showClinColumn}
                             />
                         ) : (
                             <p className="text-center margin-y-7">
@@ -370,6 +375,7 @@ const AgreementBudgetLines = ({
                                     isAgreementAwarded={isAgreementAwarded}
                                     readOnly={true}
                                     isEditable={agreement?._meta.isEditable}
+                                    showClinColumn={showClinColumn}
                                 />
                             ) : (
                                 <p className="text-center margin-y-7">

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.test.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.test.jsx
@@ -26,6 +26,12 @@ vi.mock("../../../api/opsAPI", () => ({
     ]
 }));
 
+// Mock BudgetLinesTable so column-gating tests assert the showClinColumn prop AgreementBudgetLines
+// passes, without pulling in the real table's hook chain (useGetAllCans, procurement shops, users).
+vi.mock("../../../components/BudgetLineItems/BudgetLinesTable", () => ({
+    default: (props) => <div data-testid="budget-lines-table">show-clin:{String(!!props.showClinColumn)}</div>
+}));
+
 vi.mock("react-router-dom", async () => {
     const actual = await vi.importActual("react-router-dom");
     return {
@@ -578,6 +584,81 @@ describe("AgreementBudgetLines", () => {
             renderWith(superUserStore);
             expect(screen.queryByRole("button", { name: /edit/i })).not.toBeInTheDocument();
             expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+        });
+    });
+
+    describe("CLIN column", () => {
+        const editorStore = configureStore({
+            reducer: {
+                auth: () => ({
+                    activeUser: {
+                        id: 1,
+                        full_name: "Regular User",
+                        email: "user@example.com",
+                        roles: [{ name: USER_ROLES.VIEWER_EDITOR }]
+                    }
+                })
+            }
+        });
+
+        const budgetLineWithClin = {
+            id: 5,
+            amount: 1000,
+            fees: 0,
+            date_needed: "2044-02-01",
+            status: "PLANNED",
+            services_component_id: 101,
+            line_description: "Test budget line",
+            can: { number: "CAN-001" },
+            clin: { id: 9, number: 42 },
+            _meta: { isEditable: true }
+        };
+
+        const renderContract = ({ agreementType = "CONTRACT", isAgreementAwarded = true } = {}) => {
+            useGetServicesComponentsListQueryMock.mockReturnValue({
+                data: [{ id: 101, number: 1, sub_component: null }],
+                isLoading: false
+            });
+
+            return render(
+                <Provider store={editorStore}>
+                    <Router
+                        location={history.location}
+                        navigator={history}
+                    >
+                        <AgreementBudgetLines
+                            {...defaultProps}
+                            agreement={{
+                                ...mockAgreement,
+                                agreement_type: agreementType,
+                                budget_line_items: [budgetLineWithClin]
+                            }}
+                            isAgreementNotDeveloped={false}
+                            isAgreementAwarded={isAgreementAwarded}
+                            isEditMode={false}
+                            setIsEditMode={vi.fn()}
+                        />
+                    </Router>
+                </Provider>
+            );
+        };
+
+        test("passes showClinColumn=true to the table for an awarded contract agreement", () => {
+            renderContract({ agreementType: "CONTRACT", isAgreementAwarded: true });
+
+            expect(screen.getByText("show-clin:true")).toBeInTheDocument();
+        });
+
+        test("passes showClinColumn=false for a contract agreement that is not awarded", () => {
+            renderContract({ agreementType: "CONTRACT", isAgreementAwarded: false });
+
+            expect(screen.getByText("show-clin:false")).toBeInTheDocument();
+        });
+
+        test("passes showClinColumn=false for an awarded grant agreement", () => {
+            renderContract({ agreementType: "GRANT", isAgreementAwarded: true });
+
+            expect(screen.getByText("show-clin:false")).toBeInTheDocument();
         });
     });
 });

--- a/frontend/src/pages/agreements/pre-award-approval/BudgetLinesReviewAccordion/BudgetLinesReviewAccordion.jsx
+++ b/frontend/src/pages/agreements/pre-award-approval/BudgetLinesReviewAccordion/BudgetLinesReviewAccordion.jsx
@@ -102,7 +102,7 @@ export const BudgetLinesReviewAccordion = ({
                                                 isReviewMode={true}
                                                 servicesComponentNumber={group.grantNumberNumber}
                                                 action=""
-                                                showCLINColumn={showCLINColumn}
+                                                clin={{ showColumn: showCLINColumn }}
                                                 errorStatuses={
                                                     showBudgetLineErrors ? VALIDATABLE_BLI_STATUSES : undefined
                                                 }
@@ -137,7 +137,7 @@ export const BudgetLinesReviewAccordion = ({
                                             isReviewMode={true}
                                             servicesComponentNumber={group.servicesComponentNumber}
                                             action=""
-                                            showCLINColumn={showCLINColumn}
+                                            clin={{ showColumn: showCLINColumn }}
                                             errorStatuses={showBudgetLineErrors ? VALIDATABLE_BLI_STATUSES : undefined}
                                         />
                                     ) : (

--- a/frontend/src/pages/agreements/review/ReviewAgreement.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.jsx
@@ -25,6 +25,7 @@ import {
 import { findGrantDescription, findGrantPeriodEnd, findGrantPeriodStart } from "../../../helpers/budgetLines.helpers";
 import { scrollToTop } from "../../../helpers/scrollToTop.helper";
 import { convertCodeForDisplay } from "../../../helpers/utils";
+import { AgreementType } from "../agreements.constants";
 import { actionOptions } from "./ReviewAgreement.constants";
 import useReviewAgreement from "./ReviewAgreement.hooks";
 
@@ -89,6 +90,9 @@ export const ReviewAgreement = () => {
         : undefined;
     // Add this useEffect to handle navigation after render
     const canUserEditAgreement = agreement?._meta.isEditable;
+    // CLIN column is contract-only and only meaningful once the agreement is awarded.
+    const isContract = agreement?.agreement_type === AgreementType.CONTRACT;
+    const showCLINColumn = isAgreementAwarded && isContract;
 
     React.useEffect(() => {
         if (!isLoadingAgreement) {
@@ -236,6 +240,8 @@ export const ReviewAgreement = () => {
                                             }
                                             servicesComponentNumber={groupKey}
                                             action={action}
+                                            showCLINColumn={showCLINColumn}
+                                            clinReadOnly={true}
                                         />
                                     ) : (
                                         <p className="text-center margin-y-7">
@@ -284,6 +290,8 @@ export const ReviewAgreement = () => {
                                         }
                                         servicesComponentNumber={group.servicesComponentNumber}
                                         action={action}
+                                        showCLINColumn={showCLINColumn}
+                                        clinReadOnly={true}
                                     />
                                 ) : (
                                     <p className="text-center margin-y-7">

--- a/frontend/src/pages/agreements/review/ReviewAgreement.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.jsx
@@ -240,8 +240,7 @@ export const ReviewAgreement = () => {
                                             }
                                             servicesComponentNumber={groupKey}
                                             action={action}
-                                            showCLINColumn={showCLINColumn}
-                                            clinReadOnly={true}
+                                            clin={{ showColumn: showCLINColumn, readOnly: true }}
                                         />
                                     ) : (
                                         <p className="text-center margin-y-7">
@@ -290,8 +289,7 @@ export const ReviewAgreement = () => {
                                         }
                                         servicesComponentNumber={group.servicesComponentNumber}
                                         action={action}
-                                        showCLINColumn={showCLINColumn}
-                                        clinReadOnly={true}
+                                        clin={{ showColumn: showCLINColumn, readOnly: true }}
                                     />
                                 ) : (
                                     <p className="text-center margin-y-7">

--- a/frontend/src/pages/agreements/review/ReviewAgreement.test.jsx
+++ b/frontend/src/pages/agreements/review/ReviewAgreement.test.jsx
@@ -17,6 +17,8 @@ vi.mock("../../../App", () => ({
 
 const baseHookReturn = {
     action: "",
+    submitButtonText: "Submit",
+    appliesImmediately: false,
     handleSelectBLI: vi.fn(),
     pageErrors: {},
     isAlertActive: false,
@@ -190,5 +192,73 @@ describe("ReviewAgreement unassociated services component error border", () => {
         const heading = getUnassociatedHeading();
         expect(heading).not.toHaveClass("border-2px");
         expect(heading).not.toHaveClass("border-secondary-dark");
+    });
+});
+
+describe("ReviewAgreement CLIN column", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const clinGroup = [
+        {
+            serviceComponentGroupingLabel: "1",
+            servicesComponentNumber: 1,
+            budgetLines: [
+                {
+                    id: 200,
+                    status: "PLANNED",
+                    actionable: true,
+                    selected: false,
+                    in_review: false,
+                    amount: 1000,
+                    fees: 0,
+                    total: 1000,
+                    date_needed: "2044-06-01",
+                    services_component_id: 1,
+                    services_component_number: 1,
+                    can: { number: "G994426" },
+                    clin: { id: 9, number: 42 }
+                }
+            ]
+        }
+    ];
+
+    const contractAgreement = {
+        id: 1,
+        name: "Test Agreement",
+        agreement_type: "CONTRACT",
+        _meta: { isEditable: true }
+    };
+
+    it("shows the CLIN column for an awarded contract agreement", () => {
+        renderComponent({
+            isAgreementAwarded: true,
+            agreement: contractAgreement,
+            groupedBudgetLinesByServicesComponent: clinGroup
+        });
+
+        expect(screen.getByText("CLIN")).toBeInTheDocument();
+        expect(screen.getByRole("cell", { name: "42" })).toBeInTheDocument();
+    });
+
+    it("hides the CLIN column for an awarded non-contract agreement", () => {
+        renderComponent({
+            isAgreementAwarded: true,
+            agreement: { ...contractAgreement, agreement_type: "IAA" },
+            groupedBudgetLinesByServicesComponent: clinGroup
+        });
+
+        expect(screen.queryByText("CLIN")).not.toBeInTheDocument();
+    });
+
+    it("hides the CLIN column for a contract agreement that is not awarded", () => {
+        renderComponent({
+            isAgreementAwarded: false,
+            agreement: contractAgreement,
+            groupedBudgetLinesByServicesComponent: clinGroup
+        });
+
+        expect(screen.queryByText("CLIN")).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## What changed

Adds a **CLIN** column to budget line tables for **awarded contract** agreements (contract type _and_ awarded), and to the budget-line xlsx export.

- **Agreement details → Budget Lines tab** (`AgreementBudgetLines`): shows a CLIN column after `BL ID #` for awarded contracts. Draft BLIs show `N/A`; non-draft show the assigned CLIN number or `—` if unassigned.
- **Review Agreement page**: shows the CLIN column read-only (`clinReadOnly`) — a missing non-draft CLIN renders `—` with no error styling (the Award Approval flow keeps its existing `TBD` + error styling behavior).
- **Export**: inserts a `CLIN` column after `SC`. The leading column shifts the currency column indices (`SubTotal`, `Procurement shop fee`) from `[11, 13]` to `[12, 14]`.
- CLIN `0` is treated as a valid value everywhere (guarded with `!= null`, not truthiness).

## Issue

#6138 

## How to test

1. Open an **awarded contract** agreement → **Budget Lines** tab. Confirm a **CLIN** column appears after **BL ID #**. Draft lines show `N/A`; planned/executing lines show the CLIN number, or `—` when none is assigned.
2. Confirm the CLIN column is **absent** for grants and for non-awarded contracts.
3. Export the budget lines (Export button) and confirm the xlsx has a **CLIN** column right after **SC**, with correct values, and that **SubTotal** / **Procurement shop fee** columns still format as currency.
4. Open the **Review Agreement** page for an awarded contract. Confirm the CLIN column is read-only: unassigned non-draft lines show `—` with no red error styling.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

_N/A_

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

_N/A_
