### PR TITLE
feat: default Projects and Agreements lists to all fiscal years

### DIFF
--- a/backend/ops_api/ops/services/procurement_tracker_steps.py
+++ b/backend/ops_api/ops/services/procurement_tracker_steps.py
@@ -1015,7 +1015,6 @@ class ProcurementTrackerStepService:
 
         When approval_status == "APPROVED":
         - IN_EXECUTION BLIs → OBLIGATED (date_needed set to the provided obligated_date)
-        - PLANNED BLIs → PLANNED_MOD
         - Sets procurement_action.date_awarded_obligated if not already set
         - Marks procurement_action status as AWARDED
 
@@ -1041,9 +1040,6 @@ class ProcurementTrackerStepService:
                 if obligated_date is not None:
                     bli.date_needed = obligated_date
                 logger.debug(f"Transitioned BLI {bli.id} IN_EXECUTION → OBLIGATED")
-            elif bli.status == BudgetLineItemStatus.PLANNED:
-                bli.status = BudgetLineItemStatus.PLANNED_MOD
-                logger.debug(f"Transitioned BLI {bli.id} PLANNED → PLANNED_MOD")
 
         # Set procurement action date and status — only for NEW_AWARD actions
         # (consistent with _advance_active_step_if_needed which gates on NEW_AWARD)

--- a/backend/ops_api/tests/ops/services/test_award_approval_service.py
+++ b/backend/ops_api/tests/ops/services/test_award_approval_service.py
@@ -83,7 +83,7 @@ class TestHandleAwardApprovalBLITransitions:
 
         assert bli.status == BudgetLineItemStatus.OBLIGATED
 
-    def test_planned_bli_set_to_planned_mod(self):
+    def test_planned_bli_not_changed(self):
         service = _make_service()
         bli = _make_bli(BudgetLineItemStatus.PLANNED)
         agreement = _make_agreement()
@@ -93,7 +93,7 @@ class TestHandleAwardApprovalBLITransitions:
 
         service._handle_award_approval(step, "APPROVED", None, _make_current_user())
 
-        assert bli.status == BudgetLineItemStatus.PLANNED_MOD
+        assert bli.status == BudgetLineItemStatus.PLANNED
 
     def test_draft_bli_not_changed(self):
         service = _make_service()
@@ -132,7 +132,7 @@ class TestHandleAwardApprovalBLITransitions:
         service._handle_award_approval(step, "APPROVED", None, _make_current_user())
 
         assert bli_exec.status == BudgetLineItemStatus.OBLIGATED
-        assert bli_planned.status == BudgetLineItemStatus.PLANNED_MOD
+        assert bli_planned.status == BudgetLineItemStatus.PLANNED
         assert bli_draft.status == BudgetLineItemStatus.DRAFT
 
 

--- a/frontend/cypress/e2e/agreementList.cy.js
+++ b/frontend/cypress/e2e/agreementList.cy.js
@@ -34,7 +34,7 @@ describe("Agreement List", () => {
         cy.get("thead > tr > :nth-child(3)").should("have.text", "Start");
         cy.get("thead > tr > :nth-child(4)").should("have.text", "End");
         cy.get("thead > tr > :nth-child(5)").should("have.text", "Total");
-        cy.get("thead > tr > :nth-child(6)").should("have.text", "FY26 Obligated");
+        cy.get("thead > tr > :nth-child(6)").should("have.text", "FY Obligated");
 
         cy.get("#fiscal-year-select").select("2044");
         // select the row with data-testid="agreement-table-row-9"

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.constants.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.constants.js
@@ -24,11 +24,17 @@ export const TABLE_HEADINGS_LIST = [
  * @returns {Array<{heading: string, value: string}>} - The table headings list with dynamic FY label.
  */
 export const getTableHeadingsWithFY = (fiscalYear) => {
-    const fyLabel = fiscalYear === "All" ? "FY Obligated" : `FY${String(fiscalYear).slice(-2)} Obligated`;
+    const isAllFiscalYears = fiscalYear === "All";
+    const fyLabel = isAllFiscalYears ? "FY Obligated" : `FY${String(fiscalYear).slice(-2)} Obligated`;
 
     return TABLE_HEADINGS_LIST.map((item) => {
         if (item.value === tableSortCodes.agreementCodes.FY_OBLIGATED) {
-            return { ...item, heading: fyLabel };
+            return {
+                ...item,
+                heading: fyLabel,
+                disabled: isAllFiscalYears,
+                disabledReason: `Select a specific fiscal year to sort by ${fyLabel}`
+            };
         }
         return item;
     });

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.constants.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.constants.js
@@ -24,17 +24,11 @@ export const TABLE_HEADINGS_LIST = [
  * @returns {Array<{heading: string, value: string}>} - The table headings list with dynamic FY label.
  */
 export const getTableHeadingsWithFY = (fiscalYear) => {
-    const isAllFiscalYears = fiscalYear === "All";
-    const fyLabel = isAllFiscalYears ? "FY Obligated" : `FY${String(fiscalYear).slice(-2)} Obligated`;
+    const fyLabel = fiscalYear === "All" ? "FY Obligated" : `FY${String(fiscalYear).slice(-2)} Obligated`;
 
     return TABLE_HEADINGS_LIST.map((item) => {
         if (item.value === tableSortCodes.agreementCodes.FY_OBLIGATED) {
-            return {
-                ...item,
-                heading: fyLabel,
-                disabled: isAllFiscalYears,
-                disabledReason: `Select a specific fiscal year to sort by ${fyLabel}`
-            };
+            return { ...item, heading: fyLabel };
         }
         return item;
     });

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.constants.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.constants.js
@@ -24,9 +24,8 @@ export const TABLE_HEADINGS_LIST = [
  * @param {string} currentFiscalYear - The current fiscal year (e.g., "2026").
  * @returns {Array<{heading: string, value: string}>} - The table headings list with dynamic FY label.
  */
-export const getTableHeadingsWithFY = (fiscalYear, currentFiscalYear) => {
-    const effectiveFY = fiscalYear === "All" ? currentFiscalYear : fiscalYear;
-    const fyLabel = `FY${String(effectiveFY).slice(-2)} Obligated`;
+export const getTableHeadingsWithFY = (fiscalYear) => {
+    const fyLabel = fiscalYear === "All" ? "FY Obligated" : `FY${String(fiscalYear).slice(-2)} Obligated`;
 
     return TABLE_HEADINGS_LIST.map((item) => {
         if (item.value === tableSortCodes.agreementCodes.FY_OBLIGATED) {

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.constants.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.constants.js
@@ -20,8 +20,7 @@ export const TABLE_HEADINGS_LIST = [
 
 /**
  * Returns table headings with a dynamic FY column label based on the selected fiscal year.
- * @param {string} fiscalYear - The selected fiscal year (e.g., "2025" or "All").
- * @param {string} currentFiscalYear - The current fiscal year (e.g., "2026").
+ * @param {string} fiscalYear - The selected fiscal year (e.g., "2025") or "All".
  * @returns {Array<{heading: string, value: string}>} - The table headings list with dynamic FY label.
  */
 export const getTableHeadingsWithFY = (fiscalYear) => {

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.jsx
@@ -1,6 +1,5 @@
 import Table from "../../UI/Table";
 import { getTableHeadingsWithFY } from "./AgreementsTable.constants";
-import { getCurrentFiscalYear } from "../../../helpers/utils";
 import AgreementTableRow from "./AgreementTableRow";
 
 /**
@@ -20,7 +19,7 @@ export const AgreementsTable = ({
     setSortConditions,
     selectedFiscalYear
 }) => {
-    const tableHeadings = getTableHeadingsWithFY(selectedFiscalYear, getCurrentFiscalYear());
+    const tableHeadings = getTableHeadingsWithFY(selectedFiscalYear);
 
     return (
         <>

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
@@ -123,28 +123,6 @@ it("renders without crashing", () => {
     expect(screen.getByText("FY25 Obligated")).toBeInTheDocument();
 });
 
-it("disables the FY Obligated header and blocks sorting when 'All' is selected", () => {
-    const setSortConditions = vi.fn();
-    render(
-        <Provider store={store}>
-            <BrowserRouter>
-                <AgreementsTable
-                    agreements={agreements}
-                    selectedFiscalYear="All"
-                    setSortConditions={setSortConditions}
-                />
-            </BrowserRouter>
-        </Provider>
-    );
-
-    const fyHeader = screen.getByRole("button", { name: "FY Obligated" });
-    expect(fyHeader).toHaveAttribute("aria-disabled", "true");
-
-    fireEvent.click(fyHeader);
-
-    expect(setSortConditions).not.toHaveBeenCalled();
-});
-
 it("does not render contract-only expanded fields for a GRANT agreement row", () => {
     render(
         <Provider store={store}>

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTable.test.js
@@ -123,6 +123,28 @@ it("renders without crashing", () => {
     expect(screen.getByText("FY25 Obligated")).toBeInTheDocument();
 });
 
+it("disables the FY Obligated header and blocks sorting when 'All' is selected", () => {
+    const setSortConditions = vi.fn();
+    render(
+        <Provider store={store}>
+            <BrowserRouter>
+                <AgreementsTable
+                    agreements={agreements}
+                    selectedFiscalYear="All"
+                    setSortConditions={setSortConditions}
+                />
+            </BrowserRouter>
+        </Provider>
+    );
+
+    const fyHeader = screen.getByRole("button", { name: "FY Obligated" });
+    expect(fyHeader).toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.click(fyHeader);
+
+    expect(setSortConditions).not.toHaveBeenCalled();
+});
+
 it("does not render contract-only expanded fields for a GRANT agreement row", () => {
     render(
         <Provider store={store}>

--- a/frontend/src/components/Agreements/AgreementsTable/AgreementsTableLoading.jsx
+++ b/frontend/src/components/Agreements/AgreementsTable/AgreementsTableLoading.jsx
@@ -1,5 +1,4 @@
 import TableLoadingSkeleton from "../../UI/TableLoadingSkeleton";
-import { getCurrentFiscalYear } from "../../../helpers/utils";
 import { getTableHeadingsWithFY } from "./AgreementsTable.constants";
 
 const COLUMN_WIDTHS = ["75%", "50%", "45%", "45%", "60%", "60%"];
@@ -11,7 +10,7 @@ const COLUMN_WIDTHS = ["75%", "50%", "45%", "45%", "60%", "60%"];
  * @returns {React.ReactElement}
  */
 const AgreementsTableLoading = ({ selectedFiscalYear }) => {
-    const headings = getTableHeadingsWithFY(selectedFiscalYear, getCurrentFiscalYear()).map(({ heading }) => heading);
+    const headings = getTableHeadingsWithFY(selectedFiscalYear).map(({ heading }) => heading);
 
     return (
         <TableLoadingSkeleton

--- a/frontend/src/components/Projects/ProjectsTable/ProjectsTable.jsx
+++ b/frontend/src/components/Projects/ProjectsTable/ProjectsTable.jsx
@@ -11,6 +11,7 @@ import ProjectTableRow from "./ProjectTableRow";
  * @param {string | null} props.selectedHeader - Currently selected sort code.
  * @param {boolean} props.sortDescending - Whether the selected sort is descending.
  * @param {(sortCode: string, isDescending: boolean) => void} props.onClickHeader - Sort toggle handler.
+ * @param {boolean} [props.disabled] - When true, renders as aria-disabled and blocks clicks; tooltip explains why.
  * @returns {React.ReactElement}
  */
 const SortableHeader = ({ label, sortCode, selectedHeader, sortDescending, onClickHeader, disabled }) => {

--- a/frontend/src/components/Projects/ProjectsTable/ProjectsTable.jsx
+++ b/frontend/src/components/Projects/ProjectsTable/ProjectsTable.jsx
@@ -13,7 +13,7 @@ import ProjectTableRow from "./ProjectTableRow";
  * @param {(sortCode: string, isDescending: boolean) => void} props.onClickHeader - Sort toggle handler.
  * @returns {React.ReactElement}
  */
-const SortableHeader = ({ label, sortCode, selectedHeader, sortDescending, onClickHeader }) => {
+const SortableHeader = ({ label, sortCode, selectedHeader, sortDescending, onClickHeader, disabled }) => {
     const isSelected = selectedHeader === sortCode;
 
     return (
@@ -25,7 +25,12 @@ const SortableHeader = ({ label, sortCode, selectedHeader, sortDescending, onCli
             <button
                 type="button"
                 className="usa-table__header__button cursor-pointer"
-                title={`Click to sort by ${label} in ascending or descending order`}
+                title={
+                    disabled
+                        ? `Select a specific fiscal year to sort by ${label}`
+                        : `Click to sort by ${label} in ascending or descending order`
+                }
+                disabled={disabled}
                 onClick={() => {
                     onClickHeader?.(sortCode, sortDescending == null ? true : !sortDescending);
                 }}
@@ -93,6 +98,7 @@ const ProjectsTable = ({ projects, sortConditions, sortDescending, setSortCondit
                         selectedHeader={sortConditions}
                         sortDescending={sortDescending}
                         onClickHeader={setSortConditions}
+                        disabled={selectedFiscalYear === "All"}
                     />
                     <SortableHeader
                         label="Project Total"

--- a/frontend/src/components/Projects/ProjectsTable/ProjectsTable.jsx
+++ b/frontend/src/components/Projects/ProjectsTable/ProjectsTable.jsx
@@ -25,7 +25,7 @@ const SortableHeader = ({ label, sortCode, selectedHeader, sortDescending, onCli
         >
             <button
                 type="button"
-                className="usa-table__header__button cursor-pointer"
+                className={`usa-table__header__button ${disabled ? "cursor-not-allowed text-disabled" : "cursor-pointer"}`}
                 title={
                     disabled
                         ? `Select a specific fiscal year to sort by ${label}`

--- a/frontend/src/components/Projects/ProjectsTable/ProjectsTable.jsx
+++ b/frontend/src/components/Projects/ProjectsTable/ProjectsTable.jsx
@@ -30,9 +30,9 @@ const SortableHeader = ({ label, sortCode, selectedHeader, sortDescending, onCli
                         ? `Select a specific fiscal year to sort by ${label}`
                         : `Click to sort by ${label} in ascending or descending order`
                 }
-                disabled={disabled}
+                aria-disabled={disabled}
                 onClick={() => {
-                    onClickHeader?.(sortCode, sortDescending == null ? true : !sortDescending);
+                    if (!disabled) onClickHeader?.(sortCode, sortDescending == null ? true : !sortDescending);
                 }}
             >
                 {label}

--- a/frontend/src/components/Projects/ProjectsTable/ProjectsTable.test.jsx
+++ b/frontend/src/components/Projects/ProjectsTable/ProjectsTable.test.jsx
@@ -148,6 +148,35 @@ describe("ProjectsTable", () => {
         expect(setSortConditions).toHaveBeenCalledWith(PROJECT_SORT_CODES.PROJECT_TYPE, expect.any(Boolean));
     });
 
+    it("disables the FY Total header and blocks sorting when 'All' is selected", async () => {
+        const user = userEvent.setup();
+        const setSortConditions = vi.fn();
+        renderTable({ selectedFiscalYear: "All", setSortConditions });
+
+        const fyTotalHeader = screen.getByRole("button", { name: /^FY Total$/i });
+        expect(fyTotalHeader).toHaveAttribute("aria-disabled", "true");
+        expect(fyTotalHeader.className).toContain("cursor-not-allowed");
+        expect(fyTotalHeader.className).toContain("text-disabled");
+
+        await user.click(fyTotalHeader);
+
+        expect(setSortConditions).not.toHaveBeenCalled();
+    });
+
+    it("enables the FY Total header and allows sorting when a specific fiscal year is selected", async () => {
+        const user = userEvent.setup();
+        const setSortConditions = vi.fn();
+        renderTable({ selectedFiscalYear: "2026", setSortConditions });
+
+        const fyTotalHeader = screen.getByRole("button", { name: /FY26 Total/i });
+        expect(fyTotalHeader).toHaveAttribute("aria-disabled", "false");
+        expect(fyTotalHeader.className).toContain("cursor-pointer");
+
+        await user.click(fyTotalHeader);
+
+        expect(setSortConditions).toHaveBeenCalledWith(PROJECT_SORT_CODES.FY_TOTAL, expect.any(Boolean));
+    });
+
     it("renders multiple rows when given multiple projects", () => {
         renderTable({ projects: [MOCK_PROJECT_1, MOCK_PROJECT_2] });
         expect(screen.getByText("Project Alpha")).toBeInTheDocument();

--- a/frontend/src/components/UI/Table/Table.jsx
+++ b/frontend/src/components/UI/Table/Table.jsx
@@ -5,8 +5,6 @@ import styles from "./table.module.css";
  * @typedef {Object} TableHeading
  * @property {string} heading - The heading to display.
  * @property {string} value - The value to display.
- * @property {boolean} [disabled] - When true, renders the sort button as aria-disabled and blocks clicks.
- * @property {string} [disabledReason] - Tooltip text shown when `disabled` is true, explaining why sorting is unavailable.
  */
 
 /**
@@ -85,18 +83,9 @@ const Table = ({
                                     <button
                                         type="button"
                                         data-cy={header.value}
-                                        className={`usa-table__header__button ${
-                                            header.disabled ? "cursor-not-allowed text-disabled" : "cursor-pointer"
-                                        }`}
-                                        title={
-                                            header.disabled
-                                                ? (header.disabledReason ??
-                                                  `Sorting by ${header.heading} is unavailable`)
-                                                : `Click to sort by ${header.heading}`
-                                        }
-                                        aria-disabled={header.disabled}
+                                        className="usa-table__header__button cursor-pointer"
+                                        title={`Click to sort by ${header.heading}`}
                                         onClick={() => {
-                                            if (header.disabled) return;
                                             onClickHeader?.(
                                                 header.value,
                                                 sortDescending == null ? true : !sortDescending

--- a/frontend/src/components/UI/Table/Table.jsx
+++ b/frontend/src/components/UI/Table/Table.jsx
@@ -5,6 +5,8 @@ import styles from "./table.module.css";
  * @typedef {Object} TableHeading
  * @property {string} heading - The heading to display.
  * @property {string} value - The value to display.
+ * @property {boolean} [disabled] - When true, renders the sort button as aria-disabled and blocks clicks.
+ * @property {string} [disabledReason] - Tooltip text shown when `disabled` is true, explaining why sorting is unavailable.
  */
 
 /**
@@ -83,9 +85,18 @@ const Table = ({
                                     <button
                                         type="button"
                                         data-cy={header.value}
-                                        className="usa-table__header__button cursor-pointer"
-                                        title={`Click to sort by ${header.heading}`}
+                                        className={`usa-table__header__button ${
+                                            header.disabled ? "cursor-not-allowed text-disabled" : "cursor-pointer"
+                                        }`}
+                                        title={
+                                            header.disabled
+                                                ? (header.disabledReason ??
+                                                  `Sorting by ${header.heading} is unavailable`)
+                                                : `Click to sort by ${header.heading}`
+                                        }
+                                        aria-disabled={header.disabled}
                                         onClick={() => {
+                                            if (header.disabled) return;
                                             onClickHeader?.(
                                                 header.value,
                                                 sortDescending == null ? true : !sortDescending

--- a/frontend/src/components/UI/Table/Table.test.jsx
+++ b/frontend/src/components/UI/Table/Table.test.jsx
@@ -62,35 +62,4 @@ describe("Table", () => {
 
         expect(screen.getByRole("columnheader", { name: "BL ID #" })).toHaveAttribute("aria-sort", "ascending");
     });
-
-    it("renders a disabled header with aria-disabled and blocks clicks", () => {
-        const onClickHeader = vi.fn();
-        render(
-            <Table
-                tableHeadings={[
-                    { heading: "BL ID #", value: "ID_NUMBER", disabled: true, disabledReason: "Not available" }
-                ]}
-                onClickHeader={onClickHeader}
-            />
-        );
-
-        const header = screen.getByRole("button", { name: "BL ID #" });
-        expect(header).toHaveAttribute("aria-disabled", "true");
-        expect(header).toHaveAttribute("title", "Not available");
-        expect(header.className).toContain("cursor-not-allowed");
-        expect(header.className).toContain("text-disabled");
-
-        fireEvent.click(header);
-
-        expect(onClickHeader).not.toHaveBeenCalled();
-    });
-
-    it("falls back to a generic tooltip when disabledReason is omitted", () => {
-        render(<Table tableHeadings={[{ heading: "BL ID #", value: "ID_NUMBER", disabled: true }]} />);
-
-        expect(screen.getByRole("button", { name: "BL ID #" })).toHaveAttribute(
-            "title",
-            "Sorting by BL ID # is unavailable"
-        );
-    });
 });

--- a/frontend/src/components/UI/Table/Table.test.jsx
+++ b/frontend/src/components/UI/Table/Table.test.jsx
@@ -62,4 +62,35 @@ describe("Table", () => {
 
         expect(screen.getByRole("columnheader", { name: "BL ID #" })).toHaveAttribute("aria-sort", "ascending");
     });
+
+    it("renders a disabled header with aria-disabled and blocks clicks", () => {
+        const onClickHeader = vi.fn();
+        render(
+            <Table
+                tableHeadings={[
+                    { heading: "BL ID #", value: "ID_NUMBER", disabled: true, disabledReason: "Not available" }
+                ]}
+                onClickHeader={onClickHeader}
+            />
+        );
+
+        const header = screen.getByRole("button", { name: "BL ID #" });
+        expect(header).toHaveAttribute("aria-disabled", "true");
+        expect(header).toHaveAttribute("title", "Not available");
+        expect(header.className).toContain("cursor-not-allowed");
+        expect(header.className).toContain("text-disabled");
+
+        fireEvent.click(header);
+
+        expect(onClickHeader).not.toHaveBeenCalled();
+    });
+
+    it("falls back to a generic tooltip when disabledReason is omitted", () => {
+        render(<Table tableHeadings={[{ heading: "BL ID #", value: "ID_NUMBER", disabled: true }]} />);
+
+        expect(screen.getByRole("button", { name: "BL ID #" })).toHaveAttribute(
+            "title",
+            "Sorting by BL ID # is unavailable"
+        );
+    });
 });

--- a/frontend/src/pages/agreements/list/AgreementsList.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.jsx
@@ -27,7 +27,7 @@ import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
 import { USER_ROLES } from "../../../components/Users/User.constants";
 import { ITEMS_PER_PAGE } from "../../../constants";
 import { exportTableToXlsx } from "../../../helpers/tableExport.helpers";
-import { convertCodeForDisplay, formatDate, getCurrentFiscalYear, tableSortCodes } from "../../../helpers/utils";
+import { convertCodeForDisplay, formatDate, tableSortCodes } from "../../../helpers/utils";
 import icons from "../../../uswds/img/sprite.svg";
 import AgreementsFilterButton from "./AgreementsFilterButton/AgreementsFilterButton";
 import AgreementsFilterTags from "./AgreementsFilterTags/AgreementsFilterTags";
@@ -61,7 +61,7 @@ const AgreementsList = () => {
     );
     const [currentPage, setCurrentPage] = useState(1); // 1-indexed for UI
     const [pageSize] = useState(ITEMS_PER_PAGE);
-    const [selectedFiscalYear, setSelectedFiscalYear] = React.useState(getCurrentFiscalYear());
+    const [selectedFiscalYear, setSelectedFiscalYear] = React.useState("All");
 
     const myAgreementsUrl = searchParams.get("filter") === "my-agreements";
     const changeRequestUrl = searchParams.get("filter") === "change-requests";
@@ -221,11 +221,6 @@ const AgreementsList = () => {
             // Combine all agreements from all pages
             const allAgreementsList = allResponses.flatMap((response) => response?.agreements || []);
 
-            const effectiveFY =
-                selectedFiscalYear === "All" ? Number(getCurrentFiscalYear()) : Number(selectedFiscalYear);
-
-            const agreementResponses = allAgreementsList;
-
             const corPromises = allAgreementsList
                 .filter((agreement) => agreement?.project_officer_id)
                 .map((agreement) => trigger(agreement.project_officer_id).unwrap());
@@ -241,7 +236,8 @@ const AgreementsList = () => {
                     cor: corData?.display_name ?? corData?.full_name ?? "TBD"
                 };
             });
-            const fyLabel = `FY${String(effectiveFY).slice(-2)} Obligated`;
+            const fyLabel =
+                selectedFiscalYear === "All" ? "FY Obligated" : `FY${selectedFiscalYear.slice(-2)} Obligated`;
 
             const tableHeader = [
                 "Agreement",
@@ -261,7 +257,7 @@ const AgreementsList = () => {
                 "COR"
             ];
             await exportTableToXlsx({
-                data: agreementResponses,
+                data: allAgreementsList,
                 headers: tableHeader,
                 rowMapper: (agreement) => {
                     const agreementName = getAgreementName(agreement);

--- a/frontend/src/pages/agreements/list/AgreementsList.test.jsx
+++ b/frontend/src/pages/agreements/list/AgreementsList.test.jsx
@@ -10,7 +10,7 @@ import {
     useGetChangeRequestsListQuery
 } from "../../../api/opsAPI";
 import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
-import { getCurrentFiscalYear, tableSortCodes } from "../../../helpers/utils";
+import { tableSortCodes } from "../../../helpers/utils";
 import store from "../../../store";
 import AgreementsList from "./AgreementsList";
 
@@ -666,7 +666,7 @@ describe("AgreementsList - Fiscal Year Filtering", () => {
         expect(screen.getByRole("option", { name: "2025" })).toBeInTheDocument();
     });
 
-    it("should default to current fiscal year", async () => {
+    it("should default to all fiscal years", async () => {
         render(
             <Provider store={store}>
                 <BrowserRouter>
@@ -680,8 +680,7 @@ describe("AgreementsList - Fiscal Year Filtering", () => {
         });
 
         const dropdown = screen.getByTestId("fiscal-year-dropdown");
-        // Should have a value (current fiscal year from getCurrentFiscalYear())
-        expect(dropdown.value).toBeTruthy();
+        expect(dropdown.value).toBe("All");
     });
 
     it("should pass fiscal years from API to query params when no filters applied", async () => {
@@ -768,22 +767,7 @@ describe("AgreementsList - Fiscal Year Filtering", () => {
         expect(screen.getByTestId("agreement-tabs")).toBeInTheDocument();
     });
 
-    it("should use current fiscal year as default filter regardless of API options", async () => {
-        // Mock fiscal year options that don't include the current year
-        useGetAgreementsFilterOptionsQuery.mockReturnValue({
-            data: {
-                fiscal_years: [2020, 2021, 2022],
-                portfolios: [],
-                project_titles: [],
-                agreement_types: [],
-                agreement_names: [],
-                contract_numbers: [],
-                research_types: []
-            },
-            error: undefined,
-            isLoading: false
-        });
-
+    it("should send empty fiscalYear filter by default (all fiscal years)", async () => {
         const mockQuery = vi.fn();
         useGetAgreementsQuery.mockImplementation((params) => {
             mockQuery(params);
@@ -803,12 +787,6 @@ describe("AgreementsList - Fiscal Year Filtering", () => {
             </Provider>
         );
 
-        await waitFor(() => {
-            expect(screen.getByTestId("fiscal-year-select")).toBeInTheDocument();
-        });
-
-        // The component always defaults to the current fiscal year from the dropdown
-        const currentFY = Number(getCurrentFiscalYear());
         await waitFor(
             () => {
                 expect(mockQuery).toHaveBeenCalled();
@@ -817,50 +795,13 @@ describe("AgreementsList - Fiscal Year Filtering", () => {
         );
 
         const lastCall = mockQuery.mock.calls[mockQuery.mock.calls.length - 1];
-        expect(lastCall[0].filters.fiscalYear).toEqual([{ id: currentFY, title: currentFY }]);
+        expect(lastCall[0].filters.fiscalYear).toEqual([]);
     });
 
-    it("should send empty fiscalYear filter when 'All' is selected from dropdown", async () => {
-        const mockQuery = vi.fn();
-        useGetAgreementsQuery.mockImplementation((params) => {
-            mockQuery(params);
-            return {
-                data: mockAgreementsResponse,
-                error: undefined,
-                isLoading: false,
-                isFetching: false
-            };
-        });
-
-        render(
-            <Provider store={store}>
-                <BrowserRouter>
-                    <AgreementsList />
-                </BrowserRouter>
-            </Provider>
-        );
-
-        await waitFor(() => {
-            expect(screen.getByTestId("fiscal-year-select")).toBeInTheDocument();
-        });
-
-        // Select "All" from the fiscal year dropdown
-        const dropdown = screen.getByTestId("fiscal-year-dropdown");
-        dropdown.value = "All";
-        dropdown.dispatchEvent(new Event("change", { bubbles: true }));
-
-        await waitFor(() => {
-            const lastCall = mockQuery.mock.calls[mockQuery.mock.calls.length - 1];
-            expect(lastCall[0].filters.fiscalYear).toEqual([]);
-        });
-    });
-
-    it("should keep selected fiscal year when it exists in options list", async () => {
-        // Include the current fiscal year in the options so it stays selected
-        const currentFY = Number(getCurrentFiscalYear());
+    it("should default to All regardless of which fiscal year options the API returns", async () => {
         useGetAgreementsFilterOptionsQuery.mockReturnValue({
             data: {
-                fiscal_years: [currentFY - 1, currentFY, currentFY + 1],
+                fiscal_years: [2020, 2021, 2022, 2023, 2024, 2025],
                 portfolios: [],
                 project_titles: [],
                 agreement_types: [],
@@ -872,16 +813,6 @@ describe("AgreementsList - Fiscal Year Filtering", () => {
             isLoading: false
         });
 
-        const mockQuery = vi.fn();
-        useGetAgreementsQuery.mockImplementation((params) => {
-            mockQuery(params);
-            return {
-                data: mockAgreementsResponse,
-                error: undefined,
-                isLoading: false
-            };
-        });
-
         render(
             <Provider store={store}>
                 <BrowserRouter>
@@ -894,9 +825,7 @@ describe("AgreementsList - Fiscal Year Filtering", () => {
             expect(screen.getByTestId("fiscal-year-select")).toBeInTheDocument();
         });
 
-        // The dropdown should maintain the current fiscal year
         const dropdown = screen.getByTestId("fiscal-year-dropdown");
-        const selectedYear = Number(dropdown.value);
-        expect([currentFY - 1, currentFY, currentFY + 1]).toContain(selectedYear);
+        expect(dropdown.value).toBe("All");
     });
 });

--- a/frontend/src/pages/projects/list/ProjectsList.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.jsx
@@ -74,12 +74,18 @@ const ProjectsList = () => {
         }
     }, [isError, navigate]);
 
+    // FY_TOTAL sort is meaningless once "All" fiscal years is selected — enforce this
+    // as a standing invariant rather than only when the dropdown itself triggers the change,
+    // so any future path that sets selectedFiscalYear to "All" stays consistent.
+    React.useEffect(() => {
+        if (selectedFiscalYear === "All" && sortCondition === PROJECT_SORT_CODES.FY_TOTAL) {
+            setSortConditions(PROJECT_SORT_CODES.TITLE, false);
+        }
+    }, [selectedFiscalYear, sortCondition, setSortConditions]);
+
     const handleChangeFiscalYear = (newValue) => {
         setSelectedFiscalYear(newValue);
         setFilters((prev) => ({ ...prev, fiscalYear: [] }));
-        if (newValue === "All" && sortCondition === PROJECT_SORT_CODES.FY_TOTAL) {
-            setSortConditions(PROJECT_SORT_CODES.TITLE, false);
-        }
     };
 
     const fiscalYearDropdownValue = filters.fiscalYear.length >= 2 ? "Multi" : selectedFiscalYear;

--- a/frontend/src/pages/projects/list/ProjectsList.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.jsx
@@ -12,7 +12,6 @@ import PaginationNav from "../../../components/UI/PaginationNav/PaginationNav";
 import { useSetSortConditions } from "../../../components/UI/Table/Table.hooks";
 import { ITEMS_PER_PAGE } from "../../../constants";
 import { exportTableToXlsx } from "../../../helpers/tableExport.helpers";
-import { getCurrentFiscalYear } from "../../../helpers/utils";
 import useAlert from "../../../hooks/use-alert.hooks";
 import icons from "../../../uswds/img/sprite.svg";
 import { handleProjectsExport, PROJECT_SORT_CODES } from "./ProjectsList.helpers";
@@ -27,7 +26,7 @@ const ProjectsList = () => {
     const navigate = useNavigate();
     const [currentPage, setCurrentPage] = React.useState(1);
     const [pageSize] = React.useState(ITEMS_PER_PAGE);
-    const [selectedFiscalYear, setSelectedFiscalYear] = React.useState(getCurrentFiscalYear());
+    const [selectedFiscalYear, setSelectedFiscalYear] = React.useState("All");
     const [isExporting, setIsExporting] = React.useState(false);
     const { setAlert } = useAlert();
     const [getAllProjectsTrigger] = useLazyGetProjectsQuery();

--- a/frontend/src/pages/projects/list/ProjectsList.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.jsx
@@ -77,6 +77,9 @@ const ProjectsList = () => {
     const handleChangeFiscalYear = (newValue) => {
         setSelectedFiscalYear(newValue);
         setFilters((prev) => ({ ...prev, fiscalYear: [] }));
+        if (newValue === "All" && sortCondition === PROJECT_SORT_CODES.FY_TOTAL) {
+            setSortConditions(PROJECT_SORT_CODES.TITLE, false);
+        }
     };
 
     const fiscalYearDropdownValue = filters.fiscalYear.length >= 2 ? "Multi" : selectedFiscalYear;

--- a/frontend/src/pages/projects/list/ProjectsList.test.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.test.jsx
@@ -203,10 +203,8 @@ describe("ProjectsList", () => {
 
         renderComponent();
 
-        // The FY select defaults to current fiscal year; MOCK_PROJECT_1 has fiscal_year_totals
-        // with keys 2025 and 2026. We just verify the component renders a currency value.
-        // The exact FY depends on the current date, so we check for a $ amount presence.
-        // (For a deterministic assertion, see the FY select change test below.)
+        // The FY select defaults to "All"; MOCK_PROJECT_1.fiscal_year_totals has keys 2025
+        // and 2026, so no single-year total is shown. Sanity-check the row rendered.
         expect(screen.getByText("Research")).toBeInTheDocument(); // Sanity check row rendered
     });
 

--- a/frontend/src/pages/projects/list/ProjectsList.test.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.test.jsx
@@ -279,6 +279,32 @@ describe("ProjectsList", () => {
         expect(screen.getByRole("columnheader", { name: /^fy total$/i })).toBeInTheDocument();
     });
 
+    it("resets sort to TITLE when fiscal year changes back to All while sorted by FY Total", async () => {
+        const user = userEvent.setup();
+
+        mockUseGetProjectsQuery.mockReturnValue({
+            data: { projects: [MOCK_PROJECT_1], count: 1, limit: 10, offset: 0 },
+            isLoading: false,
+            isError: false
+        });
+
+        renderComponent();
+
+        const fySelect = screen.getByLabelText("Fiscal Year");
+        await user.selectOptions(fySelect, "2025");
+        await user.click(screen.getByRole("button", { name: /FY25 Total/i }));
+
+        expect(mockUseGetProjectsQuery).toHaveBeenLastCalledWith(
+            expect.objectContaining({ sortConditions: "FY_TOTAL" })
+        );
+
+        await user.selectOptions(fySelect, "All");
+
+        expect(mockUseGetProjectsQuery).toHaveBeenLastCalledWith(
+            expect.objectContaining({ sortConditions: "TITLE", fiscalYear: "All" })
+        );
+    });
+
     it("does not render pagination when total pages is 1", () => {
         mockUseGetProjectsQuery.mockReturnValue({
             data: { projects: [MOCK_PROJECT_1], count: 1, limit: 10, offset: 0 },

--- a/frontend/src/pages/projects/list/ProjectsList.test.jsx
+++ b/frontend/src/pages/projects/list/ProjectsList.test.jsx
@@ -194,7 +194,9 @@ describe("ProjectsList", () => {
         expect(screen.getAllByText("TBD").length).toBeGreaterThanOrEqual(2);
     });
 
-    it("renders fiscal year total as currency for the selected FY", () => {
+    it("renders fiscal year total as currency for the selected FY", async () => {
+        const user = userEvent.setup();
+
         mockUseGetProjectsQuery.mockReturnValue({
             data: { projects: [MOCK_PROJECT_1], count: 1, limit: 10, offset: 0 },
             isLoading: false,
@@ -203,9 +205,11 @@ describe("ProjectsList", () => {
 
         renderComponent();
 
-        // The FY select defaults to "All"; MOCK_PROJECT_1.fiscal_year_totals has keys 2025
-        // and 2026, so no single-year total is shown. Sanity-check the row rendered.
-        expect(screen.getByText("Research")).toBeInTheDocument(); // Sanity check row rendered
+        const fySelect = screen.getByLabelText("Fiscal Year");
+        await user.selectOptions(fySelect, "2026");
+
+        // MOCK_PROJECT_1.fiscal_year_totals[2026] is "500000.00"
+        expect(screen.getByText("$500,000.00")).toBeInTheDocument();
     });
 
     it("renders project total as currency", () => {


### PR DESCRIPTION
## What changed

- Change the default fiscal year filter on Projects and Agreements list pages from the current fiscal year to \"All\" — users now see the complete picture across all fiscal years on first load without changing the filter
- Fix Agreements export FY column header to show \"FY Obligated\" (not \"FY26 Obligated\") when all fiscal years are selected, so the on-screen table and exported spreadsheet match
- Fix `getTableHeadingsWithFY` in `AgreementsTable.constants.js` to match — previously still fell back to the current FY string for the table column header; removed the now-unused `currentFiscalYear` parameter and updated callers
- Disable the FY Total sort column in the Projects table when \"All\" is selected, since the backend requires a specific fiscal year to sort by FY Total

## Issue

https://github.com/HHS/OPRE-OPS/issues/6140

## How to test

1. Open the Projects list — confirm it shows projects across all fiscal years by default with no filter interaction
2. Open the Agreements list — confirm the same
3. Select a specific fiscal year on either list — confirm the list filters correctly (existing behavior unaffected)
4. Export from the Projects list in the default \"All\" state — confirm the column header says \"FY Total\" and the file contains records from multiple fiscal years
5. Export from the Agreements list in the default \"All\" state — confirm the column header says \"FY Obligated\" (no year) and the file contains records from multiple fiscal years
6. Export from either list after narrowing to a specific fiscal year — confirm the header shows the specific year (e.g. \"FY26 Obligated\") and the export is scoped to that year
7. On the Projects list in the default \"All\" state, click the \"FY Total\" column header — confirm the button is disabled with a tooltip explaining a specific fiscal year is required
8. Select a specific fiscal year on the Projects list — confirm the \"FY Total\" sort re-enables and sorts correctly

## A11y impact

- [ ] No accessibility-impacting changes in this PR
- [ ] Accessibility changes included and validated against WCAG 2.1 AA intent
- [ ] Any temporary suppression includes `A11Y-SUPPRESSION` metadata (owner, expires, rationale)

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

_N/A — filter default change; no visual design change_

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [x] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

https://github.com/HHS/OPRE-OPS/issues/6140