### PR TITLE
fix: remove trailing periods from disabled-edit tooltip text

### DIFF
--- a/frontend/src/helpers/agreement.helpers.js
+++ b/frontend/src/helpers/agreement.helpers.js
@@ -414,14 +414,14 @@ export const cleanBudgetLineItemForApi = (data) => {
  * Kept here so the Details and Budget Lines headers stay in sync and don't drift.
  */
 export const EDIT_DISABLED_TOOLTIPS = {
-    notTeamMember: "Only team members can edit this agreement.",
+    notTeamMember: "Only team members can edit this agreement",
     notTeamMemberBLStatus: "Only team members listed on this agreement can change a BL status",
     notDeveloped:
-        "Agreements that are grants, other partner agreements (IAAs, IPAs, IDDAs), \nor direct obligations have not been developed yet, but are coming soon.",
+        "Agreements that are grants, other partner agreements (IAAs, IPAs, IDDAs), \nor direct obligations have not been developed yet, but are coming soon",
     preAwardInReview:
-        "This agreement is In Review for Pre-Award Approval. Edits or changes cannot be made at this time.",
-    awardInReview: "This agreement is In Review for Award Approval. Edits or changes cannot be made at this time.",
-    postPreAwardLocked: "This agreement has completed Pre-Award Approval and is locked from further edits.",
+        "This agreement is In Review for Pre-Award Approval. Edits or changes cannot be made at this time",
+    awardInReview: "This agreement is In Review for Award Approval. Edits or changes cannot be made at this time",
+    postPreAwardLocked: "This agreement has completed Pre-Award Approval and is locked from further edits",
     allBudgetLinesInReview: "Budget lines In Review Status cannot be sent for status changes"
 };
 


### PR DESCRIPTION
## What changed

Removed the trailing period from every message in `EDIT_DISABLED_TOOLTIPS` (`frontend/src/helpers/agreement.helpers.js`) so the disabled-edit tooltips are styled consistently — none of them end with a period now.

## Issue

https://github.com/HHS/OPRE-OPS/issues/6178

## How to test

1. `cd frontend && bun run test --watch=false` — full unit test suite should pass.
2. Manually: open an agreement's Details page or Budget Lines page where editing is disallowed (disabled Edit button visible). Hover over the button and confirm the tooltip text no longer ends with a period, for each of the disabled states (not a team member, undeveloped agreement type, pre-award in review, award in review, post pre-award locked, budget lines in review).

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — text-only change, no visual/layout difference.

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [ ] Automated unit tests updated and passed
- [ ] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A