### PR TITLE
fix: fix and harden the Slack mention-notify workflow

### DIFF
--- a/.github/workflows/slack_mention_notify.yml
+++ b/.github/workflows/slack_mention_notify.yml
@@ -8,6 +8,12 @@ permissions:
   contents: read
   actions: read
 
+# Serialize runs per commenter so the rate-limit check (which reads this workflow's own,
+# eventually-consistent run history) can't be raced by a burst of comments from one actor.
+concurrency:
+  group: notify-mention-${{ github.event.comment.user.login }}
+  cancel-in-progress: false
+
 jobs:
   notify-mention:
     runs-on: ubuntu-latest
@@ -28,14 +34,22 @@ jobs:
           # using GitHub's own run history as state, since Actions has no persistent store.
           since=$(date -u -d "${WINDOW_MINUTES} minutes ago" +%Y-%m-%dT%H:%M:%SZ)
           # Filename below must match this workflow's own file -- if this file is ever
-          # renamed, update it too, or this 404s, run_count comes back empty, and the
-          # rate limit silently stops enforcing.
-          run_count=$(gh api -X GET "repos/${REPO}/actions/workflows/slack_mention_notify.yml/runs" \
-            -f actor="$ACTOR" -f created=">=${since}" --jq '.total_count')
+          # renamed, update it too, or this 404s and falls into the retry loop below,
+          # which treats a persistently unverifiable count as rate-limited (fail-safe).
+          run_count=""
+          for attempt in 1 2 3; do
+            if run_count=$(gh api -X GET "repos/${REPO}/actions/workflows/slack_mention_notify.yml/runs" \
+              -f actor="$ACTOR" -f created=">=${since}" --jq '.total_count' 2>/dev/null); then
+              break
+            fi
+            run_count=""
+            sleep "$((attempt * 3))"
+          done
 
-          echo "run_count=${run_count}" >> "$GITHUB_ENV"
-
-          if [ "$run_count" -gt "$MAX_RUNS" ]; then
+          if [ -z "$run_count" ]; then
+            echo "::warning::Could not verify ${ACTOR}'s rate limit after retries; skipping Slack notification as a precaution."
+            echo "rate_limited=true" >> "$GITHUB_ENV"
+          elif [ "$run_count" -gt "$MAX_RUNS" ]; then
             echo "::warning::${ACTOR} has triggered this workflow ${run_count} times in the last ${WINDOW_MINUTES} minutes (limit ${MAX_RUNS}); skipping Slack notification."
             echo "rate_limited=true" >> "$GITHUB_ENV"
           fi
@@ -79,7 +93,9 @@ jobs:
           mention_text=""
           while IFS= read -r gh_user; do
             gh_user_lower=$(printf '%s' "$gh_user" | tr '[:upper:]' '[:lower:]')
-            slack_id=$(jq -r --arg u "$gh_user_lower" '.[$u] // empty' .github/slack_user_map.json)
+            # `|| slack_id=""` keeps a missing/malformed map file from aborting the whole
+            # step under set -e -- fall back to the plain @username text for that mention.
+            slack_id=$(jq -r --arg u "$gh_user_lower" '.[$u] // empty' .github/slack_user_map.json) || slack_id=""
             if [ -n "$slack_id" ]; then
               mention_text="${mention_text}<@${slack_id}> "
             else

--- a/.github/workflows/slack_mention_notify.yml
+++ b/.github/workflows/slack_mention_notify.yml
@@ -46,12 +46,17 @@ jobs:
             sleep "$((attempt * 3))"
           done
 
-          if [ -z "$run_count" ]; then
+          if [ -z "$run_count" ] || ! [[ "$run_count" =~ ^[0-9]+$ ]]; then
             echo "::warning::Could not verify ${ACTOR}'s rate limit after retries; skipping Slack notification as a precaution."
             echo "rate_limited=true" >> "$GITHUB_ENV"
-          elif [ "$run_count" -gt "$MAX_RUNS" ]; then
-            echo "::warning::${ACTOR} has triggered this workflow ${run_count} times in the last ${WINDOW_MINUTES} minutes (limit ${MAX_RUNS}); skipping Slack notification."
-            echo "rate_limited=true" >> "$GITHUB_ENV"
+          else
+            # total_count includes this run itself (already recorded as in-progress by the
+            # time this step runs), so compare prior triggers only against MAX_RUNS.
+            prior_count=$((run_count - 1))
+            if [ "$prior_count" -ge "$MAX_RUNS" ]; then
+              echo "::warning::${ACTOR} has triggered this workflow ${run_count} times in the last ${WINDOW_MINUTES} minutes (limit ${MAX_RUNS}); skipping Slack notification."
+              echo "rate_limited=true" >> "$GITHUB_ENV"
+            fi
           fi
 
       - name: Checkout (for slack_user_map.json)
@@ -79,8 +84,10 @@ jobs:
           # later mentions), and indented or ~~~-style fences aren't recognized and won't be stripped.
           body_no_code=$(printf '%s\n' "$COMMENT_BODY" | sed '/^```/,/^```/d')
 
+          # Trailing (?!/) excludes @org/team-name team mentions -- those aren't individual
+          # users and would otherwise leave a mangled "@org" fallback in the Slack message.
           mentions=$(printf '%s' "$body_no_code" \
-            | { grep -oP '(?<![\w.@-])@[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}\b' || true; } \
+            | { grep -oP '(?<![\w.@-])@[a-zA-Z0-9](?:-?[a-zA-Z0-9]){0,38}\b(?!/)' || true; } \
             | sed 's/^@//' | sort -u)
 
           if [ -z "$mentions" ]; then
@@ -115,4 +122,5 @@ jobs:
           text="*${COMMENT_AUTHOR}* mentioned ${mention_text}in a comment on ${kind} <${COMMENT_URL}|${REPO}#${ISSUE_NUMBER}: ${escaped_title}>"
 
           payload=$(jq -n --arg text "$text" '{text: $text}')
-          curl -s --fail-with-body -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"
+          curl -s --fail-with-body --connect-timeout 5 --max-time 10 \
+            -X POST -H 'Content-Type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/slack_mention_notify.yml
+++ b/.github/workflows/slack_mention_notify.yml
@@ -30,7 +30,7 @@ jobs:
           # Filename below must match this workflow's own file -- if this file is ever
           # renamed, update it too, or this 404s, run_count comes back empty, and the
           # rate limit silently stops enforcing.
-          run_count=$(gh api "repos/${REPO}/actions/workflows/slack_mention_notify.yml/runs" \
+          run_count=$(gh api -X GET "repos/${REPO}/actions/workflows/slack_mention_notify.yml/runs" \
             -f actor="$ACTOR" -f created=">=${since}" --jq '.total_count')
 
           echo "run_count=${run_count}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## What changed

The `notify-mention` workflow's "Rate limit check" step has been failing 100% of the time (confirmed live against the real repo's run history — every recent run shows `conclusion: failure`), which meant **no Slack mention notifications have been going out at all**.

**Root cause (`.github/workflows/slack_mention_notify.yml`):** the `gh api` call used `-f actor=... -f created=...` without `-X GET`. `gh api` defaults to POST whenever `-f`/`-F` flags are present unless `-X` is explicitly given, and POST isn't valid against this GET-only "list workflow runs" endpoint — hence the 404 every time.

After fixing that, three parallel adversarial reviews (security, correctness, reliability) were run against the change and the file as a whole, since the workflow had never actually run to completion in production and several latent issues were about to be exercised for the first time. This PR also fixes what those reviews turned up:

- **`slack_user_map.json` failure guard** — a missing/malformed map file previously killed the whole step mid-loop under `set -e` before ever reaching the Slack POST. Now falls back to plain `@username` text instead.
- **Concurrency group** — added `concurrency: group: notify-mention-${{ github.event.comment.user.login }}` to close a TOCTOU race: the run-history API this limiter reads is cached up to 60s and includes in-progress runs, so a comment burst from one actor could have multiple concurrent runs all read the same stale, undercounted total and all slip past `MAX_RUNS`.
- **Retry + fail-safe instead of hard job-kill** — the `gh api` call now retries 3x with backoff; if it's still unverifiable, the workflow skips the Slack notification (fail-safe) instead of hard-aborting the entire job on any transient error.
- **Off-by-one fix** — `total_count` includes the currently-running invocation itself; the check now compares prior triggers only, so exactly `MAX_RUNS` (not `MAX_RUNS - 1`) invocations are allowed per window. This also closes a narrow silent-bypass path where a non-numeric API result could no-op the limiter.
- **Team mentions excluded from the notify regex** — `@org/team-name` previously matched as a mangled `@org` fallback; now skipped entirely since it's not an individual user mention.
- **`curl` timeout added** — `--connect-timeout 5 --max-time 10` so a hung Slack endpoint can't eat the full 5-minute job timeout.

Failed-run counting in the rate window was deliberately left unchanged — this limiter caps invocation frequency for abuse prevention, not notification success, so counting failures against quota is intentional.

## Issue

N/A — no associated ticket (CI/tooling fix, branch not tied to a story).

## How to test

There's no automated test suite for this GitHub Actions workflow, so verification is manual:

1. **Reproduce the original bug vs. the fix** (already done live against `HHS/OPRE-OPS` during development):
   ```bash
   # Old behavior (404): gh api "repos/HHS/OPRE-OPS/actions/workflows/slack_mention_notify.yml/runs" -f actor=<user> -f created=">=<ts>" --jq '.total_count'
   # Fixed behavior (200): gh api -X GET "repos/HHS/OPRE-OPS/actions/workflows/slack_mention_notify.yml/runs" -f actor=<user> -f created=">=<ts>" --jq '.total_count'
   ```
2. After merge, as an org member/collaborator, comment `@some-mapped-user hey` on an issue or PR and confirm a Slack message posts with the mapped mention.
3. Comment mentioning a team, e.g. `@HHS/some-team`, and confirm it's dropped from the notification instead of posting a mangled `@HHS`.
4. Post 6+ comments with mentions from the same account within 10 minutes and confirm the 6th is rate-limited (check the run's `::warning::` annotation).
5. Check `gh run list --workflow=slack_mention_notify.yml` after merge to confirm runs show `conclusion: success` instead of the prior 100%-failure streak.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] No UI component changes in this PR

## Screenshots

N/A — backend/CI workflow change only, no UI.

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

No automated test suite covers GitHub Actions workflows in this repo; verification was manual/live as described above.

## Links

N/A