### PR TITLE
fix(grant-numbers): widen GrantNumberMetadata column spacing to 48px

### DIFF
--- a/frontend/src/components/GrantNumbers/GrantNumberMetadata/GrantNumberMetadata.jsx
+++ b/frontend/src/components/GrantNumbers/GrantNumberMetadata/GrantNumberMetadata.jsx
@@ -43,7 +43,7 @@ function GrantNumberMetadata({ periodStart, periodEnd, granteeRecipient, organiz
                         </Tag>
                     </dd>
                 </div>
-                <div className="margin-left-4">
+                <div className="margin-left-6">
                     <dt className="margin-0 text-base-dark margin-top-1px">Period of Performance - End</dt>
                     <dd className="margin-0 margin-top-1">
                         <Tag tagStyle="primaryDarkTextLightBackground">
@@ -51,19 +51,19 @@ function GrantNumberMetadata({ periodStart, periodEnd, granteeRecipient, organiz
                         </Tag>
                     </dd>
                 </div>
-                <div className="margin-left-4">
+                <div className="margin-left-6">
                     <dt className="margin-0 text-base-dark margin-top-1px">Grantee Recipient</dt>
                     <dd className="margin-0 margin-top-1">
                         <Tag tagStyle="primaryDarkTextLightBackground">{granteeRecipient || NO_DATA}</Tag>
                     </dd>
                 </div>
-                <div className="margin-left-4">
+                <div className="margin-left-6">
                     <dt className="margin-0 text-base-dark margin-top-1px">Organization Type</dt>
                     <dd className="margin-0 margin-top-1">
                         <Tag tagStyle="primaryDarkTextLightBackground">{organizationType || NO_DATA}</Tag>
                     </dd>
                 </div>
-                <div className="margin-left-4">
+                <div className="margin-left-6">
                     <dt className="margin-0 text-base-dark margin-top-1px">State</dt>
                     <dd className="margin-0 margin-top-1">
                         <Tag tagStyle="primaryDarkTextLightBackground">{state || NO_DATA}</Tag>


### PR DESCRIPTION
## What changed

Adjusts the horizontal spacing between the metadata columns in `GrantNumberMetadata` to match the updated design spec.

- **`frontend/src/components/GrantNumbers/GrantNumberMetadata/GrantNumberMetadata.jsx`**: Changes the left margin on the PoP End, Grantee Recipient, Organization Type, and State columns from `margin-left-4` (2rem / 32px) to `margin-left-6` (3rem / 48px). This is a CSS utility-class-only change with no logic or markup changes.

## Issue

https://github.com/HHS/OPRE-OPS/issues/5986

## How to test

1. Navigate to a page rendering `GrantNumberMetadata` (a grant number's Period of Performance / metadata row).
2. Confirm the spacing between each column (PoP Start → End → Grantee Recipient → Organization Type → State) is now 48px instead of 32px.
3. Run the component's unit tests:
   ```bash
   cd frontend
   bun run test --watch=false GrantNumberMetadata
   ```

## A11y impact

- [ ] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

## Screenshots

_Spacing-only change; screenshot showing 48px column gaps can be added if helpful._

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A