### PR TITLE
fix: icon layout and export button on grant agreement pages

### DIFF
--- a/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementTableRow.jsx
@@ -204,7 +204,7 @@ export const AgreementTableRow = ({ agreement }) => {
                 )}
                 {!isReadOnly && (
                     <div
-                        className="flex-align-self-end margin-bottom-1"
+                        className="flex-align-self-end margin-bottom-1 margin-left-auto"
                         data-cy="change-icons-expanded"
                     >
                         {changeIcons}

--- a/frontend/src/components/UI/Button/DisabledButtonWithTooltip/DisabledButtonWithTooltip.jsx
+++ b/frontend/src/components/UI/Button/DisabledButtonWithTooltip/DisabledButtonWithTooltip.jsx
@@ -15,10 +15,18 @@ import Tooltip from "../../USWDS/Tooltip";
  * @param {string} [props.tooltipPosition="top"] - Tooltip position passed to `<Tooltip>`.
  * @param {string} [props.className="usa-button"] - CSS class for the inner `<button>`.
  * @param {string} [props.dataCy] - data-cy selector for the inner `<button>`.
+ * @param {React.CSSProperties} [props.wrapperStyle] - Extra inline styles for the focusable wrapper div.
  * @param {React.ReactNode} props.children - Button label content.
  * @returns {React.ReactElement}
  */
-const DisabledButtonWithTooltip = ({ label, tooltipPosition = "top", className = "usa-button", dataCy, children }) => (
+const DisabledButtonWithTooltip = ({
+    label,
+    tooltipPosition = "top",
+    className = "usa-button",
+    dataCy,
+    wrapperStyle,
+    children
+}) => (
     <Tooltip
         label={label}
         position={tooltipPosition}
@@ -28,7 +36,7 @@ const DisabledButtonWithTooltip = ({ label, tooltipPosition = "top", className =
             tabIndex={0}
             role="button"
             aria-disabled="true"
-            style={{ display: "inline-block", cursor: "not-allowed" }}
+            style={{ ...wrapperStyle, display: "inline-block", cursor: "not-allowed" }}
         >
             <button
                 type="button"

--- a/frontend/src/components/UI/Button/DisabledButtonWithTooltip/DisabledButtonWithTooltip.test.jsx
+++ b/frontend/src/components/UI/Button/DisabledButtonWithTooltip/DisabledButtonWithTooltip.test.jsx
@@ -57,4 +57,20 @@ describe("DisabledButtonWithTooltip", () => {
         expect(wrapper).toHaveAttribute("aria-disabled", "true");
         expect(wrapper).toHaveAttribute("tabindex", "0");
     });
+
+    it("applies wrapperStyle to the wrapper div without overriding cursor or display", () => {
+        render(
+            <DisabledButtonWithTooltip
+                label="tooltip"
+                wrapperStyle={{ opacity: 0.3 }}
+            >
+                Click me
+            </DisabledButtonWithTooltip>
+        );
+        const buttons = screen.getAllByRole("button", { name: "Click me" });
+        const wrapper = buttons.find((el) => el.tagName === "DIV");
+        expect(wrapper).toHaveStyle({ opacity: 0.3 });
+        expect(wrapper).toHaveStyle({ cursor: "not-allowed" });
+        expect(wrapper).toHaveStyle({ display: "inline-block" });
+    });
 });

--- a/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
+++ b/frontend/src/pages/agreements/details/AgreementBudgetLines.jsx
@@ -239,7 +239,7 @@ const AgreementBudgetLines = ({
                                     <DisabledButtonWithTooltip
                                         label="Export coming soon"
                                         tooltipPosition="bottom"
-                                        className="usa-button--unstyled text-primary display-flex flex-align-end cursor-pointer"
+                                        className="usa-button--unstyled text-primary display-flex flex-align-center cursor-pointer opacity-30"
                                         dataCy="budget-line-export"
                                     >
                                         <svg
@@ -254,7 +254,7 @@ const AgreementBudgetLines = ({
                                     <button
                                         type="button"
                                         style={{ fontSize: "16px" }}
-                                        className="usa-button--unstyled text-primary display-flex flex-align-end cursor-pointer"
+                                        className="usa-button--unstyled text-primary display-flex flex-align-center cursor-pointer"
                                         data-cy="budget-line-export"
                                         onClick={() =>
                                             handleExport(


### PR DESCRIPTION
## What changed

- Fix edit/delete icons floating left instead of right in the expanded Grant row on the agreements list page — adds `margin-left-auto` to the change-icons container
- Fix disabled Grant export button appearing fully enabled — replaces inline `opacity: 0.3` with the standard `opacity-30` USWDS class on the button
- Fix icon/text vertical alignment inconsistency between Grant (disabled) and non-Grant (enabled) export buttons — both now use `flex-align-center`
- Add `wrapperStyle` escape-hatch prop to `DisabledButtonWithTooltip` with safe spread order (`wrapperStyle` first so fixed `cursor`/`display` always win)
- Add unit test for the new `wrapperStyle` prop

## Issue

https://github.com/HHS/OPRE-OPS/issues/5986

## How to test

1. Sign in and navigate to the Agreements list page
2. Expand a Grant row — confirm the edit/delete icons appear at the **right** side of the expanded row (not the left)
3. Open a Grant agreement → Grants & Budget Lines tab — confirm the Export button appears **visually dimmed** with an "Export coming soon" tooltip on hover
4. Open a non-Grant agreement → Budget Lines tab — confirm the Export button is fully enabled and the icon/text are **vertically centered**

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] Story updated to reflect changed props/states

## Screenshots

_See QA screenshots in #5986 for before; after screenshots pending staging deploy._

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

_N/A_