### PR TITLE
style: unify header spacing on Budget Lines tab

### DIFF
--- a/frontend/src/components/Agreements/AgreementBudgetLinesHeader.jsx
+++ b/frontend/src/components/Agreements/AgreementBudgetLinesHeader.jsx
@@ -43,7 +43,7 @@ export const AgreementBudgetLinesHeader = ({
     }
     return (
         <>
-            <div className="display-flex flex-justify flex-align-center margin-top-6">
+            <div className="display-flex flex-justify flex-align-center">
                 <h2
                     id="budget-lines-header"
                     className="font-sans-lg"


### PR DESCRIPTION
## What changed

Removes the extra top margin (`margin-top-6`) from the Budget Lines header container in `AgreementBudgetLinesHeader.jsx` so the header's vertical spacing matches the other agreement detail tabs.

- **`frontend/src/components/Agreements/AgreementBudgetLinesHeader.jsx`**: dropped `margin-top-6` from the wrapping `flex` container's className, leaving `display-flex flex-justify flex-align-center`.

## Issue

#6175

## How to test

1. Open any agreement's detail page.
2. Switch between the **Budget Lines** tab and other detail tabs (e.g. Agreement Details).
3. Confirm the tab header now sits at the same vertical position/spacing as the other tabs, instead of being pushed down by the extra top margin.

## A11y impact

- [ ] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

<img width="1048" height="396" alt="Screenshot 2026-08-31 at 12 44 28 PM" src="https://github.com/user-attachments/assets/24d7b608-0511-452e-9fe3-8d17716fd85e" />


## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

_N/A_