### PR TITLE
feat: include ALN program description in agreement history messages

### DIFF
--- a/backend/data_tools/data/ops_event.json5
+++ b/backend/data_tools/data/ops_event.json5
@@ -7484,8 +7484,8 @@
                     owner_id: 3,
                     updated_by: 516,
                     aln_number_changes: {
-                        aln_numbers_added: [7],
-                        aln_numbers_removed: [3],
+                        aln_numbers_added: ["93.320"],
+                        aln_numbers_removed: ["93.086"],
                     },
                 },
             },

--- a/backend/models/agreement_history.py
+++ b/backend/models/agreement_history.py
@@ -280,7 +280,7 @@ def agreement_history_trigger_func(event: OpsEvent, session: Session, system_use
                             agreement_id_record=agreement_updates["owner_id"],
                             ops_event_id=event.id,
                             history_title="Change to ALN Numbers",
-                            history_message=f"{event_user.full_name} added ALN Number {item}.",
+                            history_message=f"{event_user.full_name} added ALN Number {get_aln_display_name(item)}.",
                             timestamp=event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                             history_type=AgreementHistoryType.AGREEMENT_UPDATED,
                         )
@@ -292,7 +292,7 @@ def agreement_history_trigger_func(event: OpsEvent, session: Session, system_use
                             agreement_id_record=agreement_updates["owner_id"],
                             ops_event_id=event.id,
                             history_title="Change to ALN Numbers",
-                            history_message=f"{event_user.full_name} removed ALN Number {item}.",
+                            history_message=f"{event_user.full_name} removed ALN Number {get_aln_display_name(item)}.",
                             timestamp=event.created_on.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                             history_type=AgreementHistoryType.AGREEMENT_UPDATED,
                         )
@@ -926,6 +926,27 @@ def get_project_display_name(project) -> str:
     if project.short_title:
         return f"{project.title} ({project.short_title})"
     return project.title
+
+
+# Mirrors ALN_NUMBER_OPTIONS in frontend/src/components/Agreements/AlnNumbersComboBox/AlnNumbersComboBox.constants.js
+ALN_NUMBER_DESCRIPTIONS = {
+    "93.086": "HMRF",
+    "93.320": "MIECHV",
+    "93.493": "Congressionally Directed",
+    "93.575": "Head Start",
+    "93.591": "DV",
+    "93.595": "Welfare research",
+    "93.600": "Child Care",
+    "93.643": "Child Welfare",
+    "93.647": "SSRD",
+    "93.671": "FVPSA",
+}
+
+
+def get_aln_display_name(aln_number: str) -> str:
+    """Format an ALN number for display, including its descriptive label if known."""
+    description = ALN_NUMBER_DESCRIPTIONS.get(aln_number)
+    return f"{aln_number} ({description})" if description else aln_number
 
 
 def get_agreement_id_from_agreement(agreement: Agreement) -> int | None:

--- a/backend/ops_api/tests/ops/agreement/test_agreement_history.py
+++ b/backend/ops_api/tests/ops/agreement/test_agreement_history.py
@@ -16,6 +16,7 @@ from models.agreement_history import (
     add_history_events,
     create_agreement_update_history_event,
     create_services_component_history_event,
+    get_aln_display_name,
     get_project_display_name,
 )
 from ops_api.ops.services.agreement_messages import agreement_history_trigger
@@ -1531,12 +1532,12 @@ def test_agreement_history_aln_numbers_added_and_removed(loaded_db, app_ctx):
     added_history_item = agreement_history_list[0]
     assert added_history_item.history_type == AgreementHistoryType.AGREEMENT_UPDATED
     assert added_history_item.history_title == "Change to ALN Numbers"
-    assert added_history_item.history_message == "Steve Tekell added ALN Number 7."
+    assert added_history_item.history_message == "Steve Tekell added ALN Number 93.320 (MIECHV)."
 
     removed_history_item = agreement_history_list[1]
     assert removed_history_item.history_type == AgreementHistoryType.AGREEMENT_UPDATED
     assert removed_history_item.history_title == "Change to ALN Numbers"
-    assert removed_history_item.history_message == "Steve Tekell removed ALN Number 3."
+    assert removed_history_item.history_message == "Steve Tekell removed ALN Number 93.086 (HMRF)."
 
 
 def test_agreement_history_fpo_and_project_specialist_changes_on_grant(loaded_db, app_ctx):
@@ -1804,6 +1805,14 @@ class TestGetProjectDisplayName:
             short_title = ""
 
         assert get_project_display_name(FakeProject()) == "Child Welfare Research"
+
+
+class TestGetAlnDisplayName:
+    def test_returns_number_with_description_when_known(self):
+        assert get_aln_display_name("93.086") == "93.086 (HMRF)"
+
+    def test_returns_bare_number_when_unknown(self):
+        assert get_aln_display_name("99.999") == "99.999"
 
 
 class TestAgreementHistoryAPI:

--- a/frontend/cypress/e2e/editGrantAgreement.cy.js
+++ b/frontend/cypress/e2e/editGrantAgreement.cy.js
@@ -226,7 +226,7 @@ describe("edit an existing Grant agreement", () => {
                         "Change to Grant Funding Period",
                         "changed the Grant Funding Period from 12 months to 18 months.",
                         "Change to ALN Numbers",
-                        "added ALN Number 93.575.",
+                        "added ALN Number 93.575 (Head Start).",
                         "Change to FPO",
                         "changed the FPO from Chris Fortunato to Dave Director.",
                         "Change to Project Specialist",


### PR DESCRIPTION
## What changed

Agreement history messages for ALN Number changes now include the same parenthetical program description that's already shown everywhere else ALNs are displayed in the frontend (e.g. `93.086 (HMRF)`) instead of the bare code.

**`backend/models/agreement_history.py`**
- Added `ALN_NUMBER_DESCRIPTIONS`, a lookup table mirroring the frontend's `ALN_NUMBER_OPTIONS` (`frontend/src/components/Agreements/AlnNumbersComboBox/AlnNumbersComboBox.constants.js`), and a `get_aln_display_name()` helper that formats a raw ALN code as `"<code> (<description>)"` when known, falling back to the bare code otherwise.
- Updated the "added ALN Number" / "removed ALN Number" history message strings to use `get_aln_display_name()`.

**`backend/data_tools/data/ops_event.json5`**
- Updated the ALN test fixture event to use real ALN codes (`"93.320"` / `"93.086"`) instead of stale placeholder integers left over from before `aln_numbers` was migrated to a string array.

**`backend/ops_api/tests/ops/agreement/test_agreement_history.py`**
- Updated the ALN history message assertions to expect the new parenthetical format.
- Added a `TestGetAlnDisplayName` unit test class covering the known-code and unknown-code cases.

**`frontend/cypress/e2e/editGrantAgreement.cy.js`**
- Updated the agreement-history assertion to expect `"added ALN Number 93.575 (Head Start)."`.

## Issue

https://github.com/HHS/OPRE-OPS/issues/6191

## How to test

1. `cd backend/ops_api && pipenv run pytest tests/ops/agreement/test_agreement_history.py -v` — all ALN-related and `TestGetAlnDisplayName` tests should pass.
2. `cd frontend && bun run test:e2e` (or run `editGrantAgreement.cy.js` directly against the Docker stack) — confirm the agreement history entry reads "added ALN Number 93.575 (Head Start)." after adding an ALN on a grant agreement.
3. Manually: edit a grant agreement's ALN Numbers, save, then view the Agreement History — the entry should show the ALN code with its program description in parentheses.

## A11y impact

- [x] No accessibility-impacting changes in this PR

## Storybook

- [x] N/A — change is page-specific or non-visual

## Screenshots

N/A — backend history-message text change; no UI/visual change (the frontend edit is a test assertion update only).

## Definition of Done Checklist
- [ ] OESA: Code refactored for clarity
- [ ] OESA: Dependency rules followed
- [x] Automated unit tests updated and passed
- [x] Automated integration tests updated and passed
- [ ] Automated quality tests updated and passed
- [ ] Automated load tests updated and passed
- [ ] Automated a11y tests updated and passed
- [ ] Automated security tests updated and passed
- [ ] 90%+ Code coverage achieved
- [ ] Form validations updated

## Links

N/A