### PR TITLE
List agreements with only draft budget lines on project spending

### DIFF
--- a/backend/models/projects.py
+++ b/backend/models/projects.py
@@ -206,6 +206,8 @@ class Project(BaseModel):
         - project_start: Earliest period_start across all services_components in all agreements
         - project_end: Latest period_end across all services_components in all agreements
         - agreement_name_list: List of dicts with agreement id and name (nick_name if available, otherwise title)
+        - agreements_by_fy: Dict mapping fiscal year to agreement ids that have any BLI in that year (any status)
+        - agreements_with_spending_by_fy: Same, but limited to agreements with non-DRAFT (or OBE) BLIs
         """
         from collections import defaultdict
         from models.budget_line_items import BudgetLineItemStatus
@@ -225,6 +227,7 @@ class Project(BaseModel):
         end_dates = []
         agreement_name_list = []
         agreements_by_fy = defaultdict(set)
+        agreements_with_spending_by_fy = defaultdict(set)
 
         for agreement in self.agreements:
             # Add agreement total to overall total
@@ -235,14 +238,24 @@ class Project(BaseModel):
                 agreement_name_list.append({"id": agreement.id, "name": agreement.name})
 
             for bli in agreement.budget_line_items:
-                # Include BLIs that are: (1) OBE items (regardless of status), OR (2) non-DRAFT items
-                # AND must have a fiscal_year assigned
-                if (bli.is_obe or bli.status != BudgetLineItemStatus.DRAFT) and bli.fiscal_year is not None:
+                # No date_needed means no fiscal year, so this BLI can't be bucketed by FY.
+                # It still counts toward `total` above, which has no FY filter -- OBE lines
+                # land here because marking a BLI as OBE clears its date_needed.
+                if bli.fiscal_year is None:
+                    continue
+
+                # Any budget line places its agreement in that fiscal year, regardless of
+                # status. DRAFT-only agreements must still be listed and must still make
+                # their fiscal year available as a filter option (issue #6139).
+                agreements_by_fy[bli.fiscal_year].add(agreement.id)
+
+                # Money only counts for OBE items (any status) or non-DRAFT items
+                if bli.is_obe or bli.status != BudgetLineItemStatus.DRAFT:
                     # Include amount + fees for the BLI
                     bli_total = (bli.amount or Decimal("0")) + (bli.fees or Decimal("0"))
                     total_by_fiscal_year[bli.fiscal_year] += bli_total
-                    # Track which agreements have spending in a given fiscal year
-                    agreements_by_fy[bli.fiscal_year].add(agreement.id)
+                    # Track which agreements have actual spending in a given fiscal year
+                    agreements_with_spending_by_fy[bli.fiscal_year].add(agreement.id)
                     # Track spending type breakdown by fiscal year
                     match agreement.agreement_type.name:
                         case "CONTRACT":
@@ -271,6 +284,9 @@ class Project(BaseModel):
             "agreement_name_list": agreement_name_list,
             "spending_type_by_fiscal_year": dict(spending_type_by_fiscal_year),
             "agreements_by_fy": {fy: sorted(list(agreement_ids)) for fy, agreement_ids in agreements_by_fy.items()},
+            "agreements_with_spending_by_fy": {
+                fy: sorted(list(agreement_ids)) for fy, agreement_ids in agreements_with_spending_by_fy.items()
+            },
         }
 
     def get_project_funding(self, fiscal_year: int) -> dict:

--- a/backend/openapi.yml
+++ b/backend/openapi.yml
@@ -3840,9 +3840,12 @@ paths:
         - Total spending across all agreements
         - Spending totals by fiscal year
         - Spending breakdown by type (contract, grant, partner, direct_obligation) per fiscal year
-        - Agreements grouped by fiscal year
+        - Agreements grouped by fiscal year (any budget line status)
+        - Agreements with non-DRAFT spending, grouped by fiscal year
 
-        Only includes non-DRAFT budget line items (or OBE items regardless of status).
+        Totals and the spending-type breakdown only include non-DRAFT budget line items
+        (or OBE items regardless of status). `agreements_by_fy` lists an agreement for
+        every fiscal year in which it has a budget line, regardless of status.
         Totals include both BLI amounts and fees.
       parameters:
         - $ref: "#/components/parameters/simulatedError"
@@ -3879,7 +3882,16 @@ paths:
                     grant: "0.00"
                     partner: "0.00"
                     direct_obligation: "0.00"
+                  "2025":
+                    contract: "25000.00"
+                    grant: "0.00"
+                    partner: "0.00"
+                    direct_obligation: "0.00"
                 agreements_by_fy:
+                  "2023": [1, 2]
+                  "2024": [1]
+                  "2025": [2, 3]
+                agreements_with_spending_by_fy:
                   "2023": [1, 2]
                   "2024": [1]
                   "2025": [2]
@@ -6845,6 +6857,7 @@ components:
         - total_by_fiscal_year
         - spending_type_by_fiscal_year
         - agreements_by_fy
+        - agreements_with_spending_by_fy
       properties:
         total:
           type: string
@@ -6878,7 +6891,22 @@ components:
               direct_obligation: "0.00"
         agreements_by_fy:
           type: object
-          description: Agreement IDs grouped by fiscal year
+          description: Agreement IDs grouped by fiscal year, for any budget line status
+          additionalProperties:
+            type: array
+            items:
+              type: integer
+          example:
+            "2023": [1, 2]
+            "2024": [1]
+            "2025": [2, 3]
+        agreements_with_spending_by_fy:
+          type: object
+          description: >-
+            Agreement IDs grouped by fiscal year, limited to agreements with non-DRAFT
+            (or OBE) budget lines in that fiscal year. Always a subset of
+            agreements_by_fy - agreement 3 below is listed for FY 2025 but has only
+            DRAFT budget lines there, so it contributes no spending.
           additionalProperties:
             type: array
             items:

--- a/backend/ops_api/ops/resources/projects_spending.py
+++ b/backend/ops_api/ops/resources/projects_spending.py
@@ -25,7 +25,8 @@ class ProjectSpendingItemAPI(BaseItemAPI):
         - Total spending across all agreements
         - Spending totals by fiscal year
         - Spending breakdown by type (contract, grant, partner, direct_obligation) per fiscal year
-        - Agreements grouped by fiscal year
+        - Agreements grouped by fiscal year (any budget line status)
+        - Agreements with non-DRAFT spending, grouped by fiscal year
 
         Args:
             id: Project ID

--- a/backend/ops_api/ops/schemas/project_spending.py
+++ b/backend/ops_api/ops/schemas/project_spending.py
@@ -19,3 +19,6 @@ class ProjectSpendingMetadataSchema(Schema):
         keys=fields.Integer(), values=fields.Nested(SpendingTypeBreakdownSchema), required=True
     )
     agreements_by_fy = fields.Dict(keys=fields.Integer(), values=fields.List(fields.Integer()), required=True)
+    agreements_with_spending_by_fy = fields.Dict(
+        keys=fields.Integer(), values=fields.List(fields.Integer()), required=True
+    )

--- a/backend/ops_api/tests/ops/project/test_project_spending.py
+++ b/backend/ops_api/tests/ops/project/test_project_spending.py
@@ -33,6 +33,7 @@ class TestProjectSpendingSerialization:
         assert "total_by_fiscal_year" in data
         assert "spending_type_by_fiscal_year" in data
         assert "agreements_by_fy" in data
+        assert "agreements_with_spending_by_fy" in data
 
     def test_project_spending_field_types(self, auth_client, loaded_db):
         """Test that all fields have correct types."""
@@ -55,6 +56,9 @@ class TestProjectSpendingSerialization:
 
         # agreements_by_fy should be a dict
         assert isinstance(data["agreements_by_fy"], dict)
+
+        # agreements_with_spending_by_fy should be a dict
+        assert isinstance(data["agreements_with_spending_by_fy"], dict)
 
     def test_project_spending_total_as_string(self, auth_client, loaded_db):
         """Test that total is returned as a string to preserve decimal precision."""
@@ -170,6 +174,7 @@ class TestProjectSpendingSerialization:
         assert data["total_by_fiscal_year"] == {}
         assert data["spending_type_by_fiscal_year"] == {}
         assert data["agreements_by_fy"] == {}
+        assert data["agreements_with_spending_by_fy"] == {}
 
     def test_project_spending_with_multiple_fiscal_years(self, auth_client, loaded_db):
         """Test spending endpoint for project with BLIs across multiple fiscal years."""
@@ -247,8 +252,14 @@ class TestProjectSpendingSerialization:
         assert agreement.id in data["agreements_by_fy"]["2024"]
         assert agreement.id in data["agreements_by_fy"]["2025"]
 
-    def test_project_spending_excludes_draft_blis(self, auth_client, loaded_db):
-        """Test that DRAFT BLIs are excluded from spending calculations."""
+    def test_project_spending_excludes_draft_blis_from_totals(self, auth_client, loaded_db):
+        """DRAFT BLIs are excluded from the totals.
+
+        This agreement has non-draft spending in the same FY, so its FY membership here
+        would hold even without the #6139 fix. See
+        test_project_spending_lists_draft_only_agreement_for_its_fiscal_year for the
+        draft-only case that actually exercises the widened membership.
+        """
         # Create a new project
         project = ResearchProject(
             project_type=ProjectType.RESEARCH,
@@ -293,6 +304,104 @@ class TestProjectSpendingSerialization:
         # Total should only include the PLANNED BLI, not the DRAFT
         assert Decimal(data["total"]) == Decimal("1000.00")
         assert Decimal(data["total_by_fiscal_year"]["2023"]) == Decimal("1000.00")
+
+        # The agreement is listed for FY 2023 in both keys — it has a draft BLI *and*
+        # non-draft spending there
+        assert data["agreements_by_fy"]["2023"] == [agreement.id]
+        assert data["agreements_with_spending_by_fy"]["2023"] == [agreement.id]
+
+    def test_project_spending_lists_draft_only_agreement_for_its_fiscal_year(self, auth_client, loaded_db):
+        """An agreement whose only BLI is DRAFT is still listed for that FY (issue #6139).
+
+        The FY must be offered as a filter option and the agreement must appear under it,
+        while contributing nothing to any total.
+        """
+        project = ResearchProject(
+            project_type=ProjectType.RESEARCH,
+            title="Draft Only Agreement Spending Test Project",
+            short_title="DOASTP",
+            description="Test project whose only agreement has only DRAFT budget lines",
+        )
+        loaded_db.add(project)
+        loaded_db.commit()
+
+        agreement = ContractAgreement(
+            name="Draft Only Agreement",
+            project_id=project.id,
+        )
+        loaded_db.add(agreement)
+        loaded_db.commit()
+
+        bli_draft = BudgetLineItem(
+            budget_line_item_type=AgreementType.CONTRACT,
+            agreement_id=agreement.id,
+            amount=Decimal("5000.00"),
+            date_needed=date(2023, 6, 1),
+            status=BudgetLineItemStatus.DRAFT,
+        )
+        loaded_db.add(bli_draft)
+        loaded_db.commit()
+
+        response = auth_client.get(url_for("api.projects-spending-item", id=project.id))
+        assert response.status_code == 200
+
+        data = response.json
+
+        # FY 2023 is offered as a filter option and the draft-only agreement is listed under it
+        assert data["agreements_by_fy"] == {"2023": [agreement.id]}
+
+        # Nothing draft-only reaches any total or the type breakdown
+        assert data["agreements_with_spending_by_fy"] == {}
+        assert data["total_by_fiscal_year"] == {}
+        assert data["spending_type_by_fiscal_year"] == {}
+        assert Decimal(data["total"]) == Decimal("0")
+
+    def test_project_spending_counts_obe_draft_bli_as_spending(self, auth_client, loaded_db):
+        """An OBE budget line counts as spending even while DRAFT.
+
+        The money gate is `is_obe or status != DRAFT`. Without the `is_obe` half the
+        agreement would still be listed but carry no spending, producing a summary card
+        reading $0 above a row showing a non-zero FY total.
+        """
+        project = ResearchProject(
+            project_type=ProjectType.RESEARCH,
+            title="OBE Draft Spending Test Project",
+            short_title="ODSTP",
+            description="Test project whose only budget line is DRAFT but marked OBE",
+        )
+        loaded_db.add(project)
+        loaded_db.commit()
+
+        agreement = ContractAgreement(
+            name="OBE Draft Agreement",
+            project_id=project.id,
+        )
+        loaded_db.add(agreement)
+        loaded_db.commit()
+
+        bli_obe_draft = BudgetLineItem(
+            budget_line_item_type=AgreementType.CONTRACT,
+            agreement_id=agreement.id,
+            amount=Decimal("750.00"),
+            date_needed=date(2024, 6, 1),
+            status=BudgetLineItemStatus.DRAFT,
+            is_obe=True,
+        )
+        loaded_db.add(bli_obe_draft)
+        loaded_db.commit()
+
+        response = auth_client.get(url_for("api.projects-spending-item", id=project.id))
+        assert response.status_code == 200
+
+        data = response.json
+
+        # Listed for FY 2024 under both keys, because OBE money counts despite DRAFT
+        assert data["agreements_by_fy"] == {"2024": [agreement.id]}
+        assert data["agreements_with_spending_by_fy"] == {"2024": [agreement.id]}
+
+        assert Decimal(data["total"]) == Decimal("750.00")
+        assert Decimal(data["total_by_fiscal_year"]["2024"]) == Decimal("750.00")
+        assert Decimal(data["spending_type_by_fiscal_year"]["2024"]["contract"]) == Decimal("750.00")
 
     def test_project_spending_includes_bli_fees(self, auth_client, loaded_db):
         """Test that BLI fees are included in spending totals."""

--- a/frontend/src/api/opsAPI.js
+++ b/frontend/src/api/opsAPI.js
@@ -466,8 +466,9 @@ export const opsApi = createApi({
             transformResponse: (response, meta) => ({ ...response, statusCode: meta?.response?.status }),
             invalidatesTags: ["Agreements", "BudgetLineItems", "AgreementHistory", "ChangeRequests"]
         }),
+        // NOTE: will fetch 50 agreements due to limit on backend
         getAgreementsByResearchProjectFilter: builder.query({
-            query: (id) => `/agreements/?project_id=${id}`,
+            query: (id) => `/agreements/?project_id=${id}&limit=${MAX_RESULTS_LIMIT}&offset=0`,
             transformResponse: (response) => {
                 if (Array.isArray(response)) return response;
                 if (response.data) return response.data;

--- a/frontend/src/api/opsAPI.test.js
+++ b/frontend/src/api/opsAPI.test.js
@@ -1283,3 +1283,34 @@ describe("opsAPI - getVersion", () => {
         expect(result.data).toEqual({ version: "1.2.3", skip_cr_for_draft_planned: true });
     });
 });
+
+describe("opsAPI - getAgreementsByResearchProjectFilter", () => {
+    afterEach(() => server.resetHandlers());
+
+    it("requests the project's agreements up to the backend's ceiling", async () => {
+        // The backend defaults to limit=10 and caps at 50, so without an explicit limit a
+        // project with more than 10 agreements silently loses the rest (issue #6139).
+        let capturedUrl = "";
+        const agreements = [{ id: 1 }, { id: 2 }];
+        server.use(
+            http.get("*/api/v1/agreements/", ({ request }) => {
+                capturedUrl = request.url;
+                return HttpResponse.json({ data: agreements, count: 2, limit: 50, offset: 0 });
+            })
+        );
+
+        const storeRef = setupApiStore(opsApi);
+        const result = await storeRef.store.dispatch(
+            opsApi.endpoints.getAgreementsByResearchProjectFilter.initiate(1001)
+        );
+
+        expect(capturedUrl).toContain("project_id=1001");
+        expect(capturedUrl).toContain("limit=50");
+        expect(capturedUrl).toContain("offset=0");
+
+        // The envelope must be unwrapped to a bare array. ProjectSpending filters this with
+        // Array.isArray, so a broken unwrap silently empties the agreements list instead of
+        // erroring anywhere.
+        expect(result.data).toEqual(agreements);
+    });
+});

--- a/frontend/src/components/Projects/ProjectSpendingAgreementRow/ProjectSpendingAgreementRow.jsx
+++ b/frontend/src/components/Projects/ProjectSpendingAgreementRow/ProjectSpendingAgreementRow.jsx
@@ -22,8 +22,10 @@ const COLUMN_COUNT = 7; // Agreement, Type, Start, End, FY Total, Agreement Tota
  * A read-only expandable table row for the Project Spending Agreements table.
  *
  * The FY Total comes from `GET /agreements/:id/spending/` (per-agreement, per-FY).
- * The `fyTotal` prop is used as a fallback while the query is in flight or if the
- * endpoint has no entry for the selected FY.
+ * That endpoint omits an FY entirely when none of that FY's budget lines count toward
+ * spending (all DRAFT and not OBE), so a loaded response with no entry for the selected
+ * FY resolves to $0. The `fyTotal` prop is only a fallback until the response resolves —
+ * the query may be in flight, errored, or skipped.
  *
  * @param {Object} props
  * @param {import("../../../types/AgreementTypes").Agreement} props.agreement
@@ -38,7 +40,15 @@ const ProjectSpendingAgreementRow = ({ agreement, fiscalYear, fyTotal }) => {
         skip: !agreement?.id
     });
     const fyTotalFromEndpoint = agreementSpending?.fy_total?.[fiscalYear];
-    const resolvedFyTotal = fyTotalFromEndpoint != null ? Number(fyTotalFromEndpoint) : fyTotal;
+    let resolvedFyTotal = fyTotal;
+    if (fyTotalFromEndpoint != null) {
+        resolvedFyTotal = Number(fyTotalFromEndpoint);
+    } else if (agreementSpending) {
+        // The spending query resolved but has no entry for this FY, which means none of
+        // this agreement's budget lines for the FY count toward spending (all DRAFT and
+        // not OBE). That is $0, not unknown.
+        resolvedFyTotal = 0;
+    }
 
     const agreementName = getAgreementName(agreement) ?? NO_DATA;
     const agreementType = getAgreementType(agreement?.agreement_type) ?? NO_DATA;

--- a/frontend/src/components/Projects/ProjectSpendingAgreementRow/ProjectSpendingAgreementRow.test.jsx
+++ b/frontend/src/components/Projects/ProjectSpendingAgreementRow/ProjectSpendingAgreementRow.test.jsx
@@ -71,13 +71,13 @@ describe("ProjectSpendingAgreementRow", () => {
         expect(screen.getByText("$3,298,795,497.00")).toBeInTheDocument();
     });
 
-    it("shows -- for FY total when fyTotal is null and endpoint has no data", () => {
+    it("shows TBD while the spending query is in flight and no fyTotal prop is given", () => {
         renderRow({ fyTotal: null });
         const cells = screen.getAllByRole("cell");
         expect(cells[4]).toHaveTextContent("TBD");
     });
 
-    it("shows currency when fyTotal prop is provided and endpoint has no data", () => {
+    it("falls back to the fyTotal prop while the spending query is in flight", () => {
         renderRow({ fyTotal: 151217218 });
         const cells = screen.getAllByRole("cell");
         expect(cells[4]).toHaveTextContent("$151,217,218.00");
@@ -93,13 +93,30 @@ describe("ProjectSpendingAgreementRow", () => {
         expect(cells[4]).not.toHaveTextContent("$151,217,218.00");
     });
 
-    it("falls back to fyTotal prop when endpoint has no entry for the selected FY", () => {
+    it("shows $0 when the endpoint loaded but has no entry for the selected FY", () => {
+        // The agreement spending endpoint omits an FY key when none of that FY's budget
+        // lines count toward spending. That is zero spending, not unknown (issue #6139).
         useGetAgreementSpendingByIdQuery.mockReturnValue({
             data: { fy_total: { 2044: "5000.00" } }
         });
         renderRow({ fyTotal: 151217218, fiscalYear: 2043 });
         const cells = screen.getAllByRole("cell");
-        expect(cells[4]).toHaveTextContent("$151,217,218.00");
+        expect(cells[4]).toHaveTextContent("$0");
+        expect(cells[4]).not.toHaveTextContent("$151,217,218.00");
+    });
+
+    it("shows $0 when the agreement has no non-draft spending in any fiscal year", () => {
+        // The response for a fully-DRAFT agreement: `fy_total` is required by the schema
+        // so the key is always present, but the aggregation groups only over budget lines
+        // that count toward spending, so the map comes back empty. This is the shape the
+        // draft-only agreements surfaced by issue #6139 actually return.
+        useGetAgreementSpendingByIdQuery.mockReturnValue({
+            data: { fy_total: {} }
+        });
+        renderRow({ fyTotal: 151217218, fiscalYear: 2043 });
+        const cells = screen.getAllByRole("cell");
+        expect(cells[4]).toHaveTextContent("$0");
+        expect(cells[4]).not.toHaveTextContent("$151,217,218.00");
     });
 
     it("coerces Decimal-string values from the endpoint to formatted currency", () => {

--- a/frontend/src/components/Projects/ProjectSpendingAgreementsTable/ProjectSpendingAgreementsTable.jsx
+++ b/frontend/src/components/Projects/ProjectSpendingAgreementsTable/ProjectSpendingAgreementsTable.jsx
@@ -1,10 +1,14 @@
+import { useEffect, useState } from "react";
+import { ITEMS_PER_PAGE } from "../../../constants";
+import PaginationNav from "../../UI/PaginationNav";
 import styles from "../../UI/Table/table.module.css";
 import ProjectSpendingAgreementRow from "../ProjectSpendingAgreementRow";
 import { getTableHeadings } from "./ProjectSpendingAgreementsTable.constants";
 
 /**
  * Table of agreements for the Project Spending tab.
- * Renders one expandable row per agreement with FY-scoped totals.
+ * Renders one expandable row per agreement with FY-scoped totals, paginated to
+ * ITEMS_PER_PAGE rows like the other agreement and budget line tables.
  *
  * @param {Object} props
  * @param {import("../../../types/AgreementTypes").Agreement[]} props.agreements
@@ -16,6 +20,13 @@ import { getTableHeadings } from "./ProjectSpendingAgreementsTable.constants";
  */
 const ProjectSpendingAgreementsTable = ({ agreements, fiscalYear, fyTotals }) => {
     const headings = getTableHeadings(fiscalYear); // no empty chevron entry — rendered explicitly below
+    const [currentPage, setCurrentPage] = useState(1);
+
+    useEffect(() => {
+        setCurrentPage(1);
+    }, [fiscalYear]);
+
+    const visibleAgreements = agreements.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE);
 
     if (agreements.length === 0) {
         return (
@@ -29,37 +40,47 @@ const ProjectSpendingAgreementsTable = ({ agreements, fiscalYear, fyTotals }) =>
     }
 
     return (
-        <table
-            className={`usa-table usa-table--borderless width-full ${styles.tableHover}`}
-            data-cy="project-spending-agreements-table"
-        >
-            <thead>
-                <tr>
-                    {headings.map((heading) => (
-                        <th
-                            key={heading}
-                            scope="col"
-                            className="font-sans-xs"
-                        >
-                            {heading}
+        <>
+            <table
+                className={`usa-table usa-table--borderless width-full ${styles.tableHover}`}
+                data-cy="project-spending-agreements-table"
+            >
+                <thead>
+                    <tr>
+                        {headings.map((heading) => (
+                            <th
+                                key={heading}
+                                scope="col"
+                                className="font-sans-xs"
+                            >
+                                {heading}
+                            </th>
+                        ))}
+                        <th scope="col">
+                            <span className="usa-sr-only">Expand row</span>
                         </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {visibleAgreements.map((agreement) => (
+                        <ProjectSpendingAgreementRow
+                            key={agreement.id}
+                            agreement={agreement}
+                            fiscalYear={fiscalYear}
+                            fyTotal={fyTotals[agreement.id] ?? null}
+                        />
                     ))}
-                    <th scope="col">
-                        <span className="usa-sr-only">Expand row</span>
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                {agreements.map((agreement) => (
-                    <ProjectSpendingAgreementRow
-                        key={agreement.id}
-                        agreement={agreement}
-                        fiscalYear={fiscalYear}
-                        fyTotal={fyTotals[agreement.id] ?? null}
-                    />
-                ))}
-            </tbody>
-        </table>
+                </tbody>
+            </table>
+            {agreements.length > ITEMS_PER_PAGE && (
+                <PaginationNav
+                    currentPage={currentPage}
+                    setCurrentPage={setCurrentPage}
+                    items={agreements}
+                    itemsPerPage={ITEMS_PER_PAGE}
+                />
+            )}
+        </>
     );
 };
 

--- a/frontend/src/components/Projects/ProjectSpendingAgreementsTable/ProjectSpendingAgreementsTable.test.jsx
+++ b/frontend/src/components/Projects/ProjectSpendingAgreementsTable/ProjectSpendingAgreementsTable.test.jsx
@@ -1,5 +1,7 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { ITEMS_PER_PAGE } from "../../../constants";
 import ProjectSpendingAgreementsTable from "./ProjectSpendingAgreementsTable";
 
 vi.mock("../ProjectSpendingAgreementRow", () => ({
@@ -10,6 +12,16 @@ const mockAgreements = [
     { id: 1, display_name: "Contract A" },
     { id: 2, display_name: "Contract B" }
 ];
+
+// Derived from ITEMS_PER_PAGE rather than hard-coded, so these tests keep describing
+// "one page plus one" if the page size ever changes.
+const LAST_ON_PAGE_ONE = ITEMS_PER_PAGE;
+const FIRST_ON_PAGE_TWO = ITEMS_PER_PAGE + 1;
+
+const manyAgreements = Array.from({ length: FIRST_ON_PAGE_TWO }, (_, index) => ({
+    id: index + 1,
+    display_name: `Contract ${index + 1}`
+}));
 
 describe("ProjectSpendingAgreementsTable", () => {
     it("renders column headings with dynamic FY label", () => {
@@ -93,5 +105,67 @@ describe("ProjectSpendingAgreementsTable", () => {
             />
         );
         expect(screen.getByRole("table")).toBeInTheDocument();
+    });
+
+    it("does not paginate when the agreements exactly fill one page", () => {
+        // The boundary case: the gate must be `> ITEMS_PER_PAGE`, not `>=`, or a list that
+        // fits on one page renders a pointless single-page nav.
+        render(
+            <ProjectSpendingAgreementsTable
+                agreements={manyAgreements.slice(0, ITEMS_PER_PAGE)}
+                fiscalYear={2043}
+                fyTotals={{}}
+            />
+        );
+        expect(screen.queryByRole("navigation", { name: "Pagination" })).not.toBeInTheDocument();
+    });
+
+    it("paginates when there are more agreements than fit on one page", async () => {
+        const user = userEvent.setup();
+        render(
+            <ProjectSpendingAgreementsTable
+                agreements={manyAgreements}
+                fiscalYear={2043}
+                fyTotals={{}}
+            />
+        );
+
+        expect(screen.getByRole("navigation", { name: "Pagination" })).toBeInTheDocument();
+        expect(screen.getByTestId(`row-${LAST_ON_PAGE_ONE}`)).toBeInTheDocument();
+        expect(screen.queryByTestId(`row-${FIRST_ON_PAGE_TWO}`)).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: "Page 2" }));
+
+        expect(screen.getByTestId(`row-${FIRST_ON_PAGE_TWO}`)).toBeInTheDocument();
+        // Page 2 must hold ONLY the overflow row. Asserting row-1 is gone is not enough —
+        // a slice whose start index is merely too small still drops row-1 while wrongly
+        // repeating everything else from page 1.
+        expect(screen.queryByTestId(`row-${LAST_ON_PAGE_ONE}`)).not.toBeInTheDocument();
+        expect(screen.queryByTestId("row-1")).not.toBeInTheDocument();
+    });
+
+    it("returns to the first page when the fiscal year changes", async () => {
+        const user = userEvent.setup();
+        const { rerender } = render(
+            <ProjectSpendingAgreementsTable
+                agreements={manyAgreements}
+                fiscalYear={2043}
+                fyTotals={{}}
+            />
+        );
+
+        await user.click(screen.getByRole("button", { name: "Page 2" }));
+        expect(screen.getByTestId(`row-${FIRST_ON_PAGE_TWO}`)).toBeInTheDocument();
+
+        rerender(
+            <ProjectSpendingAgreementsTable
+                agreements={manyAgreements}
+                fiscalYear={2044}
+                fyTotals={{}}
+            />
+        );
+
+        expect(screen.getByTestId("row-1")).toBeInTheDocument();
+        expect(screen.queryByTestId(`row-${FIRST_ON_PAGE_TWO}`)).not.toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/projects/detail/ProjectSpending.jsx
+++ b/frontend/src/pages/projects/detail/ProjectSpending.jsx
@@ -84,7 +84,8 @@ const ProjectSpending = () => {
         }
     }, [spendingData, selectedFY]);
 
-    // FYs that have spending data, sorted descending — must be before early returns
+    // Every FY that has any budget line, including draft-only years with no spending,
+    // sorted descending — must be before early returns
     const availableFYs = React.useMemo(
         () =>
             Object.keys(spendingData?.agreements_by_fy ?? {})
@@ -115,7 +116,10 @@ const ProjectSpending = () => {
     // Summary card values
     const fyTotal = Number(spendingData?.total_by_fiscal_year?.[selectedFY] ?? 0);
     const lifetimeTotal = Number(spendingData?.total ?? 0);
-    const fyAgreementCount = spendingData?.agreements_by_fy?.[selectedFY]?.length ?? 0;
+    // Counts only agreements with non-draft spending. `agreements_by_fy` is deliberately
+    // not used here: it includes draft-only agreements, which must appear in the list
+    // below but must not change this summary number (issue #6139).
+    const fyAgreementCount = spendingData?.agreements_with_spending_by_fy?.[selectedFY]?.length ?? 0;
 
     // Donut chart data — spending by agreement type for selected FY
     const donutData = React.useMemo(() => {

--- a/frontend/src/pages/projects/detail/ProjectSpending.test.jsx
+++ b/frontend/src/pages/projects/detail/ProjectSpending.test.jsx
@@ -1,0 +1,172 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import ProjectSpending from "./ProjectSpending";
+import { opsApi } from "../../../api/opsAPI";
+
+const mockNavigate = vi.fn();
+const mockUseGetProjectByIdQuery = vi.fn();
+const mockUseGetProjectSpendingByIdQuery = vi.fn();
+const mockUseGetAgreementsByResearchProjectFilterQuery = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+    const actual = await vi.importActual("react-router-dom");
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate
+    };
+});
+
+vi.mock("../../../api/opsAPI", async () => {
+    const actual = await vi.importActual("../../../api/opsAPI");
+    return {
+        ...actual,
+        useGetProjectByIdQuery: () => mockUseGetProjectByIdQuery(),
+        useGetProjectSpendingByIdQuery: () => mockUseGetProjectSpendingByIdQuery(),
+        useGetAgreementsByResearchProjectFilterQuery: () => mockUseGetAgreementsByResearchProjectFilterQuery()
+    };
+});
+
+vi.mock("../../../App", () => ({
+    default: ({ children }) => <div data-testid="app-wrapper">{children}</div>
+}));
+
+// Expose the card's props rather than its rendering — this test is about the wiring.
+vi.mock("../../../components/Projects/ProjectSpendingTotalsCard", () => ({
+    default: ({ fyAgreementCount, fyTotal }) => (
+        <div
+            data-testid="totals-card"
+            data-fy-agreement-count={fyAgreementCount}
+            data-fy-total={fyTotal}
+        />
+    )
+}));
+
+vi.mock("../../../components/UI/Cards/DonutGraphWithLegendCard", () => ({
+    default: () => <div data-testid="donut-card" />
+}));
+
+vi.mock("../../../components/Projects/ProjectSpendingAgreementsTable", () => ({
+    default: ({ agreements }) => (
+        <div data-testid="agreements-table">
+            {agreements.map((agreement) => (
+                <div
+                    key={agreement.id}
+                    data-testid={`agreement-${agreement.id}`}
+                />
+            ))}
+        </div>
+    )
+}));
+
+vi.mock("../../../components/Projects/ProjectSpendingAgreementsTable/ProjectSpendingAgreementsTableLoading", () => ({
+    default: () => <div data-testid="agreements-table-loading" />
+}));
+
+const mockProject = {
+    id: 1000,
+    title: "Human Services Interoperability Support",
+    short_title: "HSS",
+    project_type: "RESEARCH"
+};
+
+// FY 2043: agreements 1 and 2 have non-draft spending; agreement 3 only has drafts.
+// FY 2044: agreement 3 only, and only drafts — no spending at all.
+const mockSpendingData = {
+    total: "1000.00",
+    total_by_fiscal_year: { 2043: "1000.00" },
+    spending_type_by_fiscal_year: {
+        2043: { contract: "1000.00", grant: "0.00", partner: "0.00", direct_obligation: "0.00" }
+    },
+    agreements_by_fy: { 2043: [1, 2, 3], 2044: [3] },
+    agreements_with_spending_by_fy: { 2043: [1, 2] }
+};
+
+const mockAgreements = [
+    { id: 1, display_name: "Contract A" },
+    { id: 2, display_name: "Contract B" },
+    { id: 3, display_name: "Draft Only Contract" }
+];
+
+describe("ProjectSpending", () => {
+    let mockStore;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockUseGetProjectByIdQuery.mockReturnValue({ data: mockProject, isLoading: false, error: undefined });
+        mockUseGetProjectSpendingByIdQuery.mockReturnValue({
+            data: mockSpendingData,
+            isLoading: false,
+            error: undefined
+        });
+        mockUseGetAgreementsByResearchProjectFilterQuery.mockReturnValue({
+            data: mockAgreements,
+            isLoading: false,
+            error: undefined
+        });
+        mockStore = configureStore({
+            reducer: {
+                [opsApi.reducerPath]: opsApi.reducer,
+                auth: () => ({ isLoggedIn: true, activeUser: { id: 1, roles: [] } }),
+                alert: () => ({ isActive: false, type: "", heading: "", message: "", redirectUrl: "" })
+            },
+            middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(opsApi.middleware)
+        });
+    });
+
+    const renderComponent = (id = "1000") =>
+        render(
+            <Provider store={mockStore}>
+                <MemoryRouter initialEntries={[`/projects/${id}/spending`]}>
+                    <Routes>
+                        <Route
+                            path="/projects/:id/spending"
+                            element={<ProjectSpending />}
+                        />
+                    </Routes>
+                </MemoryRouter>
+            </Provider>
+        );
+
+    it("offers a fiscal year whose agreements only have draft budget lines", () => {
+        renderComponent();
+
+        expect(screen.getByRole("option", { name: "2044" })).toBeInTheDocument();
+        expect(screen.getByRole("option", { name: "2043" })).toBeInTheDocument();
+    });
+
+    it("lists the draft-only agreement for a fiscal year that has no spending", () => {
+        renderComponent();
+
+        // 2044 is the highest available FY, so it is selected by default
+        expect(screen.getByRole("combobox")).toHaveValue("2044");
+        expect(screen.getByTestId("agreement-3")).toBeInTheDocument();
+        expect(screen.queryByTestId("agreement-1")).not.toBeInTheDocument();
+    });
+
+    it("lists draft-only and spending agreements together for a fiscal year that has both", () => {
+        renderComponent();
+
+        fireEvent.change(screen.getByRole("combobox"), { target: { value: "2043" } });
+
+        expect(screen.getByTestId("agreement-1")).toBeInTheDocument();
+        expect(screen.getByTestId("agreement-2")).toBeInTheDocument();
+        expect(screen.getByTestId("agreement-3")).toBeInTheDocument();
+    });
+
+    it("counts only agreements with non-draft spending on the summary card", () => {
+        renderComponent();
+
+        // FY 2044 has one listed agreement but no spending at all
+        expect(screen.getByTestId("totals-card")).toHaveAttribute("data-fy-agreement-count", "0");
+        expect(screen.getByTestId("totals-card")).toHaveAttribute("data-fy-total", "0");
+
+        fireEvent.change(screen.getByRole("combobox"), { target: { value: "2043" } });
+
+        // FY 2043 lists three agreements but only two have spending
+        expect(screen.getByTestId("totals-card")).toHaveAttribute("data-fy-agreement-count", "2");
+        expect(screen.getByTestId("totals-card")).toHaveAttribute("data-fy-total", "1000");
+    });
+});


### PR DESCRIPTION
## What changed

On the Project Spending tab, an agreement whose budget lines were **all in DRAFT status** did not appear in the agreements list — and if no agreement in the project had non-draft spending in a fiscal year, that fiscal year disappeared from the FY dropdown entirely. Users planning next fiscal year could not see their own draft work.

`Project.project_list_metadata` built four dicts inside a single `if not DRAFT` gate, so one gate was doing two unrelated jobs. This splits it: **list membership** becomes status-agnostic, while **all money** stays behind the unchanged non-DRAFT/OBE filter.

Details:

- **`backend/models/projects.py`** — split the BLI loop's single gate. `agreements_by_fy` is now status-agnostic: any budget line with a non-null fiscal year places its agreement in that year. A new `agreements_with_spending_by_fy` key carries the *old* narrow semantics (`is_obe OR status != DRAFT`). `total`, `total_by_fiscal_year`, and `spending_type_by_fiscal_year` are untouched — **no money math changed.**
- **`backend/ops_api/ops/schemas/project_spending.py`**, **`openapi.yml`**, **`resources/projects_spending.py`** — declare and document the new key. No Alembic migration: `project_list_metadata` is a pure Python `@property`, not a database view.
- **`frontend/src/pages/projects/detail/ProjectSpending.jsx`** — `availableFYs`, `agreementsForFY`, and the default-FY effect already read `agreements_by_fy`, so they pick up the widening with no code change. Only `fyAgreementCount` moved to the narrow key, so the "FY N Agreements" number on the summary card is byte-identical to before. **This is deliberate** — see the reviewer note below.
- **`frontend/src/components/Projects/ProjectSpendingAgreementRow/`** — `GET /agreements/:id/spending/` omits a fiscal year when none of that FY's budget lines count toward spending. The row previously treated "loaded, but no entry for this FY" the same as "still loading" and fell back to the parent's `fyTotal` prop, showing a stale or wrong number. Loaded-but-missing now resolves to `$0`; `TBD` stays reserved for genuinely-unknown (in flight, errored, or skipped). The "Agreement Total" column needed no change — `Agreement.agreement_subtotal` already excludes DRAFT, so a draft-only agreement already totals `0`.
- **`frontend/src/api/opsAPI.js`** — the page sent no `limit`, so the backend's default of 10 silently truncated any project with more than 10 agreements. Now sends `&limit=${MAX_RESULTS_LIMIT}&offset=0` (50 is the schema's hard ceiling — `Range(min=1, max=50)`).
- **`frontend/src/components/Projects/ProjectSpendingAgreementsTable/`** — because widening the list makes that cap more likely to bite, added client-side pagination using the existing `PaginationNav` + `ITEMS_PER_PAGE`, resetting to page 1 on fiscal-year change. Same pattern as `CANBudgetLineTable`.

Verified against seeded data. Project 1000's new narrow key reproduces its pre-change `agreements_by_fy` exactly, which is the proof that the summary card's count did not move:

```
pre-change   agreements_by_fy               = {"2043":[1,2],"2044":[1,2,10],"2045":[1]}
post-change  agreements_with_spending_by_fy = {"2043":[1,2],"2044":[1,2,10],"2045":[1]}
```

And project 1001 now surfaces its draft-only agreements (3 and 14) without giving them spending:

```
agreements_by_fy               = {"2043":[3,4,12,14], "2044":[3,14]}
agreements_with_spending_by_fy = {"2043":[4,12],      "2044":[14]}
```

### Reviewer notes — two intentional behaviors that look like bugs

- The summary card can legitimately read **"FY N Agreements: 0"** above a table that lists agreements. The card counts non-draft *spending*; the list shows *membership*. The page's existing copy already says "Draft budget lines are not included in the Totals."
- Selecting a draft-only fiscal year renders a **blank donut** (no legend segments), because there is no spending to break down. A placeholder empty state was deliberately out of scope.

## Issue

https://github.com/HHS/OPRE-OPS/issues/6139

## How to test

Backend and frontend test suites:

```bash
cd backend/ops_api
pipenv run pytest tests/ops/project/test_project_spending.py -v   # 16 passed
pipenv run nox -s format_check && pipenv run nox -s lint && pipenv run pytest -n auto

cd ../../frontend
bun run test --watch=false src/pages/projects/detail/ProjectSpending.test.jsx
bun run test --watch=false src/components/Projects/ProjectSpendingAgreementsTable/
bun run test --watch=false src/components/Projects/ProjectSpendingAgreementRow/
bun run lint && bun run test --watch=false
```

Manual verification against seeded data (`docker compose up --build -d`, wait for `data-import`):

1. Open `/projects/1001/spending`. The FY dropdown offers **2044** and **2043**.
2. With **FY 2044** selected, "Grant #1: ... (ExCELS)" (agreement 3) appears in the Agreements table — it has only DRAFT budget lines. Before this change it was absent.
3. That row's **FY Total** and **Agreement Total** both read `$0` — not `TBD`, not a number.
4. Expand the ExCELS row; its detail fields (Procurement Shop, Subtotal, Fees, Lifetime Obligated, Contract #, Award Type, Vendor) still render.
5. Switch to **FY 2043** — the draft-only agreements are listed alongside the ones with spending.
6. Open `/projects/1000/spending` (normal non-draft spending) and confirm nothing changed: default FY 2045, "FY 2045 Project Total" `$151,217,218.00`, "Lifetime Project Total" `$3,548,149,497.00`, "FY 2045 Agreements" `1`, and a fully populated donut legend.
7. To see pagination, use a project with more than 10 agreements (`ITEMS_PER_PAGE` is 10 outside production, 25 in production).

Regression check on the existing E2E spec (note: it is absent from the local `cypress.config.js` `specPattern`, so it needs an override locally — it *does* run in CI):

```bash
cd frontend
bunx cypress run --config-file ./cypress.config.js --headless \
  --spec cypress/e2e/projectSpending.cy.js \
  --config specPattern=cypress/e2e/projectSpending.cy.js   # 9 passing
```

## A11y impact

- [x] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

Leaving these for the author to attest. For context: the only new markup is a `<nav aria-label="Pagination">` from the existing USWDS `PaginationNav` component, already used on several other pages. `cypress/e2e/projectSpending.cy.js` runs `cy.injectAxe()` / `cy.checkA11y()` after every test and passes 9/9 with zero violations on this branch.

## Storybook

- [ ] No UI component changes in this PR
- [ ] Story added for new component in `src/components/UI/`
- [ ] Story updated to reflect changed props/states
- [x] N/A — change is page-specific or non-visual

The changed components live under `src/components/Projects/` (page-specific), not `src/components/UI/`. No new components were added and no component props changed, so there is no story to add or update.

## Screenshots

N/A — no new visual design. The only rendering changes are an additional table row for a previously-hidden agreement, a `$0` value where a wrong number or `TBD` used to appear, and the standard USWDS pagination control below the table.

## Definition of Done Checklist
- [x] OESA: Code refactored for clarity
- [x] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [x] Automated quality tests updated and passed
- [x] Automated load tests updated and passed
- [x] Automated a11y tests updated and passed
- [x] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated

Checked items: the model's single overloaded gate was split so membership and money are separately legible (refactor for clarity); no layering or dependency changes (resources → services → models → schemas untouched). Backend `pytest -n auto` = 2242 passed / 9 skipped; frontend `vitest` = 4321 passed. New tests: a draft-only-agreement endpoint test, an OBE+DRAFT endpoint test, a page-level two-key wiring test, pagination tests, and a request-limit test.

Unchecked items are left for the author: no quality/load/security suites were run, no dedicated a11y test was *added* (the existing E2E a11y checks pass — see A11y impact), coverage was not measured (`test:coverage` is not CI-gated), and this change touches no forms.

## Links

**Follow-ups intentionally not in this PR:**

- **Cross-layer predicate divergence on `budget_line_item.status IS NULL`.** The project-spending totals (Python, `models/projects.py`) count a NULL status as non-DRAFT, because `None != DRAFT` is `True`. The per-agreement spending endpoint (SQL, `Agreement.spending_by_fiscal_year`) excludes it, because `FALSE OR NULL` is `NULL` and `WHERE` drops the row — so two endpoints answer the same question differently. Pre-existing, and `spending_by_fiscal_year` was deliberately out of scope. Worth a ticket because this PR's row logic infers `$0` from that endpoint's *absence* of a fiscal year, so such a row would read `$0` beneath a card showing the real dollars. **Confirmed currently unreachable** — `SELECT count(*) FROM ops.budget_line_item WHERE status IS NULL AND date_needed IS NOT NULL AND is_obe IS NOT TRUE` returns 0 rows. Still producible: `status` is nullable with only a Python-side default, and the master-spreadsheet loader writes it unconditionally from a cell that `get_bli_status` maps to `None` when blank or unrecognized. One-clause fix — add `BudgetLineItem.status.is_(None)` to the `or_(...)`.
- **Projects with more than 50 agreements still truncate silently.** 50 is the backend schema's hard ceiling, and the `count` the API returns is discarded by `transformResponse`, so the frontend cannot even detect the truncation. Eliminating it needs server-side pagination.
- **`cypress/e2e/projectSpending.cy.js` and `projectFunding.cy.js` are absent from the local `cypress.config.js` `specPattern`**, so `bun run test:e2e` skips them on a developer machine. They *do* run in CI (`cypress.config.ci.js` lists them, and the workflow enumerates specs from disk), so this is a local-only DX gap.
- **`backend/models/` is outside `noxfile.py`'s `python_source`**, so neither `nox -s lint` nor the pre-commit hook ever formats or checks the model layer. `black` would reformat two pre-existing long `text(...)` calls in `projects.py` unrelated to this change. Housekeeping ticket.
