### PR TITLE
fix: don't convert Planned BLIs to Planned Mod on agreement award

### DIFF
--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -1015,7 +1015,6 @@ class ProcurementTrackerStepService:
 
         When approval_status == "APPROVED":
         - IN_EXECUTION BLIs → OBLIGATED (date_needed set to the provided obligated_date)
-        - PLANNED BLIs → PLANNED_MOD
         - Sets procurement_action.date_awarded_obligated if not already set
         - Marks procurement_action status as AWARDED
 
@@ -1041,9 +1040,6 @@ class ProcurementTrackerStepService:
                 if obligated_date is not None:
                     bli.date_needed = obligated_date
                 logger.debug(f"Transitioned BLI {bli.id} IN_EXECUTION → OBLIGATED")
-            elif bli.status == BudgetLineItemStatus.PLANNED:
-                bli.status = BudgetLineItemStatus.PLANNED_MOD
-                logger.debug(f"Transitioned BLI {bli.id} PLANNED → PLANNED_MOD")
 
         # Set procurement action date and status — only for NEW_AWARD actions
         # (consistent with _advance_active_step_if_needed which gates on NEW_AWARD)

--- a/backend/ops_api/tests/ops/services/test_award_approval_service.py
+++ b/backend/ops_api/tests/ops/services/test_award_approval_service.py
@@ -83,7 +83,7 @@ class TestHandleAwardApprovalBLITransitions:
 
         assert bli.status == BudgetLineItemStatus.OBLIGATED
 
-    def test_planned_bli_set_to_planned_mod(self):
+    def test_planned_bli_not_changed(self):
         service = _make_service()
         bli = _make_bli(BudgetLineItemStatus.PLANNED)
         agreement = _make_agreement()
@@ -93,7 +93,7 @@ class TestHandleAwardApprovalBLITransitions:
 
         service._handle_award_approval(step, "APPROVED", None, _make_current_user())
 
-        assert bli.status == BudgetLineItemStatus.PLANNED_MOD
+        assert bli.status == BudgetLineItemStatus.PLANNED
 
     def test_draft_bli_not_changed(self):
         service = _make_service()
@@ -132,7 +132,7 @@ class TestHandleAwardApprovalBLITransitions:
         service._handle_award_approval(step, "APPROVED", None, _make_current_user())
 
         assert bli_exec.status == BudgetLineItemStatus.OBLIGATED
-        assert bli_planned.status == BudgetLineItemStatus.PLANNED_MOD
+        assert bli_planned.status == BudgetLineItemStatus.PLANNED
         assert bli_draft.status == BudgetLineItemStatus.DRAFT
 
 


### PR DESCRIPTION
## What changed

Removes the erroneous logic that converted `PLANNED` status Budget Line Items (BLIs) into `PLANNED_MOD` status when an agreement's AWARD procurement tracker step was approved. Planned BLIs should remain `PLANNED` when an agreement is awarded — only `IN_EXECUTION` BLIs should transition to `OBLIGATED`.

**backend/ops_api/ops/services/procurement_tracker_steps.py**
- `_handle_award_approval` no longer sets `PLANNED` BLIs to `PLANNED_MOD` on award approval; the `elif` branch and its docstring reference were removed.

**backend/ops_api/tests/ops/services/test_award_approval_service.py**
- Renamed `test_planned_bli_set_to_planned_mod` to `test_planned_bli_not_changed` and updated its assertion to expect the BLI to remain `PLANNED`.
- Updated `test_mixed_blis_all_transitioned_correctly` to expect the planned BLI to remain `PLANNED`.

No other code in the repo sets a BLI's status to `PLANNED_MOD` — the remaining references (enum definition, CAN funding aggregation, procurement-shop-change guard, frontend display/status-label mappings) only treat `PLANNED_MOD` as read-only/equivalent to `PLANNED` for reporting or historical-data purposes, and don't need to change.

## Issue

https://github.com/HHS/OPRE-OPS/issues/6212

## How to test

```
cd backend/ops_api
pipenv run pytest tests/ops/services/test_award_approval_service.py -q
pipenv run pytest tests/ops/budget_line_items/test_budget_line_item_status.py tests/ops/services/test_agreements.py tests/ops/test_planned_mod_status.py -q
```

Manually: create an agreement with at least one `PLANNED` BLI and one `IN_EXECUTION` BLI, approve the AWARD step in the Procurement Tracker, and confirm the `PLANNED` BLI stays `PLANNED` while the `IN_EXECUTION` BLI becomes `OBLIGATED`.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] No UI component changes in this PR

## Screenshots

N/A — backend changes only

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated


## Links

N/A