### PR TITLE
fix: restore accordion spacing in edit budget lines view

### DIFF
--- a/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
+++ b/frontend/src/components/BudgetLineItems/CreateBLIsAndSCs/CreateBLIsAndSCs.jsx
@@ -568,7 +568,10 @@ export const CreateBLIsAndSCs = ({
                         const isUnassociatedError =
                             isReviewMode && group.grantNumberNumber === 0 && group.budgetLines.length > 0;
                         return (
-                            <div key={`${group.grantNumberNumber}-${index}`}>
+                            <div
+                                key={`${group.grantNumberNumber}-${index}`}
+                                className={index > 0 ? "margin-top-1" : ""}
+                            >
                                 {isUnassociatedError && (
                                     <div className="font-12px usa-form-group usa-form-group--error margin-left-0 margin-bottom-2">
                                         <span
@@ -616,7 +619,10 @@ export const CreateBLIsAndSCs = ({
                     const isUnassociatedError =
                         isReviewMode && group.servicesComponentNumber === 0 && group.budgetLines.length > 0;
                     return (
-                        <div key={`${group.servicesComponentNumber}-${index}`}>
+                        <div
+                            key={`${group.servicesComponentNumber}-${index}`}
+                            className={index > 0 ? "margin-top-1" : ""}
+                        >
                             {isUnassociatedError && (
                                 <div className="font-12px usa-form-group usa-form-group--error margin-left-0 margin-bottom-2">
                                     <span


### PR DESCRIPTION
## What changed

In edit mode on the Grants & Budget Lines tab, each accordion (grant number or services component) is wrapped in a `<div>` to pair an optional validation error message above it. This wrapper broke the USWDS adjacent-sibling CSS rule `.usa-accordion + .usa-accordion { margin-top: 0.5rem }`, causing accordions to render flush with no gap between them. Added `margin-top-1` (0.5rem) to each wrapper div for all items after the first, restoring the native USWDS spacing.

**Before:**
<img width="991" height="479" alt="Screenshot 2026-09-01 at 1 05 23 PM" src="https://github.com/user-attachments/assets/12b4a417-5ae7-44aa-8b28-1d34ee319dce" />

**After:**
<img width="993" height="478" alt="Screenshot 2026-09-01 at 1 03 10 PM" src="https://github.com/user-attachments/assets/d3120873-8c66-4ff9-983e-edbae165090a" />

## Issue

https://github.com/HHS/OPRE-OPS/issues/6013

## How to test

1. Navigate to a grant agreement (e.g. one with 2+ grant numbers)
2. Go to the **Grants & Budget Lines** tab and click **Edit**
3. Verify there is visible spacing between collapsed grant number accordions
4. Repeat for a contract agreement — verify spacing between collapsed services component accordions in edit mode
5. Verify view (non-edit) mode is unaffected on both agreement types

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] No UI component changes in this PR

## Screenshots

_Before: accordions flush with no gap in edit mode_

_After: accordions separated by 0.5rem gap, matching view mode_

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

https://github.com/HHS/OPRE-OPS/issues/6013